### PR TITLE
캠페인 삭제·목적 다중선택·"프로모션→캠페인" 리네임·다중 목표 추천

### DIFF
--- a/promo-analytics/app/(dash)/AppShell.tsx
+++ b/promo-analytics/app/(dash)/AppShell.tsx
@@ -7,7 +7,7 @@ import { usePathname } from "next/navigation";
 const NAV = [
   { href: "/", label: "대시보드", icon: "M3.5 12l8.5-8 8.5 8M5.5 10.5V19a1 1 0 001 1h3.5v-5h3v5H18a1 1 0 001-1v-8.5" },
   { href: "/predict", label: "매출 시뮬레이터", icon: "M4 18l5-5 3 3 7-8M21 8v4m0-4h-4" },
-  { href: "/prescribe", label: "프로모션 추천", icon: "M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 104 0M9 5a2 2 0 014 0m-3 8l2 2 3-4" },
+  { href: "/prescribe", label: "캠페인 추천", icon: "M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 104 0M9 5a2 2 0 014 0m-3 8l2 2 3-4" },
   { href: "/library", label: "히스토리 비교/분석", icon: "M4 7h16M4 12h16M4 17h10" },
   { href: "/upload", label: "데이터 업로드", icon: "M12 16V4m0 0l-4 4m4-4l4 4M5 20h14" },
   { href: "/settings", label: "설정", icon: "M10.3 4.3a1 1 0 011.4 0l.7.7a1 1 0 00.9.3l1-.2a1 1 0 011.2.9l.1 1a1 1 0 00.6.8l.9.4a1 1 0 01.5 1.3l-.4.9a1 1 0 000 .9l.4.9a1 1 0 01-.5 1.3l-.9.4a1 1 0 00-.6.8l-.1 1a1 1 0 01-1.2.9l-1-.2a1 1 0 00-.9.3l-.7.7a1 1 0 01-1.4 0M12 9a3 3 0 100 6 3 3 0 000-6z" },
@@ -53,7 +53,7 @@ function Brand() {
         P
       </span>
       <span className="leading-tight">
-        <span className="block text-[15px] font-bold tracking-tight">프로모션 애널리틱스</span>
+        <span className="block text-[15px] font-bold tracking-tight">캠페인 애널리틱스</span>
         <span className="block text-[11px] text-neutral-400">드르펠리스 MD</span>
       </span>
     </Link>

--- a/promo-analytics/app/(dash)/DashCharts.tsx
+++ b/promo-analytics/app/(dash)/DashCharts.tsx
@@ -97,7 +97,7 @@ export function Concentric({
   );
 }
 
-// 상시 일평균 vs 프로모션 일평균 — 비교 막대
+// 상시 일평균 vs 캠페인 일평균 — 비교 막대
 export function BaselineVsPromo({
   data,
 }: {
@@ -130,7 +130,7 @@ export function BaselineVsPromo({
                 {wonShort(d.baseline)}
               </span>
             </div>
-            {/* 프로모션 */}
+            {/* 캠페인 */}
             <div className="mt-1 flex items-center gap-2">
               <span className="w-8 shrink-0 text-[10px] text-brand-600">행사</span>
               <div className="h-3 flex-1 overflow-hidden rounded-full bg-brand-50">

--- a/promo-analytics/app/(dash)/library/LibraryTable.tsx
+++ b/promo-analytics/app/(dash)/library/LibraryTable.tsx
@@ -93,7 +93,7 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
           <thead className="bg-neutral-50 text-left text-xs text-neutral-500">
             <tr>
               <th className="px-4 py-3 text-center font-medium">종합점수</th>
-              <th className="px-4 py-3 font-medium">프로모션</th>
+              <th className="px-4 py-3 font-medium">캠페인</th>
               <th className="px-4 py-3 font-medium">혜택/시즈널리티</th>
               <th className="px-4 py-3 text-right font-medium">할인</th>
               <th className="px-4 py-3 text-right font-medium">총 기여</th>
@@ -135,7 +135,7 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
             {rows.length === 0 && (
               <tr>
                 <td colSpan={7} className="px-4 py-10 text-center text-neutral-400">
-                  조건에 맞는 프로모션이 없습니다.
+                  조건에 맞는 캠페인이 없습니다.
                 </td>
               </tr>
             )}

--- a/promo-analytics/app/(dash)/library/page.tsx
+++ b/promo-analytics/app/(dash)/library/page.tsx
@@ -37,7 +37,7 @@ export default async function LibraryPage() {
     <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
       <h1 className="text-xl font-semibold">히스토리 비교/분석</h1>
       <p className="mt-1 text-sm text-neutral-500">
-        과거 프로모션을 유형·시즈널리티·성과 기준으로 비교·분석하세요.
+        과거 캠페인을 유형·시즈널리티·성과 기준으로 비교·분석하세요.
       </p>
       <div className="mt-6">
         <LibraryTable data={rows} />

--- a/promo-analytics/app/(dash)/page.tsx
+++ b/promo-analytics/app/(dash)/page.tsx
@@ -107,7 +107,7 @@ export default async function Dashboard() {
           </div>
           <div>
             <div className="text-sm font-semibold">{dateChip}</div>
-            <div className="text-xs text-neutral-400">프로모션 {rows.length}건 분석 중</div>
+            <div className="text-xs text-neutral-400">캠페인 {rows.length}건 분석 중</div>
           </div>
         </div>
         <Link
@@ -133,7 +133,7 @@ export default async function Dashboard() {
             {" "}— 기여 매출 <strong className="text-neutral-900">{won(best.summary.total_uplift)}</strong>
             {best.summary.halo_share != null && <>, 간접 비중 {pct(best.summary.halo_share)}</>}.
             {liftRatio != null && (
-              <> 프로모션 기간엔 평소(상시 일평균)보다 <strong className="text-brand-600">{liftRatio.toFixed(1)}배</strong> 더 팔렸어요.</>
+              <> 캠페인 기간엔 평소(상시 일평균)보다 <strong className="text-brand-600">{liftRatio.toFixed(1)}배</strong> 더 팔렸어요.</>
             )}
           </p>
         </section>
@@ -141,10 +141,10 @@ export default async function Dashboard() {
 
       {/* KPI Bento */}
       <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4">
-        <Kpi label="프로모션 기여 총 매출" value={won(totalUplift)} brand />
-        <Kpi label="평균 직접 매출" value={wonShort(avgDirect)} sub={`프로모션 ${n}건 평균`} />
-        <Kpi label="평균 간접 매출" value={wonShort(avgHalo)} sub={`프로모션 ${n}건 평균`} />
-        <Kpi label="평균 운영 기간" value={`${avgDuration.toFixed(1)}일`} sub={`프로모션 ${n}건 평균`} />
+        <Kpi label="캠페인 기여 총 매출" value={won(totalUplift)} brand />
+        <Kpi label="평균 직접 매출" value={wonShort(avgDirect)} sub={`캠페인 ${n}건 평균`} />
+        <Kpi label="평균 간접 매출" value={wonShort(avgHalo)} sub={`캠페인 ${n}건 평균`} />
+        <Kpi label="평균 운영 기간" value={`${avgDuration.toFixed(1)}일`} sub={`캠페인 ${n}건 평균`} />
       </div>
 
       {/* 상시 vs 행사 비교 (비교 기준) */}
@@ -152,8 +152,8 @@ export default async function Dashboard() {
         <Card className="lg:col-span-2">
           <CardTitle>상시 대비 행사 일매출</CardTitle>
           <p className="-mt-2 mb-3 text-xs text-neutral-400">
-            <span className="font-medium text-neutral-500">상시 일평균</span> = 프로모션 직전 8주의
-            비프로모션 일평균 매출 · <span className="font-medium text-brand-600">행사 일평균</span> = 프로모션 기간 매출 ÷ 운영일수
+            <span className="font-medium text-neutral-500">상시 일평균</span> = 캠페인 직전 8주의
+            비캠페인 일평균 매출 · <span className="font-medium text-brand-600">행사 일평균</span> = 캠페인 기간 매출 ÷ 운영일수
           </p>
           <BaselineVsPromo data={compData} />
         </Card>
@@ -281,7 +281,7 @@ function EmptyState() {
         </div>
         <p className="text-base font-semibold text-neutral-800">아직 데이터가 없습니다.</p>
         <p className="mx-auto mt-1 max-w-md text-sm text-neutral-500">
-          첨부해주신 마스터·일별 매출·프로모션 데이터를 버튼 한 번으로 적재할 수 있어요.
+          첨부해주신 마스터·일별 매출·캠페인 데이터를 버튼 한 번으로 적재할 수 있어요.
         </p>
         <Link
           href="/seed"

--- a/promo-analytics/app/(dash)/prescribe/Recommend.tsx
+++ b/promo-analytics/app/(dash)/prescribe/Recommend.tsx
@@ -5,42 +5,72 @@ import Link from "next/link";
 import { won, wonShort, pct, num } from "@/lib/format";
 import type { GoalRec, Goal } from "@/lib/predict";
 
-type Options = { benefitTypes: string[]; seasonalities: string[] };
+type Options = { benefitTypes: string[]; seasonalities: string[]; purposes: string[] };
 
-const GOALS: { key: Goal; label: string; desc: string; targetLabel: string; unit: string }[] = [
-  { key: "revenue", label: "매출", desc: "기여 매출(증분)을 키우는 게 목표", targetLabel: "목표 증분 매출(₩)", unit: "won" },
-  { key: "stock", label: "재고소진", desc: "메인 제품 재고를 빠르게 소진", targetLabel: "목표 판매수량(개)", unit: "qty" },
-  { key: "branding", label: "브랜딩", desc: "구매 건수(저변 확대)가 목표", targetLabel: "목표 구매 건수", unit: "orders" },
+const GOALS: { key: Goal; label: string; desc: string; targetLabel: string; unit: "won" | "qty" | "orders"; placeholder: string }[] = [
+  { key: "revenue",  label: "세일즈",   desc: "기여 매출(증분)을 키우는 게 목표",   targetLabel: "목표 증분 매출(₩)", unit: "won",    placeholder: "50000000" },
+  { key: "stock",    label: "재고소진", desc: "메인 제품 재고를 빠르게 소진",        targetLabel: "목표 판매수량(개)",  unit: "qty",    placeholder: "3000" },
+  { key: "branding", label: "브랜딩",   desc: "구매 건수(저변 확대)가 목표",         targetLabel: "목표 구매 건수",     unit: "orders", placeholder: "1000" },
 ];
 
-function fmtMetric(unit: string, v: number) {
+const GOAL_LABEL: Record<Goal, string> = {
+  revenue: "세일즈",
+  stock: "재고소진",
+  branding: "브랜딩",
+};
+
+function fmtMetric(unit: "won" | "qty" | "orders", v: number) {
   if (unit === "won") return won(v);
   if (unit === "qty") return `${num(v)}개`;
   return `${num(v)}건`;
 }
 
+function unitFor(g: Goal): "won" | "qty" | "orders" {
+  return GOALS.find((x) => x.key === g)!.unit;
+}
+
 export default function Recommend({ options }: { options: Options }) {
-  const [goal, setGoal] = useState<Goal>("revenue");
-  const [target, setTarget] = useState("");
+  const [selected, setSelected] = useState<Goal[]>(["revenue"]);
+  const [targets, setTargets] = useState<Record<Goal, string>>({
+    revenue: "",
+    stock: "",
+    branding: "",
+  });
   const [days, setDays] = useState("4");
   const [season, setSeason] = useState("");
   const [recs, setRecs] = useState<GoalRec[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
-  const goalDef = GOALS.find((g) => g.key === goal)!;
+  function toggleGoal(g: Goal) {
+    setRecs(null);
+    setSelected((s) => {
+      if (s.includes(g)) {
+        // 최소 1개는 남겨둠
+        if (s.length === 1) return s;
+        return s.filter((x) => x !== g);
+      }
+      return [...s, g];
+    });
+  }
+  function setTarget(g: Goal, v: string) {
+    setTargets((t) => ({ ...t, [g]: v }));
+  }
 
   async function run() {
     setLoading(true);
     setError("");
     setRecs(null);
     try {
+      const goal_targets = selected.map((g) => ({
+        goal: g,
+        target: Number(targets[g].replace(/[^0-9.]/g, "")) || 0,
+      }));
       const res = await fetch("/api/prescribe", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          goal,
-          target: Number(target.replace(/[^0-9.]/g, "")) || 0,
+          goal_targets,
           duration_days: Number(days) || 1,
           season_tag: season || null,
         }),
@@ -57,37 +87,60 @@ export default function Recommend({ options }: { options: Options }) {
 
   return (
     <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
-      <h1 className="text-xl font-semibold tracking-tight">프로모션 추천</h1>
+      <h1 className="text-xl font-semibold tracking-tight">캠페인 추천</h1>
       <p className="mt-1 text-sm text-neutral-500">
-        목적을 먼저 고르면, 과거 성과를 근거로 그 목적에 맞는 혜택 구성을 추천해요.
+        목적을 하나 또는 여러 개 선택하면, 과거 성과를 근거로 그에 맞는 혜택 구성을 추천해요.
+        (예: <strong>브랜딩</strong> + <strong>세일즈</strong> 혼합)
       </p>
 
-      {/* 목적 탭 */}
+      {/* 목적 선택 — 다중선택 */}
       <div className="mt-5 grid gap-3 sm:grid-cols-3">
-        {GOALS.map((g) => (
-          <button
-            key={g.key}
-            onClick={() => { setGoal(g.key); setRecs(null); }}
-            className={`rounded-2xl border p-4 text-left transition ${
-              goal === g.key
-                ? "border-brand-500 bg-brand-50"
-                : "border-neutral-200 bg-white hover:border-neutral-300"
-            }`}
-          >
-            <div className={`text-base font-bold ${goal === g.key ? "text-brand-600" : "text-neutral-800"}`}>{g.label}</div>
-            <div className="mt-0.5 text-xs text-neutral-500">{g.desc}</div>
-          </button>
-        ))}
+        {GOALS.map((g) => {
+          const active = selected.includes(g.key);
+          return (
+            <button
+              key={g.key}
+              onClick={() => toggleGoal(g.key)}
+              className={`rounded-2xl border p-4 text-left transition ${
+                active
+                  ? "border-brand-500 bg-brand-50"
+                  : "border-neutral-200 bg-white hover:border-neutral-300"
+              }`}
+            >
+              <div className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={active}
+                  onChange={() => {}}
+                  className="pointer-events-none accent-brand-500"
+                />
+                <div className={`text-base font-bold ${active ? "text-brand-600" : "text-neutral-800"}`}>{g.label}</div>
+              </div>
+              <div className="mt-0.5 text-xs text-neutral-500">{g.desc}</div>
+            </button>
+          );
+        })}
       </div>
 
-      {/* 입력 */}
+      {/* 입력 — 선택된 목표마다 목표값 */}
       <div className="mt-4 rounded-[24px] bg-white p-5 card-soft">
-        <div className="grid gap-4 sm:grid-cols-3">
-          <Field label={goalDef.targetLabel}>
-            <input value={target} onChange={(e) => setTarget(e.target.value)} inputMode="numeric"
-              placeholder={goal === "revenue" ? "50000000" : goal === "stock" ? "3000" : "1000"}
-              className={inputCls} />
-          </Field>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {selected.map((g) => {
+            const def = GOALS.find((x) => x.key === g)!;
+            return (
+              <Field key={g} label={def.targetLabel}>
+                <input
+                  value={targets[g]}
+                  onChange={(e) => setTarget(g, e.target.value)}
+                  inputMode="numeric"
+                  placeholder={def.placeholder}
+                  className={inputCls}
+                />
+              </Field>
+            );
+          })}
+        </div>
+        <div className="mt-4 grid gap-4 sm:grid-cols-2">
           <Field label="기간(일)">
             <input value={days} onChange={(e) => setDays(e.target.value)} inputMode="numeric" className={inputCls} />
           </Field>
@@ -103,20 +156,26 @@ export default function Recommend({ options }: { options: Options }) {
           {loading ? "분석 중…" : "추천 받기"}
         </button>
         {error && <p className="mt-2 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}
+        {selected.length > 1 && (
+          <p className="mt-3 text-xs text-neutral-400">
+            여러 목적을 함께 고르면, 종합 점수는 각 목적 점수의 평균으로 계산돼요.
+            모든 목적의 목표를 만족하는 후보가 ‘목표 달성’으로 표시됩니다.
+          </p>
+        )}
       </div>
 
       {recs && (
         <div className="mt-6">
           {recs.length === 0 ? (
             <p className="rounded-[24px] border border-dashed border-neutral-300 bg-white px-6 py-10 text-center text-sm text-neutral-400">
-              추천할 사례가 부족합니다. 프로모션 데이터를 더 쌓아주세요.
+              추천할 사례가 부족합니다. 캠페인 데이터를 더 쌓아주세요.
             </p>
           ) : (
             <div className="space-y-3">
               {recs.map((r, i) => (
                 <div key={i} className={`rounded-[24px] bg-white p-5 card-soft ${i === 0 ? "ring-2 ring-brand-500" : ""}`}>
                   <div className="flex items-start justify-between gap-3">
-                    <div>
+                    <div className="min-w-0 flex-1">
                       <div className="flex flex-wrap items-center gap-2">
                         {i === 0 && <span className="rounded-full bg-brand-500 px-2 py-0.5 text-xs font-semibold text-white">추천 1순위</span>}
                         <span className="text-base font-bold">
@@ -125,8 +184,39 @@ export default function Recommend({ options }: { options: Options }) {
                         {r.meets_target && <span className="rounded-full bg-green-50 px-2 py-0.5 text-xs text-green-700">목표 달성</span>}
                         <span className="rounded-full bg-neutral-100 px-2 py-0.5 text-xs text-neutral-500">신뢰도 {r.confidence}</span>
                       </div>
+
+                      {/* 목적별 예측 */}
+                      <div className="mt-2 grid gap-1.5 text-xs text-neutral-500 sm:grid-cols-2">
+                        {(r.per_goal ?? [{
+                          goal: "revenue" as Goal,
+                          metric_per_day: r.metric_per_day,
+                          predicted_metric: r.predicted_metric,
+                          target: 0,
+                          meets_target: r.meets_target,
+                        }]).map((pg) => (
+                          <div key={pg.goal} className="flex items-center gap-1.5">
+                            <span className="rounded-full bg-neutral-100 px-2 py-0.5 text-[11px] font-medium text-neutral-600">
+                              {GOAL_LABEL[pg.goal]}
+                            </span>
+                            <span>
+                              예상 <strong className="text-neutral-800">{fmtMetric(unitFor(pg.goal), pg.predicted_metric)}</strong>
+                              {pg.target > 0 && (
+                                <>
+                                  {" / "}
+                                  목표 {fmtMetric(unitFor(pg.goal), pg.target)}
+                                  {pg.meets_target ? (
+                                    <span className="ml-1 text-green-600">✓</span>
+                                  ) : (
+                                    <span className="ml-1 text-amber-600">▾</span>
+                                  )}
+                                </>
+                              )}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+
                       <div className="mt-2 flex flex-wrap gap-x-5 gap-y-1 text-xs text-neutral-500">
-                        <span>예상 {goalDef.label}: <strong className="text-neutral-800">{fmtMetric(goalDef.unit, r.predicted_metric)}</strong></span>
                         <span>예상 증분: {wonShort(r.predicted_uplift)}</span>
                         <span>예상 공헌이익: {wonShort(r.predicted_contribution)}</span>
                         <span>근거 {r.sample}건</span>

--- a/promo-analytics/app/(dash)/promotions/[id]/edit/EditForm.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/edit/EditForm.tsx
@@ -6,7 +6,7 @@ import type { Promotion } from "@/lib/types";
 import { wonShort } from "@/lib/format";
 
 type ProductItem = { product_id: string; base_name: string; revenue: number };
-type Options = { benefitTypes: string[]; seasonalities: string[] };
+type Options = { benefitTypes: string[]; seasonalities: string[]; purposes: string[] };
 
 export default function EditForm({
   promo,
@@ -25,7 +25,9 @@ export default function EditForm({
     promo.promo_types ?? (promo.promo_type ? [promo.promo_type] : []),
   );
   const [seasonTag, setSeasonTag] = useState(promo.season_tag ?? "");
-  const [purpose, setPurpose] = useState(promo.purpose ?? "");
+  const [purposes, setPurposes] = useState<string[]>(
+    promo.purposes ?? (promo.purpose ? [promo.purpose] : []),
+  );
   const [startDate, setStartDate] = useState(promo.start_date ?? "");
   const [endDate, setEndDate] = useState(promo.end_date ?? "");
   const [discountRate, setDiscountRate] = useState(
@@ -42,10 +44,14 @@ export default function EditForm({
   );
   const [mainIds, setMainIds] = useState<string[]>(initialMainIds);
   const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const [query, setQuery] = useState("");
 
   function toggleType(t: string) {
     setPromoTypes((p) => (p.includes(t) ? p.filter((x) => x !== t) : [...p, t]));
+  }
+  function togglePurpose(t: string) {
+    setPurposes((p) => (p.includes(t) ? p.filter((x) => x !== t) : [...p, t]));
   }
   function toggleMain(id: string) {
     setMainIds((m) => (m.includes(id) ? m.filter((x) => x !== id) : [...m, id]));
@@ -76,7 +82,8 @@ export default function EditForm({
         promo_types: promoTypes,
         promo_type: promoTypes[0] ?? null,
         season_tag: seasonTag || null,
-        purpose: purpose || null,
+        purposes,
+        purpose: purposes[0] ?? null,
         start_date: startDate,
         end_date: endDate,
         benefits: Object.keys(benefits).length ? benefits : null,
@@ -88,7 +95,22 @@ export default function EditForm({
     if (res.ok) router.push(`/promotions/${promo.id}`);
     else {
       const d = await res.json().catch(() => ({}));
-      alert(d.error ?? "저장 실패 (Phase 2 SQL이 적용됐는지 확인하세요)");
+      alert(d.error ?? "저장 실패 (마이그레이션이 적용됐는지 확인하세요)");
+    }
+  }
+
+  async function remove() {
+    if (!confirm(`'${promo.name}' 캠페인을 삭제할까요?\n\n실적·메인상품·메모가 함께 삭제됩니다. 복구 불가.`))
+      return;
+    setDeleting(true);
+    const res = await fetch(`/api/promotions/${promo.id}`, { method: "DELETE" });
+    setDeleting(false);
+    if (res.ok) {
+      router.push("/library");
+      router.refresh();
+    } else {
+      const d = await res.json().catch(() => ({}));
+      alert(d.error ?? "삭제 실패");
     }
   }
 
@@ -98,13 +120,13 @@ export default function EditForm({
 
   return (
     <div className="max-w-3xl">
-      <h1 className="text-xl font-semibold tracking-tight">프로모션 편집</h1>
+      <h1 className="text-xl font-semibold tracking-tight">캠페인 편집</h1>
       <p className="mt-1 text-sm text-neutral-500">
         기간·목적·혜택을 채우고, 특별 혜택을 준 <strong>메인 상품</strong>을 지정하세요.
       </p>
 
       <div className="mt-6 space-y-5">
-        <Field label="프로모션명">
+        <Field label="캠페인명">
           <input value={name} onChange={(e) => setName(e.target.value)} className={inputCls} />
         </Field>
 
@@ -121,20 +143,15 @@ export default function EditForm({
           <MultiChips options={options.benefitTypes} values={promoTypes} onToggle={toggleType} />
         </Field>
 
-        <Field label="시즈널리티">
-          <SingleChips options={options.seasonalities} value={seasonTag} onChange={setSeasonTag} />
+        <Field label={`목적 (복수 선택) — ${purposes.length}개`}>
+          <MultiChips options={options.purposes} values={purposes} onToggle={togglePurpose} />
+          <p className="mt-1 text-xs text-neutral-400">
+            브랜딩 + 세일즈처럼 섞인 캠페인도 모두 체크해주세요. ‘설정 → 캠페인 목적’에서 항목을 추가할 수 있어요.
+          </p>
         </Field>
 
-        <Field label="목적">
-          <input
-            value={purpose}
-            onChange={(e) => setPurpose(e.target.value)}
-            placeholder="예: 신제품 런칭 / 모래류 매출 극대화 / 3주년 / 재고 소진"
-            className={inputCls}
-          />
-          <p className="mt-1 text-xs text-neutral-400">
-            ‘런칭·리뉴얼’ 등은 혜택이 아니라 <strong>목적</strong>에 적어주세요.
-          </p>
+        <Field label="시즈널리티">
+          <SingleChips options={options.seasonalities} value={seasonTag} onChange={setSeasonTag} />
         </Field>
 
         <div className="grid grid-cols-3 gap-4">
@@ -217,10 +234,10 @@ export default function EditForm({
         </Field>
       </div>
 
-      <div className="mt-6 flex gap-2">
+      <div className="mt-6 flex items-center gap-2">
         <button
           onClick={save}
-          disabled={saving}
+          disabled={saving || deleting}
           className="rounded-full bg-brand-500 px-6 py-2.5 text-sm font-medium text-white hover:bg-brand-600 disabled:opacity-50"
         >
           {saving ? "저장 중…" : "저장"}
@@ -230,6 +247,13 @@ export default function EditForm({
           className="rounded-full border border-neutral-200 px-6 py-2.5 text-sm font-medium hover:bg-neutral-50"
         >
           취소
+        </button>
+        <button
+          onClick={remove}
+          disabled={saving || deleting}
+          className="ml-auto rounded-full border border-red-200 px-5 py-2.5 text-sm font-medium text-red-600 hover:bg-red-50 disabled:opacity-50"
+        >
+          {deleting ? "삭제 중…" : "캠페인 삭제"}
         </button>
       </div>
     </div>

--- a/promo-analytics/app/(dash)/promotions/[id]/edit/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/edit/page.tsx
@@ -31,7 +31,7 @@ export default async function EditPromotion({
     .select("product_id")
     .eq("promotion_id", id);
 
-  // 프로모션 내 상품 목록 (매출 합으로 정렬, 중복 제거)
+  // 캠페인 내 상품 목록 (매출 합으로 정렬, 중복 제거)
   const agg = new Map<string, { product_id: string; base_name: string; revenue: number }>();
   for (const s of sales ?? []) {
     if (!s.product_id) continue;

--- a/promo-analytics/app/(dash)/promotions/[id]/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/page.tsx
@@ -63,7 +63,7 @@ export default async function PromotionDetail({
         <Link href="/" className="hover:underline">
           대시보드
         </Link>{" "}
-        / 프로모션
+        / 캠페인
       </div>
       <header className="mb-6 flex items-start justify-between gap-4">
         <div>
@@ -95,7 +95,7 @@ export default async function PromotionDetail({
 
       {/* 요약 카드 */}
       <div className="grid grid-cols-2 gap-3 md:grid-cols-5">
-        <Stat label="프로모션 총 매출" value={won(summary?.actual_revenue)} primary />
+        <Stat label="캠페인 총 매출" value={won(summary?.actual_revenue)} primary />
         <Stat
           label="총 기여 매출"
           value={won(summary?.total_uplift)}
@@ -199,7 +199,7 @@ export default async function PromotionDetail({
                 {rows.length === 0 && (
                   <tr>
                     <td colSpan={5} className="px-3 py-8 text-center text-neutral-400">
-                      프로모션 기간의 판매 데이터가 없습니다.
+                      캠페인 기간의 판매 데이터가 없습니다.
                     </td>
                   </tr>
                 )}
@@ -207,7 +207,7 @@ export default async function PromotionDetail({
             </table>
           </div>
           <p className="mt-2 text-[11px] text-neutral-400">
-            baseline = 직전 8주 비프로모션 일자의 요일별 평균 (±2σ 트림). 추세 보정 적용. 95% CI는 baseline 변동성 기준.
+            baseline = 직전 8주 비캠페인 일자의 요일별 평균 (±2σ 트림). 추세 보정 적용. 95% CI는 baseline 변동성 기준.
           </p>
         </section>
 

--- a/promo-analytics/app/(dash)/seed/page.tsx
+++ b/promo-analytics/app/(dash)/seed/page.tsx
@@ -33,11 +33,11 @@ export default function SeedPage() {
     setLog([]);
     setProgress(0);
     try {
-      append("마스터·프로모션 적재 중…");
+      append("마스터·캠페인 적재 중…");
       const m = await fetch(`/api/seed?key=${KEY}&phase=master`, { method: "POST" });
       const md = await m.json();
       if (!m.ok) throw new Error(md.error);
-      append(`상품 ${md.products}개 · 프로모션 ${md.promotions}개 완료`);
+      append(`상품 ${md.products}개 · 캠페인 ${md.promotions}개 완료`);
 
       let total = 0;
       for (let i = 0; i < meta.dailyChunks; i++) {
@@ -63,14 +63,14 @@ export default function SeedPage() {
     <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
       <h1 className="text-xl font-semibold">초기 데이터 적재</h1>
       <p className="mt-1 text-sm text-neutral-500">
-        첨부된 마스터·일별 매출·프로모션 시트를 한 번에 적재합니다. (중복 시 덮어쓰기)
+        첨부된 마스터·일별 매출·캠페인 시트를 한 번에 적재합니다. (중복 시 덮어쓰기)
       </p>
 
       {meta && (
         <div className="mt-5 grid max-w-md grid-cols-3 gap-3">
           <Mini label="상품" value={meta.products} />
           <Mini label="일별 행" value={meta.dailyTotal} />
-          <Mini label="프로모션" value={meta.promotions} />
+          <Mini label="캠페인" value={meta.promotions} />
         </div>
       )}
 

--- a/promo-analytics/app/(dash)/settings/page.tsx
+++ b/promo-analytics/app/(dash)/settings/page.tsx
@@ -3,18 +3,19 @@
 import { useEffect, useState, useCallback } from "react";
 
 type Item = { id: string; name: string; sort: number };
-type Kind = "benefit_types" | "seasonalities";
+type Kind = "benefit_types" | "seasonalities" | "purposes";
 
 export default function SettingsPage() {
   return (
     <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
       <h1 className="text-xl font-semibold tracking-tight">설정 — 분류 관리</h1>
       <p className="mt-1 text-sm text-neutral-500">
-        혜택 종류와 시즈널리티 항목을 추가·수정·삭제할 수 있어요. 시뮬레이터·편집 화면에 바로 반영됩니다.
+        혜택·시즈널리티·목적 항목을 추가·수정·삭제할 수 있어요. 시뮬레이터·편집 화면에 바로 반영됩니다.
       </p>
       <div className="mt-6 grid gap-4 lg:grid-cols-2">
         <ListEditor kind="benefit_types" title="혜택 종류" hint="할인·사은품·1+1 등 (고객이 받는 혜택)" />
         <ListEditor kind="seasonalities" title="시즈널리티" hint="N주년·명절·크리스마스 등 시점" />
+        <ListEditor kind="purposes" title="캠페인 목적" hint="세일즈·브랜딩·재고소진 등 (복수 선택 가능)" />
       </div>
     </div>
   );

--- a/promo-analytics/app/(dash)/upload/page.tsx
+++ b/promo-analytics/app/(dash)/upload/page.tsx
@@ -25,8 +25,8 @@ const CARDS: CardDef[] = [
   },
   {
     key: "promotion",
-    title: "③ 프로모션 시트",
-    desc: "프로모션 기간 실적(전 제품). 업로드하면 프로모션이 생성되고 상세로 이동합니다.",
+    title: "③ 캠페인 시트",
+    desc: "캠페인 기간 실적(전 제품). 업로드하면 캠페인이 생성되고 상세로 이동합니다.",
   },
 ];
 
@@ -140,7 +140,7 @@ function UploadCard({ def }: { def: CardDef }) {
       const parsed = parse.parsePromotionSheet(buf);
       if (parsed.rows.length === 0) throw new Error("유효한 행이 없습니다.");
       if (!parsed.start_date || !parsed.end_date)
-        throw new Error("프로모션 기간을 시트에서 찾지 못했습니다. (일자 누적 컬럼 확인)");
+        throw new Error("캠페인 기간을 시트에서 찾지 못했습니다. (일자 누적 컬럼 확인)");
 
       setP({ phase: "uploading", message: "상품 매칭 중…" });
       const productMap = await products.ensureProducts(
@@ -152,7 +152,7 @@ function UploadCard({ def }: { def: CardDef }) {
       const code = parse.extractPromoCode(rawName);
       const name = code ? rawName.slice(rawName.indexOf(code)) : rawName;
 
-      setP({ phase: "uploading", message: "프로모션 생성 중…" });
+      setP({ phase: "uploading", message: "캠페인 생성 중…" });
       const { data: promo, error: pErr } = await supabase
         .from("promotions")
         .insert({

--- a/promo-analytics/app/(dash)/upload/page.tsx
+++ b/promo-analytics/app/(dash)/upload/page.tsx
@@ -90,15 +90,27 @@ function UploadCard({ def }: { def: CardDef }) {
           rows.map((r) => r.base_name),
         );
 
-        const records = rows.map((r) => ({
-          sale_date: r.sale_date,
-          product_id: productMap.get(r.base_name) ?? null,
-          base_name: r.base_name,
-          option_info: r.option_info,
-          revenue: r.revenue,
-          quantity: r.quantity,
-          source_file: file.name,
-        }));
+        // 충돌 키(sale_date·base_name·option_info)로 사전 중복 제거 — 후순위 우선(합산).
+        // 같은 키가 한 배치에 두 번 들어가면 Postgres upsert가 실패하므로 방어.
+        const dedup = new Map<
+          string,
+          { sale_date: string; product_id: string | null; base_name: string; option_info: string; revenue: number; quantity: number; source_file: string }
+        >();
+        for (const r of rows) {
+          const key = JSON.stringify([r.sale_date, r.base_name, r.option_info]);
+          const prev = dedup.get(key);
+          dedup.set(key, {
+            sale_date: r.sale_date,
+            product_id: productMap.get(r.base_name) ?? null,
+            base_name: r.base_name,
+            option_info: r.option_info,
+            // 동일 키가 여러 행으로 분리돼 있으면 합산(옵션 컬럼 없는 파일 대비)
+            revenue: (prev?.revenue ?? 0) + r.revenue,
+            quantity: (prev?.quantity ?? 0) + r.quantity,
+            source_file: file.name,
+          });
+        }
+        const records = [...dedup.values()];
 
         const batches = products.chunk(records, 1000);
         let done = 0;

--- a/promo-analytics/app/api/options/route.ts
+++ b/promo-analytics/app/api/options/route.ts
@@ -3,7 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 
 export const runtime = "nodejs";
 
-const TABLES = ["benefit_types", "seasonalities"] as const;
+const TABLES = ["benefit_types", "seasonalities", "purposes"] as const;
 type Kind = (typeof TABLES)[number];
 
 function validKind(k: unknown): k is Kind {
@@ -12,13 +12,15 @@ function validKind(k: unknown): k is Kind {
 
 export async function GET() {
   const supabase = await createClient();
-  const [bt, ss] = await Promise.all([
+  const [bt, ss, pp] = await Promise.all([
     supabase.from("benefit_types").select("id, name, sort").order("sort"),
     supabase.from("seasonalities").select("id, name, sort").order("sort"),
+    supabase.from("purposes").select("id, name, sort").order("sort"),
   ]);
   return NextResponse.json({
     benefit_types: bt.data ?? [],
     seasonalities: ss.data ?? [],
+    purposes: pp.data ?? [],
   });
 }
 

--- a/promo-analytics/app/api/prescribe/route.ts
+++ b/promo-analytics/app/api/prescribe/route.ts
@@ -1,22 +1,47 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { loadCases } from "@/lib/cases";
-import { recommendByGoal, type Goal } from "@/lib/predict";
+import { recommendByGoals, type Goal, type GoalTarget } from "@/lib/predict";
 
 export const runtime = "nodejs";
 
+const VALID_GOALS: Goal[] = ["revenue", "stock", "branding"];
+
 export async function POST(req: Request) {
   try {
-    const { goal, target, duration_days, season_tag } = await req.json();
-    const g = (goal as Goal) ?? "revenue";
+    const body = await req.json();
+    const { duration_days, season_tag } = body as {
+      duration_days?: number;
+      season_tag?: string | null;
+    };
     if (!duration_days)
       return NextResponse.json({ error: "기간을 입력하세요." }, { status: 400 });
 
+    // 신·구 입력 모두 수용
+    // - 신: goal_targets: [{ goal, target }]
+    // - 구: goal + target (단일)
+    let goalTargets: GoalTarget[] = [];
+    if (Array.isArray(body.goal_targets)) {
+      goalTargets = (body.goal_targets as unknown[])
+        .map((g) => {
+          if (typeof g !== "object" || g === null) return null;
+          const o = g as Record<string, unknown>;
+          const goal = o.goal as Goal;
+          if (!VALID_GOALS.includes(goal)) return null;
+          return { goal, target: Number(o.target) || 0 } as GoalTarget;
+        })
+        .filter((x): x is GoalTarget => x !== null);
+    }
+    if (goalTargets.length === 0 && body.goal && VALID_GOALS.includes(body.goal)) {
+      goalTargets = [{ goal: body.goal as Goal, target: Number(body.target) || 0 }];
+    }
+    if (goalTargets.length === 0)
+      return NextResponse.json({ error: "목표를 하나 이상 선택하세요." }, { status: 400 });
+
     const supabase = await createClient();
     const cases = await loadCases(supabase);
-    const recs = recommendByGoal(
-      g,
-      Number(target) || 0,
+    const recs = recommendByGoals(
+      goalTargets,
       Number(duration_days),
       season_tag || null,
       cases,

--- a/promo-analytics/app/api/promotions/[id]/route.ts
+++ b/promo-analytics/app/api/promotions/[id]/route.ts
@@ -21,6 +21,7 @@ export async function PATCH(
     const allowed = [
       "name",
       "purpose",
+      "purposes",
       "promo_type",
       "promo_types",
       "season_tag",

--- a/promo-analytics/app/layout.tsx
+++ b/promo-analytics/app/layout.tsx
@@ -2,8 +2,8 @@ import type { Metadata } from "next";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "프로모션 애널리틱스",
-  description: "드르펠리스 사내 · 프로모션 매출 기여도 측정 · 예측 · 처방",
+  title: "캠페인 애널리틱스",
+  description: "드르펠리스 사내 · 캠페인 매출 기여도 측정 · 예측 · 처방",
 };
 
 export default function RootLayout({

--- a/promo-analytics/app/login/page.tsx
+++ b/promo-analytics/app/login/page.tsx
@@ -26,7 +26,7 @@ export default function LoginPage() {
     <main className="flex min-h-screen items-center justify-center bg-neutral-50 p-6">
       <div className="w-full max-w-sm rounded-2xl border border-neutral-200 bg-white p-8 shadow-sm">
         <h1 className="text-xl font-semibold text-neutral-900">
-          프로모션 애널리틱스
+          캠페인 애널리틱스
         </h1>
         <p className="mt-2 text-sm text-neutral-500">
           드르펠리스 사내 전용 · 매출 기여도 측정 · 예측 · 처방

--- a/promo-analytics/lib/constants.ts
+++ b/promo-analytics/lib/constants.ts
@@ -20,3 +20,12 @@ export const SEASON_TAGS = [
   "여름",
   "겨울",
 ];
+
+export const PURPOSE_TAGS = [
+  "세일즈",
+  "브랜딩",
+  "재고소진",
+  "신제품 런칭",
+  "리뉴얼",
+  "회원 활성화",
+];

--- a/promo-analytics/lib/options.ts
+++ b/promo-analytics/lib/options.ts
@@ -1,19 +1,24 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { PROMO_TYPES, SEASON_TAGS } from "./constants";
+import { PROMO_TYPES, SEASON_TAGS, PURPOSE_TAGS } from "./constants";
 
-export type Options = { benefitTypes: string[]; seasonalities: string[] };
+export type Options = {
+  benefitTypes: string[];
+  seasonalities: string[];
+  purposes: string[];
+};
 
 /**
- * 혜택종류·시즈널리티 목록을 DB에서 로드.
- * (테이블 미존재/비어있으면 기본 상수로 폴백 — Phase 2 SQL 적용 전에도 안전)
+ * 혜택종류·시즈널리티·목적 목록을 DB에서 로드.
+ * 테이블 미존재/비어있으면 기본 상수로 폴백 — 마이그레이션 적용 전에도 안전.
  */
 export async function loadOptions(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   supabase: SupabaseClient<any, any, any>,
 ): Promise<Options> {
-  const [bt, ss] = await Promise.all([
+  const [bt, ss, pp] = await Promise.all([
     supabase.from("benefit_types").select("name").order("sort"),
     supabase.from("seasonalities").select("name").order("sort"),
+    supabase.from("purposes").select("name").order("sort"),
   ]);
   const benefitTypes =
     !bt.error && bt.data && bt.data.length > 0
@@ -23,5 +28,9 @@ export async function loadOptions(
     !ss.error && ss.data && ss.data.length > 0
       ? ss.data.map((r) => r.name as string)
       : SEASON_TAGS;
-  return { benefitTypes, seasonalities };
+  const purposes =
+    !pp.error && pp.data && pp.data.length > 0
+      ? pp.data.map((r) => r.name as string)
+      : PURPOSE_TAGS;
+  return { benefitTypes, seasonalities, purposes };
 }

--- a/promo-analytics/lib/predict.ts
+++ b/promo-analytics/lib/predict.ts
@@ -176,7 +176,7 @@ export type Recommendation = {
   meets_target: boolean;
 };
 
-// ── 목적 기반 추천 (매출/재고소진/브랜딩) + 종합점수 ──
+// ── 목적 기반 추천 (세일즈/재고소진/브랜딩) + 종합점수 ──
 export type Goal = "revenue" | "stock" | "branding";
 
 export type GoalRec = {
@@ -192,7 +192,18 @@ export type GoalRec = {
   sample: number;
   meets_target: boolean;
   examples: { id: string; name: string }[];
+  // 멀티 목표일 때 각 목표별 예측치/달성 여부
+  per_goal?: {
+    goal: Goal;
+    metric_per_day: number;
+    predicted_metric: number;
+    target: number;
+    meets_target: boolean;
+  }[];
 };
+
+// 멀티 목표 입력
+export type GoalTarget = { goal: Goal; target: number };
 
 function goalPerDay(goal: Goal, c: CaseFeature): number {
   if (goal === "stock") return c.qty_per_day;
@@ -282,6 +293,136 @@ export function recommendByGoal(
       sample: r.sample,
       meets_target: predicted_metric >= target,
       examples: r.examples,
+    };
+  });
+
+  return recs.sort((a, b) => {
+    if (a.meets_target !== b.meets_target) return a.meets_target ? -1 : 1;
+    return b.score - a.score;
+  });
+}
+
+// 멀티 목표(브랜딩+세일즈 등) 동시 추천: 각 목표별 점수를 동일 가중 평균.
+// 목표마다 별도 target을 받아 per_goal에서 달성 여부를 함께 반환.
+export function recommendByGoals(
+  goalTargets: GoalTarget[],
+  durationDays: number,
+  seasonTag: string | null,
+  cases: CaseFeature[],
+): GoalRec[] {
+  if (goalTargets.length === 0) return [];
+  if (goalTargets.length === 1) {
+    const { goal, target } = goalTargets[0];
+    return recommendByGoal(goal, target, durationDays, seasonTag, cases);
+  }
+
+  const buckets = new Map<string, CaseFeature[]>();
+  for (const c of cases) {
+    if (!c.promo_type) continue;
+    if (seasonTag && c.season_tag && c.season_tag !== seasonTag) continue;
+    const bucket =
+      c.discount_rate != null ? Math.round((c.discount_rate * 100) / 10) * 10 : -1;
+    const key = `${c.promo_type}|${bucket}`;
+    (buckets.get(key) ?? buckets.set(key, []).get(key)!).push(c);
+  }
+
+  type Raw = {
+    promo_type: string;
+    discount_rate: number | null;
+    metrics: Map<Goal, number>; // 목적별 일평균 지표
+    uplift_per_day: number;
+    contribution_per_day: number;
+    contribution_rate: number | null;
+    efficiency: number;
+    halo_share: number;
+    sample: number;
+    examples: { id: string; name: string }[];
+  };
+  const raws: Raw[] = [];
+  for (const [key, g] of buckets) {
+    const [promo_type, bucketStr] = key.split("|");
+    const bucket = Number(bucketStr);
+    const avg = (pick: (c: CaseFeature) => number) =>
+      g.reduce((s, c) => s + pick(c), 0) / g.length;
+    const dr = bucket >= 0 ? bucket / 100 : null;
+    const uplift_per_day = avg((c) => c.uplift_per_day);
+    const crs = g.map((c) => c.contribution_rate).filter((x): x is number => x != null);
+    const cr = crs.length ? crs.reduce((a, b) => a + b, 0) / crs.length : null;
+    const metrics = new Map<Goal, number>();
+    metrics.set("revenue", uplift_per_day);
+    metrics.set("stock", avg((c) => c.qty_per_day));
+    metrics.set("branding", avg((c) => c.orders_per_day));
+    raws.push({
+      promo_type,
+      discount_rate: dr,
+      metrics,
+      uplift_per_day,
+      contribution_per_day: avg((c) => (c.duration_days > 0 ? c.contribution / c.duration_days : 0)),
+      contribution_rate: cr,
+      efficiency: dr && dr > 0 ? uplift_per_day / dr : uplift_per_day,
+      halo_share: avg((c) => c.halo_share ?? 0),
+      sample: g.length,
+      examples: g.slice(0, 3).map((c) => ({ id: c.id, name: c.name })),
+    });
+  }
+
+  const maxOf = (pick: (r: Raw) => number) => Math.max(...raws.map(pick), 1e-9);
+  const mU = maxOf((r) => r.uplift_per_day);
+  const mC = maxOf((r) => r.contribution_per_day);
+  const mE = maxOf((r) => r.efficiency);
+  // 목적별 정규화용 최대값
+  const mMetric = new Map<Goal, number>();
+  for (const gt of goalTargets) {
+    mMetric.set(gt.goal, maxOf((r) => r.metrics.get(gt.goal) ?? 0));
+  }
+
+  const recs: GoalRec[] = raws.map((r) => {
+    // 단일 목표 점수: 공헌이익40·증분30·효율20·후광10 (기존 가중치)
+    // 멀티 목표 점수: 위 점수 + 선택한 목적별 정규화 metric 평균 점수
+    //                선택한 목적 비중을 절반 정도 반영(과도한 편향 방지)
+    const baseScore =
+      0.4 * (r.contribution_per_day / mC) +
+      0.3 * (r.uplift_per_day / mU) +
+      0.2 * (r.efficiency / mE) +
+      0.1 * Math.min(1, r.halo_share);
+    const goalScore =
+      goalTargets.reduce((s, gt) => {
+        const m = r.metrics.get(gt.goal) ?? 0;
+        const max = mMetric.get(gt.goal) ?? 1e-9;
+        return s + m / max;
+      }, 0) / goalTargets.length;
+    const score = (baseScore * 0.5 + goalScore * 0.5) * 100;
+
+    const per_goal = goalTargets.map((gt) => {
+      const metricPerDay = r.metrics.get(gt.goal) ?? 0;
+      const predictedMetric = metricPerDay * durationDays;
+      return {
+        goal: gt.goal,
+        metric_per_day: metricPerDay,
+        predicted_metric: predictedMetric,
+        target: gt.target,
+        meets_target: gt.target > 0 ? predictedMetric >= gt.target : true,
+      };
+    });
+    const meetsAll = per_goal.every((p) => p.meets_target);
+
+    const cScore = Math.min(1, r.sample / 5);
+    // GoalRec의 단일 metric 필드는 첫 목표 기준으로 채움(하위 호환).
+    const primary = per_goal[0];
+    return {
+      promo_type: r.promo_type,
+      discount_rate: r.discount_rate,
+      metric_per_day: primary.metric_per_day,
+      predicted_metric: primary.predicted_metric,
+      predicted_uplift: r.uplift_per_day * durationDays,
+      predicted_contribution: r.contribution_per_day * durationDays,
+      contribution_rate: r.contribution_rate,
+      score: Math.round(score),
+      confidence: cScore >= 0.66 ? "높음" : cScore >= 0.4 ? "보통" : "낮음",
+      sample: r.sample,
+      meets_target: meetsAll,
+      examples: r.examples,
+      per_goal,
     };
   });
 

--- a/promo-analytics/lib/types.ts
+++ b/promo-analytics/lib/types.ts
@@ -16,6 +16,7 @@ export type Promotion = {
   end_date: string;
   channel: string | null;
   purpose: string | null;
+  purposes: string[] | null;
   promo_type: string | null;
   promo_types: string[] | null;
   season_tag: string | null;

--- a/promo-analytics/supabase/migrations/0004_purposes.sql
+++ b/promo-analytics/supabase/migrations/0004_purposes.sql
@@ -1,0 +1,23 @@
+-- 캠페인 목적 다중선택 + 목적 마스터 + 추천 가중치 확장
+-- 1) promotions.purposes 컬럼 추가 (기존 promotions.purpose text는 폴백/표시용 유지)
+alter table promo.promotions add column if not exists purposes text[];
+
+-- 2) 목적 마스터 테이블
+create table if not exists promo.purposes (
+  id   uuid primary key default gen_random_uuid(),
+  name text not null unique,
+  sort int  not null default 0,
+  created_at timestamptz not null default now()
+);
+
+insert into promo.purposes(name, sort) values
+  ('세일즈',1),('브랜딩',2),('재고소진',3),('신제품 런칭',4),('리뉴얼',5),('회원 활성화',6)
+on conflict (name) do nothing;
+
+alter table promo.purposes enable row level security;
+drop policy if exists purposes_auth on promo.purposes;
+create policy purposes_auth on promo.purposes for all to authenticated using (true) with check (true);
+
+grant all on all tables in schema promo to authenticated;
+grant all on all sequences in schema promo to authenticated;
+grant execute on all functions in schema promo to authenticated;


### PR DESCRIPTION
PR #21 머지 이후 사용자 피드백 반영. 업로드 방어 + 캠페인 삭제 + 목적 다중선택 + 용어 정리 + 다중 목표 추천을 묶었어.

## 1) 업로드: 옵션 컬럼 없는 일별매출 파일의 업서트 충돌 방어 (선행 커밋)

실데이터(27,400행, 옵션·수량 컬럼 누락) 검증 중 발견. option_info가 전부 `""`인 파일에서 같은 `(날짜·상품)` 행이 한 배치에 두 번 들어가면 `ON CONFLICT DO UPDATE command cannot affect row a second time` 로 배치 통째 실패.

→ 업로드 시 충돌 키 기준 사전 dedup, revenue·quantity 합산으로 손실 없이 병합.

## 2) 캠페인 삭제

편집 화면 우측에 **캠페인 삭제** 버튼. confirm 후 `/api/promotions/[id]` DELETE 호출. FK CASCADE로 `promotion_main_products`·`promotion_sales`·`promotion_notes` 함께 정리. 삭제 후 `/library`로 이동.

## 3) 캠페인 목적 다중선택

- 마이그레이션 `0004_purposes.sql`: `promotions.purposes text[]` 컬럼 + `purposes` 마스터 테이블
- 기본 목적: 세일즈 / 브랜딩 / 재고소진 / 신제품 런칭 / 리뉴얼 / 회원 활성화
- 편집 화면에 혜택과 동일한 `MultiChips`
- `/api/options`에 `purposes` CRUD 추가 → 설정 페이지에서 추가·수정·삭제
- 기존 `promotion.purpose`(단일 text)는 폴백/표시용으로 유지

## 4) "프로모션" → "캠페인" UI 텍스트 일괄 치환

사이드바·대시보드·라이브러리·편집·상세·업로드·로그인·메타·seed 페이지.

**URL 경로**(`/promotions/`), **DB 스키마**(`promotions`·`promotion_*`), **변수명**은 외부 호환을 위해 유지.

## 5) 캠페인 추천: 다중 목표 + "매출" → "세일즈"

- `revenue` 라벨을 "매출" → **"세일즈"** 로 변경
- 목표 선택을 단일 → **다중(체크박스 카드)** 으로 전환 (브랜딩 + 세일즈 혼합 등)
- 선택된 목표마다 별도 목표값 입력
- `lib/predict.ts`에 `recommendByGoals` 추가:
  - 기본 점수(공헌이익40·증분30·효율20·후광10)와 목적별 정규화 metric 평균을 50/50 혼합하여 종합점수 산출
  - `per_goal[]`로 각 목표 예측치·달성 여부 반환
  - 모든 목표 달성 시 `meets_target=true`
- `/api/prescribe`는 신(`goal_targets`)·구(`goal+target`) 모두 수용
- 추천 카드에 목적별 칩 + 예상/목표/달성 마크 표시

## 검증

- [x] `tsc --noEmit` 통과
- [x] `eslint` 통과
- [x] `next build` 통과
- [x] Supabase 마이그레이션 적용 + 기본 6개 목적 적재 확인
- [ ] 프로덕션 UI 수동 확인

https://claude.ai/code/session_01LrmgvVDVpa2YxPf5mQVHSv