### PR TITLE
디자인·UX 보완 + 상시 대비 비교

### DIFF
--- a/promo-analytics/app/(dash)/AppShell.tsx
+++ b/promo-analytics/app/(dash)/AppShell.tsx
@@ -114,7 +114,7 @@ export default function AppShell({
       {open && (
         <div className="fixed inset-0 z-50 md:hidden">
           <div className="absolute inset-0 bg-ink/40 backdrop-blur-sm" onClick={() => setOpen(false)} />
-          <div className="absolute left-0 top-0 flex h-full w-72 flex-col bg-canvas py-4 shadow-xl">
+          <div className="absolute right-0 top-0 flex h-full w-72 flex-col bg-canvas py-4 shadow-xl">
             <div className="flex items-center justify-between px-5 py-4">
               <Brand />
               <button

--- a/promo-analytics/app/(dash)/DashCharts.tsx
+++ b/promo-analytics/app/(dash)/DashCharts.tsx
@@ -9,7 +9,7 @@ import {
 } from "recharts";
 import { wonShort } from "@/lib/format";
 
-const BRAND = "#f15a2b";
+const BRAND = "#e76f51";
 
 // 월별 증분 — 오렌지 영역 스파크라인
 export function MonthlyArea({
@@ -90,6 +90,56 @@ export function Concentric({
             >
               {d.label} · {wonShort(d.value)}
             </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// 상시 일평균 vs 프로모션 일평균 — 비교 막대
+export function BaselineVsPromo({
+  data,
+}: {
+  data: { name: string; baseline: number; promo: number }[];
+}) {
+  if (data.length === 0)
+    return <div className="text-sm text-neutral-300">데이터가 없습니다.</div>;
+  const max = Math.max(...data.flatMap((d) => [d.baseline, d.promo]), 1);
+  return (
+    <div className="space-y-4">
+      {data.map((d) => {
+        const ratio = d.baseline > 0 ? d.promo / d.baseline : null;
+        return (
+          <div key={d.name}>
+            <div className="mb-1 flex items-center justify-between text-xs">
+              <span className="truncate font-medium text-neutral-700">{d.name}</span>
+              {ratio != null && (
+                <span className="ml-2 shrink-0 font-semibold text-brand-600">
+                  평소 대비 {ratio.toFixed(1)}배
+                </span>
+              )}
+            </div>
+            {/* 상시 */}
+            <div className="flex items-center gap-2">
+              <span className="w-8 shrink-0 text-[10px] text-neutral-400">상시</span>
+              <div className="h-3 flex-1 overflow-hidden rounded-full bg-neutral-100">
+                <div className="h-full rounded-full bg-neutral-300" style={{ width: `${(d.baseline / max) * 100}%` }} />
+              </div>
+              <span className="w-16 shrink-0 text-right text-[10px] tabular-nums text-neutral-400">
+                {wonShort(d.baseline)}
+              </span>
+            </div>
+            {/* 프로모션 */}
+            <div className="mt-1 flex items-center gap-2">
+              <span className="w-8 shrink-0 text-[10px] text-brand-600">행사</span>
+              <div className="h-3 flex-1 overflow-hidden rounded-full bg-brand-50">
+                <div className="h-full rounded-full bg-brand-500" style={{ width: `${(d.promo / max) * 100}%` }} />
+              </div>
+              <span className="w-16 shrink-0 text-right text-[10px] font-semibold tabular-nums text-neutral-700">
+                {wonShort(d.promo)}
+              </span>
+            </div>
           </div>
         );
       })}

--- a/promo-analytics/app/(dash)/library/LibraryTable.tsx
+++ b/promo-analytics/app/(dash)/library/LibraryTable.tsx
@@ -62,7 +62,7 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
               onClick={() => setSort(s.key)}
               className={`rounded-full px-2.5 py-1 ${
                 sort === s.key
-                  ? "bg-neutral-900 text-white"
+                  ? "bg-brand-500 text-white"
                   : "text-neutral-600 hover:bg-neutral-100"
               }`}
             >
@@ -72,7 +72,7 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
         </div>
       </div>
 
-      <div className="overflow-x-auto rounded-xl border border-neutral-200 bg-white">
+      <div className="overflow-x-auto rounded-[24px] bg-white card-soft">
         <table className="w-full min-w-[680px] text-sm">
           <thead className="bg-neutral-50 text-left text-xs text-neutral-500">
             <tr>
@@ -151,7 +151,7 @@ function Select({
     <select
       value={value}
       onChange={(e) => onChange(e.target.value)}
-      className="rounded-lg border border-neutral-300 bg-white px-3 py-1.5 text-sm text-neutral-700"
+      className="rounded-xl border border-neutral-200 bg-white px-3 py-1.5 text-sm text-neutral-700"
     >
       <option value="">{placeholder}</option>
       {options.map((o) => (

--- a/promo-analytics/app/(dash)/page.tsx
+++ b/promo-analytics/app/(dash)/page.tsx
@@ -1,12 +1,17 @@
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
-import type { Promotion, PromotionSummary } from "@/lib/types";
+import type { Promotion, PromotionSummary, MeasurementRow } from "@/lib/types";
 import { won, wonShort, pct } from "@/lib/format";
-import { MonthlyArea, Concentric, Donut } from "./DashCharts";
+import { MonthlyArea, Concentric, Donut, BaselineVsPromo } from "./DashCharts";
 
 export const dynamic = "force-dynamic";
 
-type Row = Promotion & { summary: PromotionSummary | null };
+type Row = Promotion & {
+  summary: PromotionSummary | null;
+  baseline_daily: number;
+  promo_daily: number;
+  promo_days: number;
+};
 
 export default async function Dashboard() {
   const supabase = await createClient();
@@ -17,8 +22,22 @@ export default async function Dashboard() {
 
   const rows: Row[] = await Promise.all(
     (promos ?? []).map(async (p: Promotion) => {
-      const { data } = await supabase.rpc("promotion_summary", { p_id: p.id });
-      return { ...p, summary: (data?.[0] as PromotionSummary) ?? null };
+      const [{ data: s }, { data: m }] = await Promise.all([
+        supabase.rpc("promotion_summary", { p_id: p.id }),
+        supabase.rpc("promotion_measurement", { p_id: p.id }),
+      ]);
+      const meas = (m as MeasurementRow[]) ?? [];
+      const promo_days = meas[0]?.promo_days ?? 1;
+      const baseline_daily = sum(meas.map((x) => x.baseline_daily_revenue));
+      const promo_daily =
+        promo_days > 0 ? sum(meas.map((x) => x.actual_revenue)) / promo_days : 0;
+      return {
+        ...p,
+        summary: (s?.[0] as PromotionSummary) ?? null,
+        baseline_daily,
+        promo_daily,
+        promo_days,
+      };
     }),
   );
 
@@ -29,6 +48,20 @@ export default async function Dashboard() {
   const totalDirect = sum(rows.map((r) => r.summary?.direct_uplift ?? 0));
   const totalHalo = sum(rows.map((r) => r.summary?.halo_uplift ?? 0));
   const haloShare = totalUplift !== 0 ? totalHalo / totalUplift : null;
+
+  // 상시 일평균 vs 행사 일평균
+  const totalBaselineDaily = sum(rows.map((r) => r.baseline_daily));
+  const totalPromoDaily = sum(rows.map((r) => r.promo_daily));
+  const liftRatio =
+    totalBaselineDaily > 0 ? totalPromoDaily / totalBaselineDaily : null;
+  const compData = [...rows]
+    .sort((a, b) => b.promo_daily - a.promo_daily)
+    .slice(0, 5)
+    .map((r) => ({
+      name: r.name.replace(/^CF_P_\d+_?/, ""),
+      baseline: r.baseline_daily,
+      promo: r.promo_daily,
+    }));
 
   const byMonth = new Map<string, number>();
   for (const r of rows) {
@@ -105,6 +138,12 @@ export default async function Dashboard() {
               에요.
             </p>
           )}
+          {liftRatio != null && (
+            <p className="mt-1 text-[15px] leading-relaxed text-neutral-600">
+              프로모션 기간엔 평소(상시 일평균)보다{" "}
+              <strong className="text-brand-600">{liftRatio.toFixed(1)}배</strong> 더 팔렸어요.
+            </p>
+          )}
         </div>
       </section>
 
@@ -114,6 +153,33 @@ export default async function Dashboard() {
         <Kpi label="직접효과" value={wonShort(totalDirect)} />
         <Kpi label="후광효과" value={wonShort(totalHalo)} />
         <Kpi label="누적 공헌이익" value={won(totalContribution)} />
+      </div>
+
+      {/* 상시 vs 행사 비교 (비교 기준) */}
+      <div className="mt-3 grid gap-3 sm:mt-4 sm:gap-4 lg:grid-cols-3">
+        <Card className="lg:col-span-2">
+          <CardTitle>상시 대비 행사 일매출</CardTitle>
+          <p className="-mt-2 mb-3 text-xs text-neutral-400">
+            회색=평소(상시 일평균) · 주황=프로모션 기간 일평균
+          </p>
+          <BaselineVsPromo data={compData} />
+        </Card>
+        <Card className="flex flex-col justify-center bg-ink text-white">
+          <div className="text-xs text-neutral-300">평소 대비 행사 매출</div>
+          <div className="mt-1 text-4xl font-bold text-brand-400">
+            {liftRatio != null ? `${liftRatio.toFixed(1)}배` : "—"}
+          </div>
+          <div className="mt-4 space-y-1.5 text-sm">
+            <div className="flex justify-between">
+              <span className="text-neutral-400">상시 일평균</span>
+              <span className="tabular-nums">{wonShort(totalBaselineDaily)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-neutral-400">행사 일평균</span>
+              <span className="font-semibold tabular-nums text-brand-400">{wonShort(totalPromoDaily)}</span>
+            </div>
+          </div>
+        </Card>
       </div>
 
       {/* 차트 Bento */}

--- a/promo-analytics/app/(dash)/predict/page.tsx
+++ b/promo-analytics/app/(dash)/predict/page.tsx
@@ -56,7 +56,7 @@ export default function PredictPage() {
 
       <div className="mt-6 grid gap-6 lg:grid-cols-2">
         {/* 입력 */}
-        <div className="rounded-xl border border-neutral-200 bg-white p-5">
+        <div className="rounded-[24px] bg-white card-soft p-5">
           <Field label="혜택 종류">
             <Chips options={PROMO_TYPES} value={promoType} onChange={setPromoType} />
           </Field>
@@ -70,7 +70,7 @@ export default function PredictPage() {
                 onChange={(e) => setDiscount(e.target.value)}
                 inputMode="numeric"
                 placeholder="50"
-                className="w-full rounded-lg border border-neutral-300 px-3 py-2 text-sm"
+                className="w-full rounded-xl border border-neutral-200 px-3 py-2 text-sm"
               />
             </Field>
             <Field label="기간(일)">
@@ -78,14 +78,14 @@ export default function PredictPage() {
                 value={days}
                 onChange={(e) => setDays(e.target.value)}
                 inputMode="numeric"
-                className="w-full rounded-lg border border-neutral-300 px-3 py-2 text-sm"
+                className="w-full rounded-xl border border-neutral-200 px-3 py-2 text-sm"
               />
             </Field>
           </div>
           <button
             onClick={run}
             disabled={loading}
-            className="mt-2 w-full rounded-lg bg-neutral-900 px-4 py-2.5 text-sm font-medium text-white hover:bg-neutral-700 disabled:opacity-50"
+            className="mt-2 w-full rounded-lg bg-brand-500 px-4 py-2.5 text-sm font-medium text-white hover:bg-brand-600 disabled:opacity-50"
           >
             {loading ? "추산 중…" : "예상 매출 추산"}
           </button>
@@ -97,7 +97,7 @@ export default function PredictPage() {
         </div>
 
         {/* 결과 */}
-        <div className="rounded-xl border border-neutral-200 bg-white p-5">
+        <div className="rounded-[24px] bg-white card-soft p-5">
           {!result ? (
             <p className="text-sm text-neutral-400">
               조건을 입력하고 추산을 실행하세요.
@@ -183,7 +183,7 @@ function Chips({
           onClick={() => onChange(value === o ? "" : o)}
           className={`rounded-full border px-3 py-1 text-xs transition ${
             value === o
-              ? "border-neutral-900 bg-neutral-900 text-white"
+              ? "border-neutral-900 bg-brand-500 text-white"
               : "border-neutral-300 text-neutral-600 hover:bg-neutral-50"
           }`}
         >

--- a/promo-analytics/app/(dash)/prescribe/page.tsx
+++ b/promo-analytics/app/(dash)/prescribe/page.tsx
@@ -45,7 +45,7 @@ export default function PrescribePage() {
         추천합니다. (공헌이익률 우선 정렬)
       </p>
 
-      <div className="mt-6 rounded-xl border border-neutral-200 bg-white p-5">
+      <div className="mt-6 rounded-[24px] bg-white card-soft p-5">
         <div className="grid gap-4 sm:grid-cols-3">
           <Field label="목표 증분(₩)">
             <input
@@ -53,7 +53,7 @@ export default function PrescribePage() {
               onChange={(e) => setTarget(e.target.value)}
               inputMode="numeric"
               placeholder="50000000"
-              className="w-full rounded-lg border border-neutral-300 px-3 py-2 text-sm"
+              className="w-full rounded-xl border border-neutral-200 px-3 py-2 text-sm"
             />
           </Field>
           <Field label="기간(일)">
@@ -61,14 +61,14 @@ export default function PrescribePage() {
               value={days}
               onChange={(e) => setDays(e.target.value)}
               inputMode="numeric"
-              className="w-full rounded-lg border border-neutral-300 px-3 py-2 text-sm"
+              className="w-full rounded-xl border border-neutral-200 px-3 py-2 text-sm"
             />
           </Field>
           <Field label="시점 / 시즌 (선택)">
             <select
               value={seasonTag}
               onChange={(e) => setSeasonTag(e.target.value)}
-              className="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm"
+              className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm"
             >
               <option value="">무관</option>
               {SEASON_TAGS.map((s) => (
@@ -82,7 +82,7 @@ export default function PrescribePage() {
         <button
           onClick={run}
           disabled={loading}
-          className="mt-4 rounded-lg bg-neutral-900 px-5 py-2.5 text-sm font-medium text-white hover:bg-neutral-700 disabled:opacity-50"
+          className="mt-4 rounded-lg bg-brand-500 px-5 py-2.5 text-sm font-medium text-white hover:bg-brand-600 disabled:opacity-50"
         >
           {loading ? "분석 중…" : "추천 받기"}
         </button>
@@ -96,7 +96,7 @@ export default function PrescribePage() {
       {recs && (
         <div className="mt-6">
           {recs.length === 0 ? (
-            <p className="rounded-xl border border-dashed border-neutral-300 bg-white px-6 py-10 text-center text-sm text-neutral-400">
+            <p className="rounded-[24px] border border-dashed border-neutral-300 bg-white px-6 py-10 text-center text-sm text-neutral-400">
               추천할 사례가 부족합니다. 프로모션 데이터를 더 쌓아주세요.
             </p>
           ) : (

--- a/promo-analytics/app/(dash)/promotions/[id]/Notes.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/Notes.tsx
@@ -58,7 +58,7 @@ export default function Notes({
               onClick={() => setQuestion(q)}
               className={`rounded-full border px-3 py-1 text-xs transition ${
                 question === q
-                  ? "border-neutral-900 bg-neutral-900 text-white"
+                  ? "border-neutral-900 bg-brand-500 text-white"
                   : "border-neutral-300 text-neutral-600 hover:bg-neutral-50"
               }`}
             >
@@ -72,14 +72,14 @@ export default function Notes({
         value={question}
         onChange={(e) => setQuestion(e.target.value)}
         placeholder="이 성과의 원인을 묻는 질문"
-        className="w-full rounded-lg border border-neutral-300 px-3 py-2 text-sm"
+        className="w-full rounded-xl border border-neutral-200 px-3 py-2 text-sm"
       />
       <textarea
         value={answer}
         onChange={(e) => setAnswer(e.target.value)}
         placeholder="원인·가설을 기록하세요. (다음 예측의 근거로 축적됩니다)"
         rows={2}
-        className="mt-2 w-full rounded-lg border border-neutral-300 px-3 py-2 text-sm"
+        className="mt-2 w-full rounded-xl border border-neutral-200 px-3 py-2 text-sm"
       />
       <div className="mt-2 flex flex-wrap gap-1.5">
         {CAUSE_TAGS.map((tag) => (
@@ -99,7 +99,7 @@ export default function Notes({
       <button
         onClick={submit}
         disabled={saving || !answer.trim()}
-        className="mt-3 rounded-lg bg-neutral-900 px-4 py-2 text-sm font-medium text-white hover:bg-neutral-700 disabled:opacity-50"
+        className="mt-3 rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-white hover:bg-brand-600 disabled:opacity-50"
       >
         {saving ? "저장 중…" : "메모 추가"}
       </button>

--- a/promo-analytics/app/(dash)/promotions/[id]/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/page.tsx
@@ -77,7 +77,7 @@ export default async function PromotionDetail({
         </div>
         <Link
           href={`/promotions/${id}/edit`}
-          className="shrink-0 rounded-lg border border-neutral-300 px-4 py-2 text-sm font-medium hover:bg-neutral-50"
+          className="shrink-0 rounded-xl border border-neutral-200 px-4 py-2 text-sm font-medium hover:bg-neutral-50"
         >
           메타·메인상품 편집
         </Link>
@@ -116,7 +116,7 @@ export default async function PromotionDetail({
           <h2 className="mb-2 text-sm font-semibold text-neutral-700">
             상품별 증분 측정
           </h2>
-          <div className="overflow-x-auto rounded-xl border border-neutral-200 bg-white">
+          <div className="overflow-x-auto rounded-[24px] bg-white card-soft">
             <table className="w-full min-w-[680px] text-sm">
               <thead className="bg-neutral-50 text-left text-xs text-neutral-500">
                 <tr>
@@ -133,7 +133,7 @@ export default async function PromotionDetail({
                     <td className="px-3 py-2.5">
                       <span className="text-neutral-800">{r.base_name}</span>
                       {r.is_main && (
-                        <span className="ml-1.5 rounded bg-neutral-900 px-1.5 py-0.5 text-[10px] font-medium text-white">
+                        <span className="ml-1.5 rounded bg-brand-500 px-1.5 py-0.5 text-[10px] font-medium text-white">
                           메인
                         </span>
                       )}
@@ -173,11 +173,11 @@ export default async function PromotionDetail({
           <h2 className="mb-2 text-sm font-semibold text-neutral-700">
             증분 Top 10 (검정=메인 · 회색=후광)
           </h2>
-          <div className="rounded-xl border border-neutral-200 bg-white p-4">
+          <div className="rounded-[24px] bg-white card-soft p-4">
             <UpliftChart data={chartData} />
           </div>
 
-          <div className="mt-4 rounded-xl border border-neutral-200 bg-white p-4">
+          <div className="mt-4 rounded-[24px] bg-white card-soft p-4">
             <div className="text-xs text-neutral-500">메인 상품</div>
             {mains.length > 0 ? (
               <ul className="mt-1.5 space-y-1 text-sm">
@@ -231,7 +231,7 @@ function Stat({
     <div
       className={`rounded-xl border p-4 ${
         primary
-          ? "border-neutral-900 bg-neutral-900 text-white"
+          ? "border-neutral-900 bg-brand-500 text-white"
           : "border-neutral-200 bg-white"
       }`}
     >

--- a/promo-analytics/app/(dash)/upload/page.tsx
+++ b/promo-analytics/app/(dash)/upload/page.tsx
@@ -90,13 +90,13 @@ function UploadCard({ def }: { def: CardDef }) {
   }
 
   return (
-    <div className="rounded-xl border border-neutral-200 bg-white p-5">
+    <div className="rounded-[24px] bg-white card-soft p-5">
       <div className="flex items-start justify-between gap-4">
         <div>
           <h2 className="font-medium">{def.title}</h2>
           <p className="mt-1 text-sm text-neutral-500">{def.desc}</p>
         </div>
-        <label className="shrink-0 cursor-pointer rounded-lg border border-neutral-300 px-4 py-2 text-sm font-medium hover:bg-neutral-50">
+        <label className="shrink-0 cursor-pointer rounded-xl border border-neutral-200 px-4 py-2 text-sm font-medium hover:bg-neutral-50">
           파일 선택
           <input
             type="file"

--- a/promo-analytics/app/globals.css
+++ b/promo-analytics/app/globals.css
@@ -1,19 +1,19 @@
 @import "tailwindcss";
 
 @theme {
-  /* 키컬러: 오렌지(코랄) */
-  --color-brand-50: #fff4ef;
-  --color-brand-100: #ffe6da;
-  --color-brand-200: #ffc8b0;
-  --color-brand-300: #ffa482;
-  --color-brand-400: #ff7d50;
-  --color-brand-500: #f15a2b;
-  --color-brand-600: #df4a1d;
-  --color-brand-700: #b93b17;
+  /* 키컬러: 차분한 테라코타 코랄 (쨍하지 않게) */
+  --color-brand-50: #fdf3ef;
+  --color-brand-100: #f9e0d6;
+  --color-brand-200: #f1c0ac;
+  --color-brand-300: #e79e80;
+  --color-brand-400: #e08260;
+  --color-brand-500: #e76f51;
+  --color-brand-600: #d0573a;
+  --color-brand-700: #ab4329;
 
   /* 따뜻한 캔버스 배경 */
-  --color-canvas: #e9e7e3;
-  --color-ink: #1c1b1a;
+  --color-canvas: #ecebe7;
+  --color-ink: #211f1d;
 
   --font-sans:
     ui-sans-serif, system-ui, "Apple SD Gothic Neo", "Malgun Gothic",


### PR DESCRIPTION
피드백 반영:
- 오렌지 톤다운(테라코타) + 큰 면적 사용 자제
- 예측·처방·라이브러리·상세·업로드 전 페이지에 소프트 카드 디자인 적용
- 모바일 드로어를 우측에서 열리게(버튼 위치 일치)
- 대시보드에 '상시 일평균 vs 행사 일평균' 비교 + 평소 대비 배수(비교 기준 시각화)

https://claude.ai/code/session_019bLndSp4ozYod3bYPTL8Mq

---
_Generated by [Claude Code](https://claude.ai/code/session_019bLndSp4ozYod3bYPTL8Mq)_