### PR TITLE
UI/UX 반응형 개편 (모바일 대응)

### DIFF
--- a/promo-analytics/app/(dash)/AppShell.tsx
+++ b/promo-analytics/app/(dash)/AppShell.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const NAV = [
+  { href: "/", label: "대시보드", icon: "M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" },
+  { href: "/predict", label: "예상 매출 추산", icon: "M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" },
+  { href: "/prescribe", label: "프로모션 처방", icon: "M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" },
+  { href: "/library", label: "사례 라이브러리", icon: "M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" },
+  { href: "/upload", label: "데이터 업로드", icon: "M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" },
+];
+
+function isActive(pathname: string, href: string) {
+  if (href === "/") return pathname === "/";
+  return pathname.startsWith(href);
+}
+
+function NavLinks({ onNavigate }: { onNavigate?: () => void }) {
+  const pathname = usePathname();
+  return (
+    <nav className="flex flex-col gap-1 px-3">
+      {NAV.map((n) => {
+        const active = isActive(pathname, n.href);
+        return (
+          <Link
+            key={n.href}
+            href={n.href}
+            onClick={onNavigate}
+            className={`flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition ${
+              active
+                ? "bg-neutral-900 text-white shadow-sm"
+                : "text-neutral-600 hover:bg-neutral-100 hover:text-neutral-900"
+            }`}
+          >
+            <svg className="h-[18px] w-[18px] shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth={1.7} stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d={n.icon} />
+            </svg>
+            {n.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+
+function Brand() {
+  return (
+    <Link href="/" className="flex items-center gap-2.5">
+      <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-neutral-900 text-sm font-bold text-white">
+        P
+      </span>
+      <span className="leading-tight">
+        <span className="block text-[15px] font-semibold tracking-tight">프로모션 애널리틱스</span>
+        <span className="block text-[11px] text-neutral-400">드르펠리스 MD</span>
+      </span>
+    </Link>
+  );
+}
+
+function UserFooter({ email }: { email?: string }) {
+  return (
+    <div className="border-t border-neutral-100 px-4 py-4">
+      <div className="truncate text-xs text-neutral-500">{email}</div>
+      <form action="/auth/signout" method="post">
+        <button className="mt-1.5 text-xs text-neutral-400 underline-offset-2 hover:text-neutral-700 hover:underline">
+          로그아웃
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default function AppShell({
+  email,
+  children,
+}: {
+  email?: string;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="min-h-screen md:flex">
+      {/* 데스크톱 사이드바 */}
+      <aside className="sticky top-0 hidden h-screen w-64 shrink-0 flex-col border-r border-neutral-200 bg-white md:flex">
+        <div className="px-5 py-5">
+          <Brand />
+        </div>
+        <NavLinks />
+        <div className="mt-auto">
+          <UserFooter email={email} />
+        </div>
+      </aside>
+
+      {/* 모바일 상단바 */}
+      <header className="sticky top-0 z-30 flex h-14 items-center justify-between border-b border-neutral-200 bg-white/85 px-4 backdrop-blur md:hidden">
+        <Brand />
+        <button
+          onClick={() => setOpen(true)}
+          aria-label="메뉴 열기"
+          className="flex h-9 w-9 items-center justify-center rounded-lg border border-neutral-200 text-neutral-700"
+        >
+          <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.8} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+      </header>
+
+      {/* 모바일 드로어 */}
+      {open && (
+        <div className="fixed inset-0 z-50 md:hidden">
+          <div
+            className="absolute inset-0 bg-neutral-900/40 backdrop-blur-sm"
+            onClick={() => setOpen(false)}
+          />
+          <div className="absolute left-0 top-0 flex h-full w-72 flex-col bg-white shadow-xl">
+            <div className="flex items-center justify-between px-5 py-5">
+              <Brand />
+              <button
+                onClick={() => setOpen(false)}
+                aria-label="메뉴 닫기"
+                className="flex h-8 w-8 items-center justify-center rounded-lg text-neutral-500 hover:bg-neutral-100"
+              >
+                <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.8} stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+            <NavLinks onNavigate={() => setOpen(false)} />
+            <div className="mt-auto">
+              <UserFooter email={email} />
+            </div>
+          </div>
+        </div>
+      )}
+
+      <main className="min-w-0 flex-1">{children}</main>
+    </div>
+  );
+}

--- a/promo-analytics/app/(dash)/layout.tsx
+++ b/promo-analytics/app/(dash)/layout.tsx
@@ -1,13 +1,5 @@
-import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
-
-const NAV = [
-  { href: "/", label: "대시보드" },
-  { href: "/predict", label: "예상 매출 추산" },
-  { href: "/prescribe", label: "프로모션 처방" },
-  { href: "/library", label: "사례 라이브러리" },
-  { href: "/upload", label: "데이터 업로드" },
-];
+import AppShell from "./AppShell";
 
 export default async function DashLayout({
   children,
@@ -19,36 +11,5 @@ export default async function DashLayout({
     data: { user },
   } = await supabase.auth.getUser();
 
-  return (
-    <div className="flex min-h-screen">
-      <aside className="flex w-60 shrink-0 flex-col border-r border-neutral-200 bg-white">
-        <div className="px-5 py-5">
-          <Link href="/" className="block">
-            <div className="text-base font-semibold">프로모션 애널리틱스</div>
-            <div className="mt-0.5 text-xs text-neutral-400">드르펠리스 MD</div>
-          </Link>
-        </div>
-        <nav className="flex flex-col gap-0.5 px-3">
-          {NAV.map((n) => (
-            <Link
-              key={n.href}
-              href={n.href}
-              className="rounded-lg px-3 py-2 text-sm text-neutral-700 transition hover:bg-neutral-100"
-            >
-              {n.label}
-            </Link>
-          ))}
-        </nav>
-        <div className="mt-auto border-t border-neutral-100 px-5 py-4">
-          <div className="truncate text-xs text-neutral-500">{user?.email}</div>
-          <form action="/auth/signout" method="post">
-            <button className="mt-2 text-xs text-neutral-400 underline-offset-2 hover:text-neutral-700 hover:underline">
-              로그아웃
-            </button>
-          </form>
-        </div>
-      </aside>
-      <main className="flex-1 overflow-x-hidden">{children}</main>
-    </div>
-  );
+  return <AppShell email={user?.email}>{children}</AppShell>;
 }

--- a/promo-analytics/app/(dash)/library/LibraryTable.tsx
+++ b/promo-analytics/app/(dash)/library/LibraryTable.tsx
@@ -72,8 +72,8 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
         </div>
       </div>
 
-      <div className="overflow-hidden rounded-xl border border-neutral-200 bg-white">
-        <table className="w-full text-sm">
+      <div className="overflow-x-auto rounded-xl border border-neutral-200 bg-white">
+        <table className="w-full min-w-[680px] text-sm">
           <thead className="bg-neutral-50 text-left text-xs text-neutral-500">
             <tr>
               <th className="px-4 py-3 font-medium">프로모션</th>

--- a/promo-analytics/app/(dash)/library/page.tsx
+++ b/promo-analytics/app/(dash)/library/page.tsx
@@ -34,7 +34,7 @@ export default async function LibraryPage() {
   );
 
   return (
-    <div className="px-8 py-7">
+    <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
       <h1 className="text-xl font-semibold">사례 라이브러리</h1>
       <p className="mt-1 text-sm text-neutral-500">
         유형·시즌·성과 기준으로 과거 프로모션을 비교하세요.

--- a/promo-analytics/app/(dash)/page.tsx
+++ b/promo-analytics/app/(dash)/page.tsx
@@ -28,7 +28,7 @@ export default async function Dashboard() {
   );
 
   return (
-    <div className="px-8 py-7">
+    <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
       <header className="mb-6 flex items-end justify-between">
         <div>
           <h1 className="text-xl font-semibold">대시보드</h1>
@@ -48,8 +48,8 @@ export default async function Dashboard() {
       {rows.length === 0 ? (
         <EmptyState />
       ) : (
-        <div className="overflow-hidden rounded-xl border border-neutral-200 bg-white">
-          <table className="w-full text-sm">
+        <div className="overflow-x-auto rounded-xl border border-neutral-200 bg-white">
+          <table className="w-full min-w-[680px] text-sm">
             <thead className="bg-neutral-50 text-left text-xs text-neutral-500">
               <tr>
                 <th className="px-4 py-3 font-medium">프로모션</th>

--- a/promo-analytics/app/(dash)/predict/page.tsx
+++ b/promo-analytics/app/(dash)/predict/page.tsx
@@ -48,7 +48,7 @@ export default function PredictPage() {
         : "text-neutral-600 bg-neutral-100";
 
   return (
-    <div className="px-8 py-7">
+    <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
       <h1 className="text-xl font-semibold">예상 매출 추산</h1>
       <p className="mt-1 text-sm text-neutral-500">
         계획 중인 프로모션 조건을 넣으면 유사 사례로 예상 증분을 추산합니다.

--- a/promo-analytics/app/(dash)/prescribe/page.tsx
+++ b/promo-analytics/app/(dash)/prescribe/page.tsx
@@ -38,7 +38,7 @@ export default function PrescribePage() {
   }
 
   return (
-    <div className="px-8 py-7">
+    <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
       <h1 className="text-xl font-semibold">프로모션 처방</h1>
       <p className="mt-1 text-sm text-neutral-500">
         목표 증분을 입력하면, 과거 성과를 근거로 어떤 혜택 구성이 좋을지

--- a/promo-analytics/app/(dash)/promotions/[id]/edit/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/edit/page.tsx
@@ -47,7 +47,7 @@ export default async function EditPromotion({
   const mainIds = (mains ?? []).map((m) => m.product_id);
 
   return (
-    <div className="px-8 py-7">
+    <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
       <EditForm
         promo={promo}
         products={products}

--- a/promo-analytics/app/(dash)/promotions/[id]/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/page.tsx
@@ -58,7 +58,7 @@ export default async function PromotionDetail({
   const hasBaseline = rows.some((r) => r.baseline_daily_revenue > 0);
 
   return (
-    <div className="px-8 py-7">
+    <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
       <div className="mb-1 text-sm text-neutral-400">
         <Link href="/" className="hover:underline">
           대시보드
@@ -116,8 +116,8 @@ export default async function PromotionDetail({
           <h2 className="mb-2 text-sm font-semibold text-neutral-700">
             상품별 증분 측정
           </h2>
-          <div className="overflow-hidden rounded-xl border border-neutral-200 bg-white">
-            <table className="w-full text-sm">
+          <div className="overflow-x-auto rounded-xl border border-neutral-200 bg-white">
+            <table className="w-full min-w-[680px] text-sm">
               <thead className="bg-neutral-50 text-left text-xs text-neutral-500">
                 <tr>
                   <th className="px-3 py-2.5 font-medium">상품</th>

--- a/promo-analytics/app/(dash)/upload/page.tsx
+++ b/promo-analytics/app/(dash)/upload/page.tsx
@@ -37,7 +37,7 @@ const CARDS: CardDef[] = [
 
 export default function UploadPage() {
   return (
-    <div className="px-8 py-7">
+    <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
       <h1 className="text-xl font-semibold">데이터 업로드</h1>
       <p className="mt-1 text-sm text-neutral-500">
         엑셀(.xlsx) 파일을 순서대로 올려주세요. 헤더 이름으로 자동 인식합니다.


### PR DESCRIPTION
모바일에서 사이드바가 본문을 가리던 문제 해결 + 모던 반응형 셸.

- 데스크톱 사이드바 + 모바일 상단바/슬라이드 드로어
- nav 아이콘·활성 상태, 브랜드 마크
- 반응형 페이지 여백, 넓은 표 가로 스크롤

배포(drfelis.vercel.app) 반영용.

https://claude.ai/code/session_019bLndSp4ozYod3bYPTL8Mq

---
_Generated by [Claude Code](https://claude.ai/code/session_019bLndSp4ozYod3bYPTL8Mq)_