### PR TITLE
fix: 정적 seed json 인증 제외 (적재 오류 해결)

### DIFF
--- a/promo-analytics/proxy.ts
+++ b/promo-analytics/proxy.ts
@@ -8,7 +8,7 @@ export async function proxy(request: NextRequest) {
 
 export const config = {
   matcher: [
-    // _next 정적 자원, 이미지, favicon 제외
-    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+    // _next 정적 자원, 이미지, 정적 json(seed 데이터), favicon 제외
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|json)$).*)",
   ],
 };


### PR DESCRIPTION
서버측에서 `/seed/*.json` 정적 파일을 fetch할 때 proxy가 `/login` HTML로 리다이렉트해 JSON 파싱이 깨지던 문제 수정. 매처에서 정적 `.json`을 인증 제외.

https://claude.ai/code/session_019bLndSp4ozYod3bYPTL8Mq

---
_Generated by [Claude Code](https://claude.ai/code/session_019bLndSp4ozYod3bYPTL8Mq)_