### PR TITLE
디자인 리뉴얼: 오렌지 소프트 Bento

### DIFF
--- a/promo-analytics/app/(dash)/AppShell.tsx
+++ b/promo-analytics/app/(dash)/AppShell.tsx
@@ -5,11 +5,11 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 const NAV = [
-  { href: "/", label: "대시보드", icon: "M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" },
-  { href: "/predict", label: "예상 매출 추산", icon: "M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" },
-  { href: "/prescribe", label: "프로모션 처방", icon: "M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" },
-  { href: "/library", label: "사례 라이브러리", icon: "M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" },
-  { href: "/upload", label: "데이터 업로드", icon: "M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" },
+  { href: "/", label: "대시보드", icon: "M3.5 12l8.5-8 8.5 8M5.5 10.5V19a1 1 0 001 1h3.5v-5h3v5H18a1 1 0 001-1v-8.5" },
+  { href: "/predict", label: "예상 매출 추산", icon: "M4 18l5-5 3 3 7-8M21 8v4m0-4h-4" },
+  { href: "/prescribe", label: "프로모션 처방", icon: "M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 104 0M9 5a2 2 0 014 0m-3 8l2 2 3-4" },
+  { href: "/library", label: "사례 라이브러리", icon: "M4 7h16M4 12h16M4 17h10" },
+  { href: "/upload", label: "데이터 업로드", icon: "M12 16V4m0 0l-4 4m4-4l4 4M5 20h14" },
 ];
 
 function isActive(pathname: string, href: string) {
@@ -28,13 +28,13 @@ function NavLinks({ onNavigate }: { onNavigate?: () => void }) {
             key={n.href}
             href={n.href}
             onClick={onNavigate}
-            className={`flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition ${
+            className={`flex items-center gap-3 rounded-2xl px-3.5 py-2.5 text-sm font-medium transition ${
               active
-                ? "bg-neutral-900 text-white shadow-sm"
-                : "text-neutral-600 hover:bg-neutral-100 hover:text-neutral-900"
+                ? "bg-brand-500 text-white shadow-[0_8px_20px_-8px_var(--color-brand-500)]"
+                : "text-neutral-500 hover:bg-white hover:text-neutral-900"
             }`}
           >
-            <svg className="h-[18px] w-[18px] shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth={1.7} stroke="currentColor">
+            <svg className="h-[18px] w-[18px] shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth={1.8} stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" d={n.icon} />
             </svg>
             {n.label}
@@ -48,11 +48,11 @@ function NavLinks({ onNavigate }: { onNavigate?: () => void }) {
 function Brand() {
   return (
     <Link href="/" className="flex items-center gap-2.5">
-      <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-neutral-900 text-sm font-bold text-white">
+      <span className="flex h-9 w-9 items-center justify-center rounded-2xl bg-ink text-sm font-bold text-white">
         P
       </span>
       <span className="leading-tight">
-        <span className="block text-[15px] font-semibold tracking-tight">프로모션 애널리틱스</span>
+        <span className="block text-[15px] font-bold tracking-tight">프로모션 애널리틱스</span>
         <span className="block text-[11px] text-neutral-400">드르펠리스 MD</span>
       </span>
     </Link>
@@ -61,13 +61,15 @@ function Brand() {
 
 function UserFooter({ email }: { email?: string }) {
   return (
-    <div className="border-t border-neutral-100 px-4 py-4">
-      <div className="truncate text-xs text-neutral-500">{email}</div>
-      <form action="/auth/signout" method="post">
-        <button className="mt-1.5 text-xs text-neutral-400 underline-offset-2 hover:text-neutral-700 hover:underline">
-          로그아웃
-        </button>
-      </form>
+    <div className="px-5 py-4">
+      <div className="rounded-2xl bg-white/70 px-3 py-2.5">
+        <div className="truncate text-xs font-medium text-neutral-600">{email}</div>
+        <form action="/auth/signout" method="post">
+          <button className="mt-0.5 text-xs text-neutral-400 hover:text-brand-600">
+            로그아웃
+          </button>
+        </form>
+      </div>
     </div>
   );
 }
@@ -84,8 +86,8 @@ export default function AppShell({
   return (
     <div className="min-h-screen md:flex">
       {/* 데스크톱 사이드바 */}
-      <aside className="sticky top-0 hidden h-screen w-64 shrink-0 flex-col border-r border-neutral-200 bg-white md:flex">
-        <div className="px-5 py-5">
+      <aside className="sticky top-0 hidden h-screen w-64 shrink-0 flex-col py-4 md:flex">
+        <div className="px-5 py-4">
           <Brand />
         </div>
         <NavLinks />
@@ -95,12 +97,12 @@ export default function AppShell({
       </aside>
 
       {/* 모바일 상단바 */}
-      <header className="sticky top-0 z-30 flex h-14 items-center justify-between border-b border-neutral-200 bg-white/85 px-4 backdrop-blur md:hidden">
+      <header className="sticky top-0 z-30 flex h-16 items-center justify-between bg-canvas/80 px-4 backdrop-blur md:hidden">
         <Brand />
         <button
           onClick={() => setOpen(true)}
           aria-label="메뉴 열기"
-          className="flex h-9 w-9 items-center justify-center rounded-lg border border-neutral-200 text-neutral-700"
+          className="flex h-10 w-10 items-center justify-center rounded-2xl bg-white text-neutral-700 card-soft"
         >
           <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.8} stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
@@ -111,17 +113,14 @@ export default function AppShell({
       {/* 모바일 드로어 */}
       {open && (
         <div className="fixed inset-0 z-50 md:hidden">
-          <div
-            className="absolute inset-0 bg-neutral-900/40 backdrop-blur-sm"
-            onClick={() => setOpen(false)}
-          />
-          <div className="absolute left-0 top-0 flex h-full w-72 flex-col bg-white shadow-xl">
-            <div className="flex items-center justify-between px-5 py-5">
+          <div className="absolute inset-0 bg-ink/40 backdrop-blur-sm" onClick={() => setOpen(false)} />
+          <div className="absolute left-0 top-0 flex h-full w-72 flex-col bg-canvas py-4 shadow-xl">
+            <div className="flex items-center justify-between px-5 py-4">
               <Brand />
               <button
                 onClick={() => setOpen(false)}
                 aria-label="메뉴 닫기"
-                className="flex h-8 w-8 items-center justify-center rounded-lg text-neutral-500 hover:bg-neutral-100"
+                className="flex h-8 w-8 items-center justify-center rounded-xl text-neutral-500 hover:bg-white"
               >
                 <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.8} stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -136,7 +135,9 @@ export default function AppShell({
         </div>
       )}
 
-      <main className="min-w-0 flex-1">{children}</main>
+      <main className="min-w-0 flex-1 md:py-4 md:pr-4">
+        <div className="min-h-full md:rounded-[32px] md:bg-white/40 md:card-soft">{children}</div>
+      </main>
     </div>
   );
 }

--- a/promo-analytics/app/(dash)/DashCharts.tsx
+++ b/promo-analytics/app/(dash)/DashCharts.tsx
@@ -1,82 +1,122 @@
 "use client";
 
 import {
-  Bar,
-  BarChart,
-  Cell,
+  Area,
+  AreaChart,
   ResponsiveContainer,
   Tooltip,
   XAxis,
 } from "recharts";
 import { wonShort } from "@/lib/format";
 
-const ACCENT = "#4f46e5";
+const BRAND = "#f15a2b";
 
-export function MonthlyUplift({
+// 월별 증분 — 오렌지 영역 스파크라인
+export function MonthlyArea({
   data,
 }: {
   data: { month: string; uplift: number }[];
 }) {
   if (data.length === 0)
     return (
-      <div className="flex h-full min-h-[180px] items-center justify-center text-sm text-neutral-400">
-        데이터가 쌓이면 월별 추세가 표시됩니다.
+      <div className="flex h-[120px] items-center justify-center text-sm text-neutral-300">
+        데이터가 쌓이면 추세가 표시됩니다.
       </div>
     );
   return (
-    <ResponsiveContainer width="100%" height={200}>
-      <BarChart data={data} margin={{ top: 8, right: 4, left: 4, bottom: 0 }}>
+    <ResponsiveContainer width="100%" height={130}>
+      <AreaChart data={data} margin={{ top: 6, right: 6, left: 6, bottom: 0 }}>
+        <defs>
+          <linearGradient id="upliftFill" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={BRAND} stopOpacity={0.28} />
+            <stop offset="100%" stopColor={BRAND} stopOpacity={0} />
+          </linearGradient>
+        </defs>
         <XAxis
           dataKey="month"
-          fontSize={11}
-          stroke="#a3a3a3"
+          fontSize={10}
+          stroke="#bcb8b3"
           tickLine={false}
           axisLine={false}
           tickFormatter={(m: string) => m.slice(2).replace("-", ".")}
+          interval="preserveStartEnd"
         />
         <Tooltip
-          cursor={{ fill: "#f5f5f5" }}
+          cursor={{ stroke: BRAND, strokeOpacity: 0.3 }}
           formatter={(v) => [wonShort(Number(v)), "증분"] as [string, string]}
-          labelFormatter={(m) => `${m}`}
-          contentStyle={{ borderRadius: 12, border: "1px solid #e5e5e5", fontSize: 12 }}
+          contentStyle={{ borderRadius: 14, border: "none", boxShadow: "0 8px 24px -8px rgba(0,0,0,.2)", fontSize: 12 }}
         />
-        <Bar dataKey="uplift" radius={[6, 6, 0, 0]} maxBarSize={40}>
-          {data.map((d, i) => (
-            <Cell key={i} fill={d.uplift < 0 ? "#f87171" : ACCENT} />
-          ))}
-        </Bar>
-      </BarChart>
+        <Area
+          type="monotone"
+          dataKey="uplift"
+          stroke={BRAND}
+          strokeWidth={2.5}
+          fill="url(#upliftFill)"
+          dot={{ r: 0 }}
+          activeDot={{ r: 5, fill: BRAND, strokeWidth: 0 }}
+        />
+      </AreaChart>
     </ResponsiveContainer>
   );
 }
 
-export function TypeBreakdown({
+// 동심원 — 유형별/제품별 증분
+export function Concentric({
   data,
 }: {
-  data: { label: string; uplift: number }[];
+  data: { label: string; value: number }[];
 }) {
-  const max = Math.max(...data.map((d) => Math.abs(d.uplift)), 1);
-  if (data.length === 0)
-    return <div className="text-sm text-neutral-400">유형 데이터가 없습니다.</div>;
+  const items = data.filter((d) => d.value > 0).slice(0, 4);
+  if (items.length === 0)
+    return <div className="text-sm text-neutral-300">데이터가 없습니다.</div>;
+  const max = items[0].value;
+  const shades = ["#ffd9c8", "#ffb293", "#ff8255", BRAND];
+  const baseShade = (i: number) => shades[Math.min(i, shades.length - 1)];
+
   return (
-    <div className="space-y-2.5">
-      {data.map((d) => (
-        <div key={d.label}>
-          <div className="mb-1 flex items-center justify-between text-xs">
-            <span className="text-neutral-600">{d.label}</span>
-            <span className="font-medium text-neutral-800">{wonShort(d.uplift)}</span>
+    <div className="relative mx-auto h-[230px] w-full max-w-[300px]">
+      {items.map((d, i) => {
+        const dia = 110 + 150 * Math.sqrt(d.value / max);
+        const shade = baseShade(items.length - 1 - i); // 바깥=연하게, 안=진하게
+        return (
+          <div
+            key={d.label}
+            className="absolute bottom-0 left-1/2 flex -translate-x-1/2 justify-center rounded-full"
+            style={{ width: dia, height: dia, background: shade, zIndex: i }}
+          >
+            <span
+              className="mt-2 text-xs font-semibold"
+              style={{ color: i >= items.length - 1 ? "#fff" : "#7a3b22" }}
+            >
+              {d.label} · {wonShort(d.value)}
+            </span>
           </div>
-          <div className="h-2 w-full overflow-hidden rounded-full bg-neutral-100">
-            <div
-              className="h-full rounded-full"
-              style={{
-                width: `${(Math.abs(d.uplift) / max) * 100}%`,
-                background: d.uplift < 0 ? "#f87171" : ACCENT,
-              }}
-            />
-          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// 블랙 도넛 — 단일 비율
+export function Donut({
+  pct,
+  label,
+}: {
+  pct: number | null;
+  label: string;
+}) {
+  const deg = Math.max(0, Math.min(1, pct ?? 0)) * 360;
+  return (
+    <div className="flex h-full flex-col items-center justify-center">
+      <div
+        className="relative flex h-28 w-28 items-center justify-center rounded-full"
+        style={{ background: `conic-gradient(${BRAND} ${deg}deg, #2f2d2b 0deg)` }}
+      >
+        <div className="flex h-[88px] w-[88px] flex-col items-center justify-center rounded-full bg-ink text-white">
+          <span className="text-xl font-bold">{pct != null ? Math.round(pct * 100) : "—"}%</span>
         </div>
-      ))}
+      </div>
+      <span className="mt-3 text-xs text-neutral-300">{label}</span>
     </div>
   );
 }

--- a/promo-analytics/app/(dash)/page.tsx
+++ b/promo-analytics/app/(dash)/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 import type { Promotion, PromotionSummary } from "@/lib/types";
 import { won, wonShort, pct } from "@/lib/format";
-import { MonthlyUplift, TypeBreakdown } from "./DashCharts";
+import { MonthlyArea, Concentric, Donut } from "./DashCharts";
 
 export const dynamic = "force-dynamic";
 
@@ -24,15 +24,11 @@ export default async function Dashboard() {
 
   if (rows.length === 0) return <EmptyState />;
 
-  // ── 집계 ──
   const totalUplift = sum(rows.map((r) => r.summary?.total_uplift ?? 0));
   const totalContribution = sum(rows.map((r) => r.summary?.contribution ?? 0));
-  const haloShares = rows
-    .map((r) => r.summary?.halo_share)
-    .filter((x): x is number => x != null);
-  const avgHalo = haloShares.length
-    ? haloShares.reduce((a, b) => a + b, 0) / haloShares.length
-    : null;
+  const totalDirect = sum(rows.map((r) => r.summary?.direct_uplift ?? 0));
+  const totalHalo = sum(rows.map((r) => r.summary?.halo_uplift ?? 0));
+  const haloShare = totalUplift !== 0 ? totalHalo / totalUplift : null;
 
   const byMonth = new Map<string, number>();
   for (const r of rows) {
@@ -42,103 +38,135 @@ export default async function Dashboard() {
   const monthly = [...byMonth.entries()]
     .map(([month, uplift]) => ({ month, uplift }))
     .sort((a, b) => a.month.localeCompare(b.month));
+  const trend =
+    monthly.length >= 2 && monthly[monthly.length - 2].uplift !== 0
+      ? (monthly[monthly.length - 1].uplift - monthly[monthly.length - 2].uplift) /
+        Math.abs(monthly[monthly.length - 2].uplift)
+      : null;
 
   const byType = new Map<string, number>();
   for (const r of rows) {
     const t = r.promo_type ?? "기타";
     byType.set(t, (byType.get(t) ?? 0) + (r.summary?.total_uplift ?? 0));
   }
-  const typeBreakdown = [...byType.entries()]
-    .map(([label, uplift]) => ({ label, uplift }))
-    .sort((a, b) => b.uplift - a.uplift)
-    .slice(0, 6);
+  const typeData = [...byType.entries()]
+    .map(([label, value]) => ({ label, value }))
+    .sort((a, b) => b.value - a.value);
 
   const ranked = [...rows].sort(
     (a, b) => (b.summary?.total_uplift ?? 0) - (a.summary?.total_uplift ?? 0),
   );
   const best = ranked[0];
 
+  const now = new Date();
+  const dateChip = `${now.getMonth() + 1}월 ${now.getDate()}일`;
+
   return (
-    <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
-      <header className="mb-5 flex flex-wrap items-end justify-between gap-3">
-        <div>
-          <h1 className="text-xl font-semibold tracking-tight">대시보드</h1>
-          <p className="mt-1 text-sm text-neutral-500">
-            프로모션 {rows.length}건의 성과를 한눈에
-          </p>
+    <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
+      {/* 상단 바 */}
+      <header className="mb-6 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <div className="flex h-12 w-12 flex-col items-center justify-center rounded-2xl bg-white card-soft">
+            <span className="text-base font-bold leading-none">{now.getDate()}</span>
+          </div>
+          <div>
+            <div className="text-sm font-semibold">{dateChip}</div>
+            <div className="text-xs text-neutral-400">프로모션 {rows.length}건 분석 중</div>
+          </div>
         </div>
         <Link
           href="/predict"
-          className="rounded-xl bg-neutral-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-neutral-700"
+          className="rounded-full bg-brand-500 px-5 py-2.5 text-sm font-semibold text-white shadow-[0_10px_24px_-10px_var(--color-brand-500)] transition hover:bg-brand-600"
         >
           예상 매출 추산 →
         </Link>
       </header>
 
-      {/* Ambient AI 인사이트 */}
-      {best?.summary && (
-        <div className="mb-4 overflow-hidden rounded-2xl bg-gradient-to-br from-indigo-50 via-white to-white p-5 ring-1 ring-indigo-100">
-          <div className="flex items-center gap-2 text-xs font-medium text-indigo-600">
-            <span className="flex h-1.5 w-1.5 animate-pulse rounded-full bg-indigo-500" />
-            AI 인사이트
+      {/* 헤로 — AI 인사이트 */}
+      <section className="mb-5 flex flex-col gap-4 rounded-[28px] bg-white p-6 card-soft sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-xs font-semibold text-brand-600">
+            <span className="flex h-1.5 w-1.5 animate-pulse rounded-full bg-brand-500" />
+            AI MD 인사이트
           </div>
-          <p className="mt-2 text-[15px] leading-relaxed text-neutral-800">
-            가장 효과적이었던 프로모션은{" "}
-            <Link href={`/promotions/${best.id}`} className="font-semibold text-indigo-700 hover:underline">
-              {best.name}
-            </Link>
-            {" "}— 증분 <strong>{won(best.summary.total_uplift)}</strong>
-            {best.summary.halo_share != null && (
-              <>, 그중 후광효과 {pct(best.summary.halo_share)}</>
-            )}
-            {avgHalo != null && (
-              <span className="text-neutral-500">
-                {" "}· 전체 평균 후광비중 {pct(avgHalo)}
-              </span>
-            )}
-          </p>
+          <h1 className="mt-2 text-2xl font-bold leading-snug tracking-tight">
+            안녕하세요 <span className="align-middle">👋</span>
+          </h1>
+          {best?.summary && (
+            <p className="mt-1 max-w-2xl text-[15px] leading-relaxed text-neutral-600">
+              가장 효과적이었던 건{" "}
+              <Link href={`/promotions/${best.id}`} className="font-semibold text-brand-600 hover:underline">
+                {best.name}
+              </Link>
+              {" "}— 증분 <strong className="text-neutral-900">{won(best.summary.total_uplift)}</strong>
+              {best.summary.halo_share != null && (
+                <>, 후광효과 {pct(best.summary.halo_share)}</>
+              )}
+              에요.
+            </p>
+          )}
         </div>
-      )}
+      </section>
 
-      {/* KPI 타일 (Bento) */}
+      {/* KPI Bento */}
       <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4">
-        <Kpi label="누적 증분 기여" value={won(totalUplift)} accent />
+        <Kpi label="누적 증분 기여" value={won(totalUplift)} brand />
+        <Kpi label="직접효과" value={wonShort(totalDirect)} />
+        <Kpi label="후광효과" value={wonShort(totalHalo)} />
         <Kpi label="누적 공헌이익" value={won(totalContribution)} />
-        <Kpi label="평균 후광비중" value={avgHalo != null ? pct(avgHalo) : "—"} />
-        <Kpi label="등록 프로모션" value={`${rows.length}건`} />
       </div>
 
-      {/* Bento 차트 영역 */}
+      {/* 차트 Bento */}
       <div className="mt-3 grid gap-3 sm:mt-4 sm:gap-4 lg:grid-cols-3">
         <Card className="lg:col-span-2">
-          <CardTitle>월별 증분 추세</CardTitle>
-          <MonthlyUplift data={monthly} />
+          <div className="mb-1 flex items-center justify-between">
+            <CardTitle className="mb-0">월별 증분 추세</CardTitle>
+            {trend != null && (
+              <span
+                className={`rounded-full px-2.5 py-1 text-xs font-semibold ${
+                  trend >= 0 ? "bg-brand-50 text-brand-600" : "bg-neutral-100 text-neutral-500"
+                }`}
+              >
+                {trend >= 0 ? "▲" : "▼"} {pct(Math.abs(trend), 1)}
+              </span>
+            )}
+          </div>
+          <MonthlyArea data={monthly} />
         </Card>
-        <Card>
-          <CardTitle>혜택 유형별 증분</CardTitle>
-          <TypeBreakdown data={typeBreakdown} />
+
+        <Card className="bg-ink text-white">
+          <CardTitle className="mb-0 text-neutral-300">전체 후광 비중</CardTitle>
+          <Donut pct={haloShare} label="기타 제품 동반구매 기여" />
         </Card>
       </div>
 
-      {/* 성과 랭킹 + 최고 프로모션 */}
       <div className="mt-3 grid gap-3 sm:mt-4 sm:gap-4 lg:grid-cols-3">
+        <Card>
+          <CardTitle>혜택 유형별 증분</CardTitle>
+          <Concentric data={typeData} />
+        </Card>
+
         <Card className="lg:col-span-2">
           <div className="mb-2 flex items-center justify-between">
             <CardTitle className="mb-0">성과 랭킹</CardTitle>
-            <Link href="/library" className="text-xs text-neutral-400 hover:text-neutral-700">
+            <Link href="/library" className="text-xs text-neutral-400 hover:text-brand-600">
               전체 보기 →
             </Link>
           </div>
           <ul className="divide-y divide-neutral-100">
             {ranked.slice(0, 6).map((r, i) => (
               <li key={r.id} className="flex items-center gap-3 py-2.5">
-                <span className="w-5 text-center text-sm font-semibold text-neutral-300">
+                <span
+                  className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-bold ${
+                    i === 0 ? "bg-brand-500 text-white" : "bg-neutral-100 text-neutral-400"
+                  }`}
+                >
                   {i + 1}
                 </span>
                 <div className="min-w-0 flex-1">
                   <Link
                     href={`/promotions/${r.id}`}
-                    className="block truncate text-sm font-medium text-neutral-800 hover:underline"
+                    className="block truncate text-sm font-medium text-neutral-800 hover:text-brand-600"
                   >
                     {r.name}
                   </Link>
@@ -147,32 +175,12 @@ export default async function Dashboard() {
                     {r.promo_type && <span>· {r.promo_type}</span>}
                   </div>
                 </div>
-                <span className="shrink-0 text-sm font-semibold tabular-nums">
+                <span className="shrink-0 text-sm font-bold tabular-nums text-neutral-900">
                   {wonShort(r.summary?.total_uplift)}
                 </span>
               </li>
             ))}
           </ul>
-        </Card>
-
-        <Card>
-          <CardTitle>가장 효과적인 프로모션</CardTitle>
-          {best && (
-            <div>
-              <Link
-                href={`/promotions/${best.id}`}
-                className="text-sm font-semibold text-neutral-900 hover:underline"
-              >
-                {best.name}
-              </Link>
-              <div className="mt-3 space-y-2 text-sm">
-                <Stat k="총 증분" v={won(best.summary?.total_uplift)} />
-                <Stat k="직접효과" v={wonShort(best.summary?.direct_uplift)} />
-                <Stat k="후광효과" v={wonShort(best.summary?.halo_uplift)} />
-                <Stat k="공헌이익" v={wonShort(best.summary?.contribution)} />
-              </div>
-            </div>
-          )}
         </Card>
       </div>
     </div>
@@ -183,71 +191,44 @@ function sum(a: number[]) {
   return a.reduce((x, y) => x + y, 0);
 }
 
-function Kpi({ label, value, accent }: { label: string; value: string; accent?: boolean }) {
+function Kpi({ label, value, brand }: { label: string; value: string; brand?: boolean }) {
   return (
     <div
-      className={`rounded-2xl p-5 ring-1 ${
-        accent
-          ? "bg-neutral-900 text-white ring-neutral-900"
-          : "bg-white ring-neutral-200/70"
-      } shadow-[0_1px_3px_rgba(0,0,0,0.03)]`}
+      className={`rounded-[24px] p-5 ${
+        brand ? "bg-brand-500 text-white" : "bg-white card-soft"
+      }`}
     >
-      <div className={`text-xs ${accent ? "text-neutral-400" : "text-neutral-500"}`}>
-        {label}
-      </div>
-      <div className="mt-1.5 text-xl font-semibold tracking-tight tabular-nums sm:text-2xl">
-        {value}
-      </div>
+      <div className={`text-xs ${brand ? "text-brand-100" : "text-neutral-400"}`}>{label}</div>
+      <div className="mt-2 text-xl font-bold tracking-tight tabular-nums sm:text-2xl">{value}</div>
     </div>
   );
 }
 
 function Card({ children, className = "" }: { children: React.ReactNode; className?: string }) {
-  return (
-    <div
-      className={`rounded-2xl bg-white p-5 ring-1 ring-neutral-200/70 shadow-[0_1px_3px_rgba(0,0,0,0.03)] ${className}`}
-    >
-      {children}
-    </div>
-  );
+  return <div className={`rounded-[28px] bg-white p-5 card-soft ${className}`}>{children}</div>;
 }
 
 function CardTitle({ children, className = "" }: { children: React.ReactNode; className?: string }) {
-  return (
-    <h2 className={`mb-3 text-sm font-semibold text-neutral-700 ${className}`}>{children}</h2>
-  );
-}
-
-function Stat({ k, v }: { k: string; v: string }) {
-  return (
-    <div className="flex items-center justify-between">
-      <span className="text-neutral-500">{k}</span>
-      <span className="font-medium tabular-nums text-neutral-800">{v}</span>
-    </div>
-  );
+  return <h2 className={`mb-3 text-sm font-semibold text-neutral-700 ${className}`}>{children}</h2>;
 }
 
 function EmptyState() {
   return (
-    <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
-      <h1 className="text-xl font-semibold">대시보드</h1>
-      <div className="mt-6 overflow-hidden rounded-2xl bg-gradient-to-br from-indigo-50 via-white to-white p-8 text-center ring-1 ring-indigo-100">
-        <p className="text-base font-medium text-neutral-800">
-          아직 데이터가 없습니다.
-        </p>
+    <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
+      <div className="mx-auto mt-6 max-w-lg rounded-[28px] bg-white p-8 text-center card-soft">
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-2xl bg-brand-500 text-xl text-white">
+          ✦
+        </div>
+        <p className="text-base font-semibold text-neutral-800">아직 데이터가 없습니다.</p>
         <p className="mx-auto mt-1 max-w-md text-sm text-neutral-500">
-          첨부해주신 마스터·일별 매출·프로모션 데이터를 한 번에 적재할 수 있어요.
-          버튼 한 번이면 됩니다.
+          첨부해주신 마스터·일별 매출·프로모션 데이터를 버튼 한 번으로 적재할 수 있어요.
         </p>
         <Link
           href="/seed"
-          className="mt-5 inline-block rounded-xl bg-neutral-900 px-5 py-2.5 text-sm font-medium text-white hover:bg-neutral-700"
+          className="mt-5 inline-block rounded-full bg-brand-500 px-6 py-2.5 text-sm font-semibold text-white hover:bg-brand-600"
         >
           초기 데이터 적재하기 →
         </Link>
-        <p className="mt-3 text-xs text-neutral-400">
-          또는 <Link href="/upload" className="underline">데이터 업로드</Link>에서 직접 올릴 수 있어요.
-        </p>
       </div>
     </div>
   );

--- a/promo-analytics/app/globals.css
+++ b/promo-analytics/app/globals.css
@@ -1,6 +1,20 @@
 @import "tailwindcss";
 
-@theme inline {
+@theme {
+  /* 키컬러: 오렌지(코랄) */
+  --color-brand-50: #fff4ef;
+  --color-brand-100: #ffe6da;
+  --color-brand-200: #ffc8b0;
+  --color-brand-300: #ffa482;
+  --color-brand-400: #ff7d50;
+  --color-brand-500: #f15a2b;
+  --color-brand-600: #df4a1d;
+  --color-brand-700: #b93b17;
+
+  /* 따뜻한 캔버스 배경 */
+  --color-canvas: #e9e7e3;
+  --color-ink: #1c1b1a;
+
   --font-sans:
     ui-sans-serif, system-ui, "Apple SD Gothic Neo", "Malgun Gothic",
     "Pretendard", sans-serif;
@@ -8,4 +22,16 @@
 
 html {
   font-family: var(--font-sans);
+}
+
+body {
+  background: var(--color-canvas);
+  color: var(--color-ink);
+}
+
+/* 부드러운 카드 그림자 */
+@utility card-soft {
+  box-shadow:
+    0 1px 2px rgba(28, 27, 26, 0.04),
+    0 8px 24px -12px rgba(28, 27, 26, 0.12);
 }

--- a/promo-analytics/app/layout.tsx
+++ b/promo-analytics/app/layout.tsx
@@ -11,9 +11,7 @@ export default function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="ko" className="h-full antialiased">
-      <body className="min-h-full bg-neutral-50 text-neutral-900">
-        {children}
-      </body>
+      <body className="min-h-full">{children}</body>
     </html>
   );
 }


### PR DESCRIPTION
오렌지 키컬러 기반 소프트 Bento 대시보드로 디자인 리뉴얼.

- 토큰: brand 오렌지 팔레트 + 따뜻한 캔버스 배경 + card-soft 그림자
- 셸: 캔버스 배경, 오렌지 활성 nav, 흰 카드 패널
- 대시보드: AI 헤로, 오렌지 KPI, 오렌지 영역 스파크라인, 블랙 도넛(후광비중), 동심원(유형별 증분), 성과 랭킹

https://claude.ai/code/session_019bLndSp4ozYod3bYPTL8Mq

---
_Generated by [Claude Code](https://claude.ai/code/session_019bLndSp4ozYod3bYPTL8Mq)_