### PR TITLE
수정 Phase 1 (라벨·지표·시뮬레이터)

### DIFF
--- a/promo-analytics/app/(dash)/AppShell.tsx
+++ b/promo-analytics/app/(dash)/AppShell.tsx
@@ -6,9 +6,9 @@ import { usePathname } from "next/navigation";
 
 const NAV = [
   { href: "/", label: "대시보드", icon: "M3.5 12l8.5-8 8.5 8M5.5 10.5V19a1 1 0 001 1h3.5v-5h3v5H18a1 1 0 001-1v-8.5" },
-  { href: "/predict", label: "예상 매출 추산", icon: "M4 18l5-5 3 3 7-8M21 8v4m0-4h-4" },
-  { href: "/prescribe", label: "프로모션 처방", icon: "M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 104 0M9 5a2 2 0 014 0m-3 8l2 2 3-4" },
-  { href: "/library", label: "사례 라이브러리", icon: "M4 7h16M4 12h16M4 17h10" },
+  { href: "/predict", label: "매출 시뮬레이터", icon: "M4 18l5-5 3 3 7-8M21 8v4m0-4h-4" },
+  { href: "/prescribe", label: "프로모션 추천", icon: "M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 104 0M9 5a2 2 0 014 0m-3 8l2 2 3-4" },
+  { href: "/library", label: "히스토리 비교/분석", icon: "M4 7h16M4 12h16M4 17h10" },
   { href: "/upload", label: "데이터 업로드", icon: "M12 16V4m0 0l-4 4m4-4l4 4M5 20h14" },
 ];
 

--- a/promo-analytics/app/(dash)/library/page.tsx
+++ b/promo-analytics/app/(dash)/library/page.tsx
@@ -35,9 +35,9 @@ export default async function LibraryPage() {
 
   return (
     <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
-      <h1 className="text-xl font-semibold">사례 라이브러리</h1>
+      <h1 className="text-xl font-semibold">히스토리 비교/분석</h1>
       <p className="mt-1 text-sm text-neutral-500">
-        유형·시즌·성과 기준으로 과거 프로모션을 비교하세요.
+        과거 프로모션을 유형·시즈널리티·성과 기준으로 비교·분석하세요.
       </p>
       <div className="mt-6">
         <LibraryTable data={rows} />

--- a/promo-analytics/app/(dash)/page.tsx
+++ b/promo-analytics/app/(dash)/page.tsx
@@ -43,10 +43,13 @@ export default async function Dashboard() {
 
   if (rows.length === 0) return <EmptyState />;
 
+  const n = rows.length;
   const totalUplift = sum(rows.map((r) => r.summary?.total_uplift ?? 0));
-  const totalContribution = sum(rows.map((r) => r.summary?.contribution ?? 0));
   const totalDirect = sum(rows.map((r) => r.summary?.direct_uplift ?? 0));
   const totalHalo = sum(rows.map((r) => r.summary?.halo_uplift ?? 0));
+  const avgDirect = n ? totalDirect / n : 0;
+  const avgHalo = n ? totalHalo / n : 0;
+  const avgDuration = n ? sum(rows.map((r) => r.promo_days)) / n : 0;
   const haloShare = totalUplift !== 0 ? totalHalo / totalUplift : null;
 
   // 상시 일평균 vs 행사 일평균
@@ -111,48 +114,37 @@ export default async function Dashboard() {
           href="/predict"
           className="rounded-full bg-brand-500 px-5 py-2.5 text-sm font-semibold text-white shadow-[0_10px_24px_-10px_var(--color-brand-500)] transition hover:bg-brand-600"
         >
-          예상 매출 추산 →
+          매출 시뮬레이터 →
         </Link>
       </header>
 
-      {/* 헤로 — AI 인사이트 */}
-      <section className="mb-5 flex flex-col gap-4 rounded-[28px] bg-white p-6 card-soft sm:flex-row sm:items-center sm:justify-between">
-        <div>
+      {/* AI 인사이트 */}
+      {best?.summary && (
+        <section className="mb-5 rounded-[28px] bg-white p-6 card-soft">
           <div className="flex items-center gap-2 text-xs font-semibold text-brand-600">
             <span className="flex h-1.5 w-1.5 animate-pulse rounded-full bg-brand-500" />
             AI MD 인사이트
           </div>
-          <h1 className="mt-2 text-2xl font-bold leading-snug tracking-tight">
-            안녕하세요 <span className="align-middle">👋</span>
-          </h1>
-          {best?.summary && (
-            <p className="mt-1 max-w-2xl text-[15px] leading-relaxed text-neutral-600">
-              가장 효과적이었던 건{" "}
-              <Link href={`/promotions/${best.id}`} className="font-semibold text-brand-600 hover:underline">
-                {best.name}
-              </Link>
-              {" "}— 증분 <strong className="text-neutral-900">{won(best.summary.total_uplift)}</strong>
-              {best.summary.halo_share != null && (
-                <>, 후광효과 {pct(best.summary.halo_share)}</>
-              )}
-              에요.
-            </p>
-          )}
-          {liftRatio != null && (
-            <p className="mt-1 text-[15px] leading-relaxed text-neutral-600">
-              프로모션 기간엔 평소(상시 일평균)보다{" "}
-              <strong className="text-brand-600">{liftRatio.toFixed(1)}배</strong> 더 팔렸어요.
-            </p>
-          )}
-        </div>
-      </section>
+          <p className="mt-2 max-w-3xl text-[15px] leading-relaxed text-neutral-700">
+            가장 효과적이었던 건{" "}
+            <Link href={`/promotions/${best.id}`} className="font-semibold text-brand-600 hover:underline">
+              {best.name}
+            </Link>
+            {" "}— 기여 매출 <strong className="text-neutral-900">{won(best.summary.total_uplift)}</strong>
+            {best.summary.halo_share != null && <>, 간접 비중 {pct(best.summary.halo_share)}</>}.
+            {liftRatio != null && (
+              <> 프로모션 기간엔 평소(상시 일평균)보다 <strong className="text-brand-600">{liftRatio.toFixed(1)}배</strong> 더 팔렸어요.</>
+            )}
+          </p>
+        </section>
+      )}
 
       {/* KPI Bento */}
       <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4">
-        <Kpi label="누적 증분 기여" value={won(totalUplift)} brand />
-        <Kpi label="직접효과" value={wonShort(totalDirect)} />
-        <Kpi label="후광효과" value={wonShort(totalHalo)} />
-        <Kpi label="누적 공헌이익" value={won(totalContribution)} />
+        <Kpi label="프로모션 기여 총 매출" value={won(totalUplift)} brand />
+        <Kpi label="평균 직접 매출" value={wonShort(avgDirect)} sub={`프로모션 ${n}건 평균`} />
+        <Kpi label="평균 간접 매출" value={wonShort(avgHalo)} sub={`프로모션 ${n}건 평균`} />
+        <Kpi label="평균 운영 기간" value={`${avgDuration.toFixed(1)}일`} sub={`프로모션 ${n}건 평균`} />
       </div>
 
       {/* 상시 vs 행사 비교 (비교 기준) */}
@@ -160,7 +152,8 @@ export default async function Dashboard() {
         <Card className="lg:col-span-2">
           <CardTitle>상시 대비 행사 일매출</CardTitle>
           <p className="-mt-2 mb-3 text-xs text-neutral-400">
-            회색=평소(상시 일평균) · 주황=프로모션 기간 일평균
+            <span className="font-medium text-neutral-500">상시 일평균</span> = 프로모션 직전 8주의
+            비프로모션 일평균 매출 · <span className="font-medium text-brand-600">행사 일평균</span> = 프로모션 기간 매출 ÷ 운영일수
           </p>
           <BaselineVsPromo data={compData} />
         </Card>
@@ -257,7 +250,7 @@ function sum(a: number[]) {
   return a.reduce((x, y) => x + y, 0);
 }
 
-function Kpi({ label, value, brand }: { label: string; value: string; brand?: boolean }) {
+function Kpi({ label, value, sub, brand }: { label: string; value: string; sub?: string; brand?: boolean }) {
   return (
     <div
       className={`rounded-[24px] p-5 ${
@@ -266,6 +259,7 @@ function Kpi({ label, value, brand }: { label: string; value: string; brand?: bo
     >
       <div className={`text-xs ${brand ? "text-brand-100" : "text-neutral-400"}`}>{label}</div>
       <div className="mt-2 text-xl font-bold tracking-tight tabular-nums sm:text-2xl">{value}</div>
+      {sub && <div className={`mt-0.5 text-[11px] ${brand ? "text-brand-100" : "text-neutral-400"}`}>{sub}</div>}
     </div>
   );
 }

--- a/promo-analytics/app/(dash)/predict/Simulator.tsx
+++ b/promo-analytics/app/(dash)/predict/Simulator.tsx
@@ -43,16 +43,30 @@ export default function Simulator({ cases }: { cases: CaseFeature[] }) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const pred = useMemo(() => predict(spec, cases), [promoType, seasonTag, discount, days, cases]);
 
-  // 할인율별 예상 증분 곡선
+  // 할인율별 예상 증분/공헌이익 곡선
   const curve = useMemo(() => {
-    const out: { discount: number; uplift: number }[] = [];
+    const out: { discount: number; uplift: number; contribution: number }[] = [];
     for (let d = 0; d <= 70; d += 5) {
       const p = predict({ ...spec, discount_rate: d / 100 }, cases);
-      out.push({ discount: d, uplift: Math.round(p.expected_uplift) });
+      out.push({
+        discount: d,
+        uplift: Math.round(p.expected_uplift),
+        contribution: Math.round(p.expected_contribution),
+      });
     }
     return out;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [promoType, seasonTag, days, cases]);
+
+  // 스윗스팟: 최고 효과(증분 최대) / 최고 효율(공헌이익 최대)
+  const bestEffect = useMemo(
+    () => curve.reduce((b, c) => (c.uplift > b.uplift ? c : b), curve[0]),
+    [curve],
+  );
+  const bestEfficiency = useMemo(
+    () => curve.reduce((b, c) => (c.contribution > b.contribution ? c : b), curve[0]),
+    [curve],
+  );
 
   const curUplift = Math.round(pred.expected_uplift);
 
@@ -96,7 +110,7 @@ export default function Simulator({ cases }: { cases: CaseFeature[] }) {
           <Field label="혜택 종류">
             <Chips options={PROMO_TYPES} value={promoType} onChange={setPromoType} />
           </Field>
-          <Field label="시점 / 시즌">
+          <Field label="시즈널리티">
             <Chips options={SEASON_TAGS} value={seasonTag} onChange={setSeasonTag} clearable />
           </Field>
 
@@ -166,12 +180,43 @@ export default function Simulator({ cases }: { cases: CaseFeature[] }) {
         </section>
       </div>
 
-      {/* 할인율 곡선 */}
+      {/* 할인율 곡선 — 스윗스팟 */}
       <section className="mt-3 rounded-[24px] bg-white p-6 card-soft sm:mt-4">
-        <h2 className="mb-1 text-sm font-semibold text-neutral-700">할인율별 예상 증분 — 스윗스팟 찾기</h2>
-        <p className="mb-3 text-xs text-neutral-400">
-          현재 조건({promoType || "전체"}·{days}일)에서 할인율만 바꿨을 때의 예상 증분. 점이 현재 설정.
+        <div className="flex items-center gap-2">
+          <span className="text-xl">🎯</span>
+          <h2 className="text-2xl font-bold tracking-tight">스윗스팟 찾기</h2>
+        </div>
+        <p className="mt-1 text-xs text-neutral-400">
+          현재 조건({promoType || "전체"}·{days}일{seasonTag ? `·${seasonTag}` : ""})에서 할인율만 바꿨을 때의 곡선. 점이 현재 설정.
         </p>
+
+        {/* 최고 포인트 미리보기 */}
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          <button
+            onClick={() => setDiscount(bestEffect.discount)}
+            className="rounded-2xl bg-brand-50 p-4 text-left ring-1 ring-brand-100 transition hover:ring-brand-300"
+          >
+            <div className="text-xs font-semibold text-brand-600">최고 효과 (증분 최대)</div>
+            <div className="mt-1 flex items-baseline gap-2">
+              <span className="text-2xl font-bold text-brand-600">{bestEffect.discount}% 할인</span>
+              <span className="text-sm text-neutral-500">→ 증분 {wonShort(bestEffect.uplift)}</span>
+            </div>
+            <div className="mt-0.5 text-[11px] text-neutral-400">클릭하면 이 조건으로 설정</div>
+          </button>
+          <button
+            onClick={() => setDiscount(bestEfficiency.discount)}
+            className="rounded-2xl bg-neutral-900 p-4 text-left transition hover:bg-neutral-800"
+          >
+            <div className="text-xs font-semibold text-brand-400">최고 효율 (공헌이익 최대)</div>
+            <div className="mt-1 flex items-baseline gap-2">
+              <span className="text-2xl font-bold text-white">{bestEfficiency.discount}% 할인</span>
+              <span className="text-sm text-neutral-300">→ 이익 {wonShort(bestEfficiency.contribution)}</span>
+            </div>
+            <div className="mt-0.5 text-[11px] text-neutral-500">클릭하면 이 조건으로 설정</div>
+          </button>
+        </div>
+
+        <p className="mb-2 mt-5 text-xs font-medium text-neutral-500">할인율별 예상 증분</p>
         <ResponsiveContainer width="100%" height={220}>
           <LineChart data={curve} margin={{ top: 8, right: 12, left: 4, bottom: 0 }}>
             <XAxis dataKey="discount" tickFormatter={(d) => `${d}%`} fontSize={11} stroke="#bcb8b3" tickLine={false} axisLine={false} />

--- a/promo-analytics/app/(dash)/prescribe/page.tsx
+++ b/promo-analytics/app/(dash)/prescribe/page.tsx
@@ -39,7 +39,7 @@ export default function PrescribePage() {
 
   return (
     <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
-      <h1 className="text-xl font-semibold">프로모션 처방</h1>
+      <h1 className="text-xl font-semibold">프로모션 추천</h1>
       <p className="mt-1 text-sm text-neutral-500">
         목표 증분을 입력하면, 과거 성과를 근거로 어떤 혜택 구성이 좋을지
         추천합니다. (공헌이익률 우선 정렬)

--- a/promo-analytics/app/(dash)/promotions/[id]/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/page.tsx
@@ -91,17 +91,18 @@ export default async function PromotionDetail({
       )}
 
       {/* 요약 카드 */}
-      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
-        <Stat label="총 증분 기여" value={won(summary?.total_uplift)} primary />
-        <Stat label="직접효과 (메인)" value={won(summary?.direct_uplift)} />
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-5">
+        <Stat label="프로모션 총 매출" value={won(summary?.actual_revenue)} primary />
+        <Stat label="총 기여 매출" value={won(summary?.total_uplift)} />
+        <Stat label="메인 상품 직접 매출" value={wonShort(summary?.direct_uplift)} />
         <Stat
-          label="후광효과 (기타)"
-          value={won(summary?.halo_uplift)}
+          label="간접 매출"
+          value={wonShort(summary?.halo_uplift)}
           sub={summary?.halo_share != null ? `비중 ${pct(summary.halo_share)}` : undefined}
         />
         <Stat
           label="공헌이익"
-          value={won(summary?.contribution)}
+          value={wonShort(summary?.contribution)}
           sub={
             summary?.contribution_rate != null
               ? `이익률 ${pct(summary.contribution_rate)}`


### PR DESCRIPTION
수정사항 Phase 1 (라벨/지표/시뮬레이터, DB 변경 불필요).

- 메뉴 라벨 3종 변경
- 대시보드: 인사 삭제, KPI 재구성(프로모션 기여 총 매출/평균 직접·간접 매출/평균 운영 기간), 상시 vs 행사 평균 기준 설명
- 시뮬레이터: 시즈널리티 라벨, 스윗스팟 강조(최고 효과/효율 포인트 미리 표시)
- 프로모션 상세 지표 라벨 정비

https://claude.ai/code/session_019bLndSp4ozYod3bYPTL8Mq

---
_Generated by [Claude Code](https://claude.ai/code/session_019bLndSp4ozYod3bYPTL8Mq)_