### PR TITLE
대시보드 상시/행사 일평균 부풀림 수정 (전 매장 일자 단위 집계)

### DIFF
--- a/promo-analytics/app/(dash)/page.tsx
+++ b/promo-analytics/app/(dash)/page.tsx
@@ -13,12 +13,24 @@ type Row = Promotion & {
   promo_days: number;
 };
 
+type OverallMetrics = {
+  data_start: string;
+  data_end: string;
+  non_promo_days: number;
+  promo_days: number;
+  baseline_daily: number;
+  promo_daily: number;
+  lift_ratio: number | null;
+};
+
 export default async function Dashboard() {
   const supabase = await createClient();
-  const { data: promos } = await supabase
-    .from("promotions")
-    .select("*")
-    .order("start_date", { ascending: false });
+  const [{ data: promos }, { data: overallData }] = await Promise.all([
+    supabase.from("promotions").select("*").order("start_date", { ascending: false }),
+    supabase.rpc("overall_baseline_metrics"),
+  ]);
+
+  const overall = (overallData?.[0] as OverallMetrics | undefined) ?? null;
 
   const rows: Row[] = await Promise.all(
     (promos ?? []).map(async (p: Promotion) => {
@@ -52,11 +64,10 @@ export default async function Dashboard() {
   const avgDuration = n ? sum(rows.map((r) => r.promo_days)) / n : 0;
   const haloShare = totalUplift !== 0 ? totalHalo / totalUplift : null;
 
-  // 상시 일평균 vs 행사 일평균
-  const totalBaselineDaily = sum(rows.map((r) => r.baseline_daily));
-  const totalPromoDaily = sum(rows.map((r) => r.promo_daily));
-  const liftRatio =
-    totalBaselineDaily > 0 ? totalPromoDaily / totalBaselineDaily : null;
+  // 상시 일평균 vs 행사 일평균 — 데이터 기간 전체에서 일자 단위로 산출 (product 중복 합산 X)
+  const totalBaselineDaily = overall?.baseline_daily ?? 0;
+  const totalPromoDaily = overall?.promo_daily ?? 0;
+  const liftRatio = overall?.lift_ratio ?? null;
   const compData = [...rows]
     .sort((a, b) => b.promo_daily - a.promo_daily)
     .slice(0, 5)
@@ -155,15 +166,16 @@ export default async function Dashboard() {
       {/* 상시 vs 행사 비교 (비교 기준) */}
       <div className="mt-3 grid gap-3 sm:mt-4 sm:gap-4 lg:grid-cols-3">
         <Card className="lg:col-span-2">
-          <CardTitle>상시 대비 행사 일매출</CardTitle>
+          <CardTitle>상시 대비 행사 일매출 (캠페인별)</CardTitle>
           <p className="-mt-2 mb-3 text-xs text-neutral-400">
             <span className="font-medium text-neutral-500">상시 일평균</span> = 캠페인 직전 8주의
             비캠페인 일평균 매출 · <span className="font-medium text-brand-600">행사 일평균</span> = 캠페인 기간 매출 ÷ 운영일수
+            <span className="block">※ 그 캠페인에 등장한 상품들만 합산한 값 (전 매장 합계 아님)</span>
           </p>
           <BaselineVsPromo data={compData} />
         </Card>
         <div className="flex flex-col justify-center rounded-[28px] bg-neutral-900 p-5 text-white card-soft">
-          <div className="text-xs text-neutral-400">평소 대비 행사 매출</div>
+          <div className="text-xs text-neutral-400">평소 대비 행사 매출 (전 매장)</div>
           <div className="mt-1 text-4xl font-bold text-brand-400">
             {liftRatio != null ? `${liftRatio.toFixed(1)}배` : "—"}
           </div>
@@ -177,6 +189,11 @@ export default async function Dashboard() {
               <span className="font-semibold tabular-nums text-brand-400">{wonShort(totalPromoDaily)}</span>
             </div>
           </div>
+          {overall && (
+            <div className="mt-3 text-[10px] text-neutral-500">
+              {overall.data_start} ~ {overall.data_end} · 비캠페인 {overall.non_promo_days}일 · 캠페인 {overall.promo_days}일
+            </div>
+          )}
         </div>
       </div>
 

--- a/promo-analytics/supabase/migrations/0005_overall_metrics.sql
+++ b/promo-analytics/supabase/migrations/0005_overall_metrics.sql
@@ -1,0 +1,66 @@
+-- 전체 데이터 기간의 정확한 상시/행사 일평균을 일자 단위로 계산.
+-- 대시보드 하단 비교 카드가 product별 baseline_daily 합산을 22개 캠페인에 걸쳐
+-- 다시 합산해 product 중복 부풀림이 발생하던 문제 해결용.
+
+create or replace function promo.overall_baseline_metrics()
+returns table (
+  data_start         date,
+  data_end           date,
+  non_promo_days     int,
+  promo_days         int,
+  baseline_daily     numeric, -- 비프로모션 일자 평균 매출 (전 매장)
+  promo_daily        numeric, -- 캠페인 기간 일자 평균 매출 (전 매장)
+  lift_ratio         numeric  -- promo_daily / baseline_daily
+)
+language sql
+stable
+set search_path = ''
+as $$
+  with bounds as (
+    select min(sale_date) as min_d, max(sale_date) as max_d
+    from promo.daily_sales
+  ),
+  promo_days_all as (
+    select distinct g.d::date as d
+    from promo.promotions p,
+         lateral generate_series(p.start_date, p.end_date, interval '1 day') g(d)
+  ),
+  range_days as (
+    select g.d::date as d
+    from bounds, lateral generate_series(bounds.min_d, bounds.max_d, interval '1 day') g(d)
+  ),
+  non_promo as (
+    select rd.d from range_days rd
+    where rd.d not in (select d from promo_days_all)
+  ),
+  in_range_promo as (
+    select pd.d from promo_days_all pd, bounds
+    where pd.d between bounds.min_d and bounds.max_d
+  ),
+  np_daily as (
+    select ds.sale_date, sum(ds.revenue) as rev
+    from promo.daily_sales ds
+    join non_promo n on n.d = ds.sale_date
+    group by ds.sale_date
+  ),
+  p_daily as (
+    select ds.sale_date, sum(ds.revenue) as rev
+    from promo.daily_sales ds
+    join in_range_promo p on p.d = ds.sale_date
+    group by ds.sale_date
+  )
+  select
+    (select min_d from bounds) as data_start,
+    (select max_d from bounds) as data_end,
+    (select count(*)::int from non_promo)        as non_promo_days,
+    (select count(*)::int from in_range_promo)   as promo_days,
+    coalesce((select avg(rev) from np_daily), 0) as baseline_daily,
+    coalesce((select avg(rev) from p_daily),  0) as promo_daily,
+    case
+      when coalesce((select avg(rev) from np_daily), 0) > 0
+        then (select avg(rev) from p_daily) / (select avg(rev) from np_daily)
+      else null
+    end as lift_ratio;
+$$;
+
+grant execute on function promo.overall_baseline_metrics() to authenticated;


### PR DESCRIPTION
## 사용자 보고
> "행사 대비 상시 일평균 매출액이 너무 낮게 나오고 그 아래 상시 일평균 매출은 너무 높게 잡혀. 데이터에 문제가 있는지 확인해. 중복 데이터가 있을 수도 있어."

## 데이터 진단
**daily_sales 중복 없음**: 73,061행 = 73,061개 고유 키. 데이터 자체는 깨끗.

## 원인
`(dash)/page.tsx`의 합산 로직:
```ts
totalBaselineDaily = sum(rows.map(r => r.baseline_daily));
```
캠페인별 `baseline_daily`는 그 캠페인에 등장한 product들의 baseline 일평균 합. **동일 product가 여러 캠페인에 걸쳐있으면**, 22개 캠페인에 대해 합산 시 같은 product의 baseline이 중복으로 더해짐. `promo_daily`도 같은 패턴이라 양쪽 모두 부풀려지고 비율(8.6배)도 왜곡.

## 실측 (2024-06-04 ~ 2026-06-03, 730일)

| 지표 | 실제 | 화면 표시 | 부풀림 |
|---|---:|---:|---|
| 상시 일평균 (비캠페인 617일 평균) | **₩12,582,977** | ₩1.1억 | ×8.7 |
| 행사 일평균 (캠페인 113일 평균) | **₩35,398,952** | ₩9.3억 | ×26 |
| 평소 대비 비율 | **2.8배** | 8.6배 | — |

## 변경

### `supabase/migrations/0005_overall_metrics.sql`
`promo.overall_baseline_metrics()` 함수 추가. `daily_sales`를 일자 단위로 집계해 정확한 상시/행사 일평균과 비율 반환. 반환 컬럼:
- `data_start` / `data_end`
- `non_promo_days` / `promo_days`
- `baseline_daily` / `promo_daily`
- `lift_ratio`

### `app/(dash)/page.tsx`
- 하단 검은 카드의 `totalBaselineDaily` / `totalPromoDaily` / `liftRatio`를 RPC 결과로 교체
- 상위 비교 카드(`BaselineVsPromo`) 제목에 "**캠페인별**" 명시
- 안내문에 "그 캠페인에 등장한 상품들만 합산한 값 (전 매장 합계 아님)" 추가
- 하단 카드 라벨에 "**전 매장**" 명시
- 데이터 기간·일수(617/113)도 카드 하단에 노출해 검증 가능

## 검증
- [x] `tsc --noEmit` 통과
- [x] `next build` 통과
- [x] RPC `overall_baseline_metrics()` 정상 반환 확인 (`baseline_daily=12,582,977`, `promo_daily=35,398,952`, `lift_ratio=2.81`)

## 비고
상위 비교 차트의 캠페인별 표시값(예: 모래반짝 상시 334만)은 그 캠페인에 등장한 product만 합산한 정상값이라 그대로 유지. 라벨로 의미만 명확화.

https://claude.ai/code/session_01LrmgvVDVpa2YxPf5mQVHSv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LrmgvVDVpa2YxPf5mQVHSv)_