### PR TITLE
harden: seed 라우트 origin/응답 처리

### DIFF
--- a/promo-analytics/app/api/seed/route.ts
+++ b/promo-analytics/app/api/seed/route.ts
@@ -31,11 +31,21 @@ type PromoSeed = {
   }[];
 };
 
+function originOf(req: Request): string {
+  const proto = req.headers.get("x-forwarded-proto") ?? "https";
+  const host = req.headers.get("x-forwarded-host") ?? req.headers.get("host");
+  return host ? `${proto}://${host}` : new URL(req.url).origin;
+}
+
 async function loadJson<T>(req: Request, path: string): Promise<T> {
-  const url = new URL(path, new URL(req.url).origin).toString();
-  const res = await fetch(url, { cache: "no-store" });
+  const res = await fetch(`${originOf(req)}${path}`, { cache: "no-store" });
   if (!res.ok) throw new Error(`${path} 로드 실패 (${res.status})`);
-  return res.json() as Promise<T>;
+  const text = await res.text();
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new Error(`${path} 응답이 JSON이 아닙니다 (인증/경로 확인)`);
+  }
 }
 
 function chunk<T>(arr: T[], size: number): T[][] {


### PR DESCRIPTION
seed 라우트의 정적 파일 fetch origin을 x-forwarded-host 헤더 기반으로 산출하고, 비-JSON 응답을 명확히 처리.

https://claude.ai/code/session_019bLndSp4ozYod3bYPTL8Mq

---
_Generated by [Claude Code](https://claude.ai/code/session_019bLndSp4ozYod3bYPTL8Mq)_