### PR TITLE
폰트(ASTA Sans/Pretendard) · 모바일 레이아웃 · 동심원 차트 · 시즌성 자동 추정

### DIFF
--- a/promo-analytics/app/(dash)/DashCharts.tsx
+++ b/promo-analytics/app/(dash)/DashCharts.tsx
@@ -74,25 +74,34 @@ export function Concentric({
   const baseShade = (i: number) => shades[Math.min(i, shades.length - 1)];
 
   return (
-    <div className="relative mx-auto h-[230px] w-full max-w-[300px]">
-      {items.map((d, i) => {
-        const dia = 110 + 150 * Math.sqrt(d.value / max);
-        const shade = baseShade(items.length - 1 - i); // 바깥=연하게, 안=진하게
-        return (
-          <div
-            key={d.label}
-            className="absolute bottom-0 left-1/2 flex -translate-x-1/2 justify-center rounded-full"
-            style={{ width: dia, height: dia, background: shade, zIndex: i }}
-          >
+    <div className="flex flex-col items-center gap-3 sm:flex-row sm:items-end sm:gap-5">
+      <div className="relative h-[220px] w-[220px] shrink-0">
+        {items.map((d, i) => {
+          const dia = 110 + 110 * Math.sqrt(d.value / max);
+          const shade = baseShade(items.length - 1 - i); // 바깥=연하게, 안=진하게
+          return (
+            <div
+              key={d.label}
+              className="absolute bottom-0 left-1/2 -translate-x-1/2 rounded-full"
+              style={{ width: dia, height: dia, background: shade, zIndex: i }}
+            />
+          );
+        })}
+      </div>
+      <ul className="flex w-full flex-col gap-1.5 text-xs sm:max-w-[180px]">
+        {items.map((d, i) => (
+          <li key={d.label} className="flex items-center gap-2">
             <span
-              className="mt-2 text-xs font-semibold"
-              style={{ color: i >= items.length - 1 ? "#fff" : "#7a3b22" }}
-            >
-              {d.label} · {wonShort(d.value)}
+              className="h-2.5 w-2.5 shrink-0 rounded-full"
+              style={{ background: baseShade(items.length - 1 - i) }}
+            />
+            <span className="min-w-0 flex-1 truncate text-neutral-700">{d.label}</span>
+            <span className="shrink-0 font-semibold tabular-nums text-neutral-900">
+              {wonShort(d.value)}
             </span>
-          </div>
-        );
-      })}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/promo-analytics/app/(dash)/library/LibraryTable.tsx
+++ b/promo-analytics/app/(dash)/library/LibraryTable.tsx
@@ -88,7 +88,59 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
         </div>
       </div>
 
-      <div className="overflow-x-auto rounded-[24px] bg-white card-soft">
+      {/* 모바일: 카드 리스트 */}
+      <ul className="space-y-2 md:hidden">
+        {rows.map((r) => (
+          <li key={r.id} className="rounded-[20px] bg-white p-4 card-soft">
+            <div className="flex items-start gap-3">
+              <span
+                className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-bold ${
+                  r.score >= 70
+                    ? "bg-brand-500 text-white"
+                    : r.score >= 40
+                      ? "bg-brand-50 text-brand-600"
+                      : "bg-neutral-100 text-neutral-400"
+                }`}
+              >
+                {r.score}
+              </span>
+              <div className="min-w-0 flex-1">
+                <Link
+                  href={`/promotions/${r.id}`}
+                  className="block truncate text-[15px] font-semibold text-neutral-900 hover:text-brand-600"
+                >
+                  {r.name}
+                </Link>
+                <div className="mt-0.5 text-xs text-neutral-400">
+                  {r.start_date} ~ {r.end_date}
+                </div>
+                {(r.promo_type || r.season_tag) && (
+                  <div className="mt-1.5 flex flex-wrap gap-1">
+                    {r.promo_type && <Tag>{r.promo_type}</Tag>}
+                    {r.season_tag && <Tag>{r.season_tag}</Tag>}
+                  </div>
+                )}
+              </div>
+            </div>
+            <dl className="mt-3 grid grid-cols-3 gap-2 text-xs">
+              <Stat label="총 기여" value={wonShort(r.total_uplift)} bold />
+              <Stat label="간접비중" value={pct(r.halo_share)} />
+              <Stat label="공헌이익" value={wonShort(r.contribution)} />
+              <Stat label="일평균 기여" value={wonShort(r.uplift_per_day)} />
+              <Stat label="할인" value={r.discount_rate != null ? pct(r.discount_rate, 0) : "—"} />
+              {r.purpose && <Stat label="목적" value={r.purpose} truncate />}
+            </dl>
+          </li>
+        ))}
+        {rows.length === 0 && (
+          <li className="rounded-[20px] bg-white px-4 py-10 text-center text-sm text-neutral-400 card-soft">
+            조건에 맞는 캠페인이 없습니다.
+          </li>
+        )}
+      </ul>
+
+      {/* 데스크톱: 테이블 */}
+      <div className="hidden overflow-x-auto rounded-[24px] bg-white card-soft md:block">
         <table className="w-full min-w-[760px] text-sm">
           <thead className="bg-neutral-50 text-left text-xs text-neutral-500">
             <tr>
@@ -127,9 +179,9 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
                 <td className="px-4 py-3 text-right text-neutral-600">
                   {r.discount_rate != null ? pct(r.discount_rate, 0) : "—"}
                 </td>
-                <td className="px-4 py-3 text-right font-semibold">{wonShort(r.total_uplift)}</td>
-                <td className="px-4 py-3 text-right text-neutral-600">{pct(r.halo_share)}</td>
-                <td className="px-4 py-3 text-right text-neutral-600">{wonShort(r.contribution)}</td>
+                <td className="px-4 py-3 text-right font-semibold tabular-nums">{wonShort(r.total_uplift)}</td>
+                <td className="px-4 py-3 text-right tabular-nums text-neutral-600">{pct(r.halo_share)}</td>
+                <td className="px-4 py-3 text-right tabular-nums text-neutral-600">{wonShort(r.contribution)}</td>
               </tr>
             ))}
             {rows.length === 0 && (
@@ -145,6 +197,31 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
       <p className="mt-2 px-1 text-xs text-neutral-400">
         종합점수 = 공헌이익 40% · 일평균 기여 30% · 효율(기여/할인깊이) 20% · 간접비중 10% (전체 대비 상대 점수)
       </p>
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  bold,
+  truncate,
+}: {
+  label: string;
+  value: string;
+  bold?: boolean;
+  truncate?: boolean;
+}) {
+  return (
+    <div className="rounded-lg bg-neutral-50 px-2 py-1.5">
+      <dt className="text-[10px] text-neutral-400">{label}</dt>
+      <dd
+        className={`mt-0.5 tabular-nums ${bold ? "font-semibold text-neutral-900" : "text-neutral-700"} ${
+          truncate ? "truncate" : ""
+        }`}
+      >
+        {value}
+      </dd>
     </div>
   );
 }

--- a/promo-analytics/app/(dash)/page.tsx
+++ b/promo-analytics/app/(dash)/page.tsx
@@ -141,7 +141,12 @@ export default async function Dashboard() {
 
       {/* KPI Bento */}
       <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4">
-        <Kpi label="캠페인 기여 총 매출" value={won(totalUplift)} brand />
+        <Kpi
+          label="캠페인 기여 총 매출"
+          value={wonShort(totalUplift)}
+          full={won(totalUplift)}
+          brand
+        />
         <Kpi label="평균 직접 매출" value={wonShort(avgDirect)} sub={`캠페인 ${n}건 평균`} />
         <Kpi label="평균 간접 매출" value={wonShort(avgHalo)} sub={`캠페인 ${n}건 평균`} />
         <Kpi label="평균 운영 기간" value={`${avgDuration.toFixed(1)}일`} sub={`캠페인 ${n}건 평균`} />
@@ -250,15 +255,30 @@ function sum(a: number[]) {
   return a.reduce((x, y) => x + y, 0);
 }
 
-function Kpi({ label, value, sub, brand }: { label: string; value: string; sub?: string; brand?: boolean }) {
+function Kpi({
+  label,
+  value,
+  sub,
+  full,
+  brand,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  full?: string; // 데스크톱에서 풀 표기 (예: ₩3,409,316,915)
+  brand?: boolean;
+}) {
   return (
     <div
-      className={`rounded-[24px] p-5 ${
+      className={`rounded-[24px] p-4 sm:p-5 ${
         brand ? "bg-brand-500 text-white" : "bg-white card-soft"
       }`}
     >
       <div className={`text-xs ${brand ? "text-brand-100" : "text-neutral-400"}`}>{label}</div>
-      <div className="mt-2 text-xl font-bold tracking-tight tabular-nums sm:text-2xl">{value}</div>
+      <div className="mt-2 break-words text-lg font-bold tracking-tight tabular-nums sm:text-2xl">
+        <span className={full ? "sm:hidden" : ""}>{value}</span>
+        {full && <span className="hidden sm:inline">{full}</span>}
+      </div>
       {sub && <div className={`mt-0.5 text-[11px] ${brand ? "text-brand-100" : "text-neutral-400"}`}>{sub}</div>}
     </div>
   );

--- a/promo-analytics/app/(dash)/promotions/[id]/edit/EditForm.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/edit/EditForm.tsx
@@ -152,6 +152,17 @@ export default function EditForm({
 
         <Field label="시즈널리티">
           <SingleChips options={options.seasonalities} value={seasonTag} onChange={setSeasonTag} />
+          <button
+            type="button"
+            onClick={async () => {
+              const { inferSeasonality } = await import("@/lib/season");
+              const inferred = inferSeasonality(name, startDate, options.seasonalities);
+              setSeasonTag(inferred ?? "");
+            }}
+            className="mt-2 rounded-full border border-neutral-200 px-2.5 py-1 text-[11px] text-neutral-600 hover:bg-neutral-50"
+          >
+            이름·기간으로 자동 추정
+          </button>
         </Field>
 
         <div className="grid grid-cols-3 gap-4">

--- a/promo-analytics/app/(dash)/upload/page.tsx
+++ b/promo-analytics/app/(dash)/upload/page.tsx
@@ -152,6 +152,15 @@ function UploadCard({ def }: { def: CardDef }) {
       const code = parse.extractPromoCode(rawName);
       const name = code ? rawName.slice(rawName.indexOf(code)) : rawName;
 
+      // 시즌 마스터 + 이름·기간으로 시즌성 자동 추정
+      const { inferSeasonality } = await import("@/lib/season");
+      const { data: seasonRows } = await supabase
+        .from("seasonalities")
+        .select("name")
+        .order("sort");
+      const seasonNames = (seasonRows ?? []).map((r) => r.name as string);
+      const season_tag = inferSeasonality(name, parsed.start_date, seasonNames);
+
       setP({ phase: "uploading", message: "캠페인 생성 중…" });
       const { data: promo, error: pErr } = await supabase
         .from("promotions")
@@ -160,6 +169,7 @@ function UploadCard({ def }: { def: CardDef }) {
           code,
           start_date: parsed.start_date,
           end_date: parsed.end_date,
+          season_tag,
         })
         .select("id")
         .single();

--- a/promo-analytics/app/globals.css
+++ b/promo-analytics/app/globals.css
@@ -1,4 +1,44 @@
 @import "tailwindcss";
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css");
+
+/* ASTA Sans (라이선스 폰트) — 폰트 파일을 public/fonts/asta-sans/에 두면 자동 적용.
+   파일이 없으면 폴백(Pretendard → 시스템)으로 안전하게 표시됨. */
+@font-face {
+  font-family: "ASTA Sans";
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+  src:
+    url("/fonts/asta-sans/ASTASans-Regular.woff2") format("woff2"),
+    url("/fonts/asta-sans/ASTASans-Regular.woff")  format("woff");
+}
+@font-face {
+  font-family: "ASTA Sans";
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+  src:
+    url("/fonts/asta-sans/ASTASans-Medium.woff2") format("woff2"),
+    url("/fonts/asta-sans/ASTASans-Medium.woff")  format("woff");
+}
+@font-face {
+  font-family: "ASTA Sans";
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
+  src:
+    url("/fonts/asta-sans/ASTASans-SemiBold.woff2") format("woff2"),
+    url("/fonts/asta-sans/ASTASans-SemiBold.woff")  format("woff");
+}
+@font-face {
+  font-family: "ASTA Sans";
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+  src:
+    url("/fonts/asta-sans/ASTASans-Bold.woff2") format("woff2"),
+    url("/fonts/asta-sans/ASTASans-Bold.woff")  format("woff");
+}
 
 @theme {
   /* 키컬러: 차분한 테라코타 코랄 (쨍하지 않게) */
@@ -16,12 +56,14 @@
   --color-ink: #211f1d;
 
   --font-sans:
-    ui-sans-serif, system-ui, "Apple SD Gothic Neo", "Malgun Gothic",
-    "Pretendard", sans-serif;
+    "ASTA Sans", "Pretendard Variable", "Pretendard",
+    -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Malgun Gothic",
+    ui-sans-serif, system-ui, sans-serif;
 }
 
 html {
   font-family: var(--font-sans);
+  -webkit-text-size-adjust: 100%;
 }
 
 body {

--- a/promo-analytics/lib/season.ts
+++ b/promo-analytics/lib/season.ts
@@ -1,0 +1,94 @@
+// 캠페인 시즌성 자동 추정
+// 우선순위: 이름 키워드 > 시작일이 속한 시즌 윈도
+
+const NAME_KEYWORDS: { season: string; aliases: string[] }[] = [
+  { season: "한국 고양이의 날", aliases: ["한국고양이", "한국 고양이", "한고날"] },
+  { season: "세계 고양이의 날",  aliases: ["세계고양이", "세계 고양이", "세고날"] },
+  { season: "한가위 고양이",     aliases: ["한가위", "추석", "한고잔치"] },
+  { season: "크리스마스",        aliases: ["크리스마스", "christmas", "xmas", "x-mas"] },
+  { season: "블랙프라이데이",    aliases: ["블랙프라이데이", "blackfriday", "black friday", "bfcm", "11.11", "1111", "11월11일"] },
+  { season: "설 연휴",           aliases: ["설날", "설 연휴", "설연휴", "구정", "신정"] },
+  { season: "N주년",             aliases: ["주년", "anniversary", "anniv"] },
+  { season: "신학기",            aliases: ["신학기", "개강", "입학"] },
+  { season: "여름",              aliases: ["여름", "summer", "휴가", "바캉스"] },
+  { season: "겨울",              aliases: ["겨울", "winter", "연말"] },
+];
+
+// 시작일 기준 시즌 윈도 (월-일 → 시즌)
+// 음력 시즌(추석·설)은 매년 다르지만 근사 윈도로 잡음
+type Window = { season: string; from: [number, number]; to: [number, number] };
+const DATE_WINDOWS: Window[] = [
+  { season: "설 연휴",           from: [1, 25],  to: [2, 15] },
+  { season: "신학기",            from: [2, 25],  to: [3, 15] },
+  { season: "여름",              from: [6, 15],  to: [8, 31] },
+  { season: "한국 고양이의 날",  from: [9, 7],   to: [9, 12] }, // 9/9
+  { season: "한가위 고양이",     from: [9, 15],  to: [10, 10] },
+  { season: "블랙프라이데이",    from: [11, 20], to: [11, 30] },
+  { season: "크리스마스",        from: [12, 18], to: [12, 28] },
+  { season: "겨울",              from: [12, 1],  to: [1, 31] },
+  { season: "세계 고양이의 날",  from: [8, 5],   to: [8, 10] }, // 8/8
+];
+
+function normalize(s: string): string {
+  return s.toLowerCase().replace(/[\s_\-·]+/g, "");
+}
+
+function inWindow(month: number, day: number, w: Window): boolean {
+  const md = month * 100 + day;
+  const from = w.from[0] * 100 + w.from[1];
+  const to = w.to[0] * 100 + w.to[1];
+  // 연도 경계(예: 겨울 12/1 ~ 1/31) 처리
+  return from <= to ? md >= from && md <= to : md >= from || md <= to;
+}
+
+/**
+ * 이름과 시작일로 시즌성 추정.
+ * - 이름에 키워드가 있으면 1순위
+ * - 날짜 윈도에 들어가면 2순위
+ * - available이 주어지면 그 안에서만 선택 (정확히 일치하지 않으면 무시)
+ */
+export function inferSeasonality(
+  name: string,
+  startDate?: string | null,
+  available?: string[],
+): string | null {
+  const n = normalize(name);
+
+  // 1) 이름 키워드
+  for (const k of NAME_KEYWORDS) {
+    if (k.aliases.some((a) => n.includes(normalize(a)))) {
+      const picked = pickAvailable(k.season, available);
+      if (picked) return picked;
+    }
+  }
+
+  // 2) 시작일 윈도
+  if (startDate) {
+    const m = startDate.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (m) {
+      const month = Number(m[2]);
+      const day = Number(m[3]);
+      for (const w of DATE_WINDOWS) {
+        if (inWindow(month, day, w)) {
+          const picked = pickAvailable(w.season, available);
+          if (picked) return picked;
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+// available 마스터에서 정확 매칭 또는 부분 매칭(어느 한쪽이 포함)
+function pickAvailable(season: string, available?: string[]): string | null {
+  if (!available || available.length === 0) return season;
+  const exact = available.find((x) => x === season);
+  if (exact) return exact;
+  const partial = available.find(
+    (x) =>
+      normalize(x).includes(normalize(season)) ||
+      normalize(season).includes(normalize(x)),
+  );
+  return partial ?? null;
+}

--- a/promo-analytics/lib/season.ts
+++ b/promo-analytics/lib/season.ts
@@ -15,9 +15,10 @@ const NAME_KEYWORDS: { season: string; aliases: string[] }[] = [
 ];
 
 // 시작일 기준 시즌 윈도 (월-일 → 시즌)
-// 음력 시즌(추석·설)은 매년 다르지만 근사 윈도로 잡음
+// 음력 시즌(추석·설)은 매년 다르지만 근사 윈도로 잡음.
+// 좁은 윈도가 넓은 윈도보다 우선하도록 windowLen 오름차순으로 자동 정렬.
 type Window = { season: string; from: [number, number]; to: [number, number] };
-const DATE_WINDOWS: Window[] = [
+const DATE_WINDOWS_RAW: Window[] = [
   { season: "설 연휴",           from: [1, 25],  to: [2, 15] },
   { season: "신학기",            from: [2, 25],  to: [3, 15] },
   { season: "여름",              from: [6, 15],  to: [8, 31] },
@@ -28,6 +29,23 @@ const DATE_WINDOWS: Window[] = [
   { season: "겨울",              from: [12, 1],  to: [1, 31] },
   { season: "세계 고양이의 날",  from: [8, 5],   to: [8, 10] }, // 8/8
 ];
+
+function windowLen(w: Window): number {
+  const from = w.from[0] * 100 + w.from[1];
+  const to = w.to[0] * 100 + w.to[1];
+  // 연도 경계(겨울 12/1 ~ 1/31)는 환산이 부정확하지만 좁은 윈도(holiday) 우선이 보장되면 충분.
+  return from <= to ? to - from : 12_31 - from + to;
+}
+const DATE_WINDOWS: Window[] = [...DATE_WINDOWS_RAW].sort(
+  (a, b) => windowLen(a) - windowLen(b),
+);
+
+// 마스터에 특정 시즌이 없을 때 폴백할 대안 시즌(완화 매칭용).
+// 기본 시드에 '명절'만 있고 '한가위 고양이'·'설 연휴'는 없을 수 있어 대응.
+const FALLBACK_ALIASES: Record<string, string[]> = {
+  "한가위 고양이": ["명절"],
+  "설 연휴":      ["명절"],
+};
 
 function normalize(s: string): string {
   return s.toLowerCase().replace(/[\s_\-·]+/g, "");
@@ -80,7 +98,7 @@ export function inferSeasonality(
   return null;
 }
 
-// available 마스터에서 정확 매칭 또는 부분 매칭(어느 한쪽이 포함)
+// available 마스터에서 정확 매칭 → 부분 매칭 → 폴백 별칭 순으로 시도.
 function pickAvailable(season: string, available?: string[]): string | null {
   if (!available || available.length === 0) return season;
   const exact = available.find((x) => x === season);
@@ -90,5 +108,10 @@ function pickAvailable(season: string, available?: string[]): string | null {
       normalize(x).includes(normalize(season)) ||
       normalize(season).includes(normalize(x)),
   );
-  return partial ?? null;
+  if (partial) return partial;
+  for (const alt of FALLBACK_ALIASES[season] ?? []) {
+    const altMatch = available.find((x) => x === alt);
+    if (altMatch) return altMatch;
+  }
+  return null;
 }

--- a/promo-analytics/public/fonts/asta-sans/README.md
+++ b/promo-analytics/public/fonts/asta-sans/README.md
@@ -1,0 +1,12 @@
+# ASTA Sans 폰트 파일 위치
+
+ASTA Sans는 라이선스 폰트라 저장소에 직접 커밋하지 않습니다.
+다음 파일을 이 폴더에 두면 자동으로 적용됩니다(없으면 Pretendard 폴백):
+
+- `ASTASans-Regular.woff2` / `.woff`
+- `ASTASans-Medium.woff2`  / `.woff`
+- `ASTASans-SemiBold.woff2`/ `.woff`
+- `ASTASans-Bold.woff2`    / `.woff`
+
+폰트 라이선스는 산돌(또는 라이선스 발급처) 약관을 따릅니다.
+사내 사용 범위·도메인이 약관에 포함되는지 확인 후 배포 도메인에 사용하세요.


### PR DESCRIPTION
## 사용자 피드백 4건 반영

### 1) 폰트 — ASTA Sans 우선 + Pretendard 폴백
- `app/globals.css`에 ASTA Sans `@font-face` 4종(Regular/Medium/SemiBold/Bold) 선언. `public/fonts/asta-sans/`에 라이선스 폰트 파일을 두면 자동 적용. 파일 없으면 폴백
- 폴백 1순위: **Pretendard Variable** (jsdelivr CDN, dynamic-subset로 한국어 영역만 로드 → 가벼움)
- 폴백 체인: ASTA Sans → Pretendard → Apple SD Gothic Neo → Malgun Gothic → 시스템
- `public/fonts/asta-sans/README.md`에 라이선스/파일 배치 안내

> ASTA Sans는 라이선스 폰트라 저장소에 직접 커밋하지 않음. 사내가 라이선스 보유 중이면 `.woff2`/`.woff` 4벌을 폴더에 넣어 자동 활성화.

### 2) 모바일 레이아웃
- **대시보드 KPI**: ₩3,409,316,915처럼 길어지면 모바일 화면 밖으로 튀어나가던 문제 → 모바일은 `wonShort`(₩34억), 데스크톱은 풀 표기 자동 분기. 폰트도 모바일 `text-lg` + `break-words`
- **히스토리(LibraryTable)**: 모바일은 카드 리스트(`md:hidden`), 데스크톱은 기존 테이블(`hidden md:block`). 카드는 점수 칩 + 캠페인명 + 3×n stat 그리드로 핵심 지표를 한 화면에 담음

### 3) 동심원 차트 — 텍스트 겹침 해결
원 내부에 라벨을 얹어 작은 원이 큰 원에 가려지던 문제. 라벨을 차트 밖 우측(모바일에선 아래) 범례 리스트로 분리. 색 점 + 라벨 + 금액.

### 4) 시즌성 자동 추정 — `lib/season.ts`
캠페인 이름 키워드 1순위 + 시작일 윈도 2순위로 추정. 마스터 매칭 안 되면 `null`(수동 유지).

지원하는 시즌: 한가위 고양이 / N주년 / 크리스마스 / 블랙프라이데이 / 11.11 / 한국 고양이의 날(9.9) / 세계 고양이의 날(8.8) / 설 연휴 / 여름 / 겨울 / 신학기.

**적용 위치**:
- 업로드 시 자동 채움(클라이언트에서 `seasonalities` 마스터 조회 → 추정)
- 편집 화면 시즈널리티 옆 **"이름·기간으로 자동 추정"** 버튼

**단위 테스트 9/9 통과**:
```
✓ 한가위 고양이 대잔치       (2025-09-22) → 한가위 고양이
✓ CF_P_251104_꽃같은3주년 (2025-11-04) → N주년
✓ 크리스마스 특가            (2025-12-22) → 크리스마스
✓ 블프 11.11 빅세일         (2025-11-26) → 블랙프라이데이
✓ 여름 휴가 세일            (2025-07-15) → 여름
✓ 한국 고양이의 날 캠페인    (2025-09-09) → 한국 고양이의 날
✓ 세계 고양이의 날 이벤트    (2025-08-08) → 세계 고양이의 날
✓ 설 연휴 모음전            (2026-01-29) → 설 연휴
✓ 그냥 평범 캠페인           (2025-04-15) → null
```

## 검증
- [x] tsc / eslint / next build 통과
- [x] season 단위 테스트 9/9

## 안내
- **캠페인 삭제 버튼이 안 보였던 건**: 이전 PR(#23)에서 이미 머지·배포 완료. 브라우저 캐시 문제일 가능성 큼 → `Cmd+Shift+R` 강력 새로고침 후 편집 화면 우측 하단 빨간 "캠페인 삭제" 버튼 확인.

https://claude.ai/code/session_01LrmgvVDVpa2YxPf5mQVHSv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LrmgvVDVpa2YxPf5mQVHSv)_