### PR TITLE
중복 적재 방지: seed 라우트 비활성 + 업로드 중복 경고

### DIFF
--- a/promo-analytics/app/(dash)/seed/page.tsx
+++ b/promo-analytics/app/(dash)/seed/page.tsx
@@ -1,129 +1,27 @@
-"use client";
-
-import { useEffect, useState } from "react";
 import Link from "next/link";
 
-const KEY = "felis-seed-2026";
+export const dynamic = "force-static";
 
-type Meta = { dailyChunks: number; dailyTotal: number; products: number; promotions: number };
+// seed 라우트는 영구 비활성화. 사용자 데이터 정리 작업(2026-06-04) 후
+// 동일 데이터가 다른 source_file로 중복 적재되는 사고를 막기 위함.
+// 초기 데이터는 데이터 업로드 페이지(/upload)에서 원본 파일을 직접 올린다.
 
 export default function SeedPage() {
-  const [meta, setMeta] = useState<Meta | null>(null);
-  const [running, setRunning] = useState(false);
-  const [done, setDone] = useState(false);
-  const [progress, setProgress] = useState(0);
-  const [log, setLog] = useState<string[]>([]);
-  const [error, setError] = useState("");
-
-  useEffect(() => {
-    fetch("/seed/meta.json")
-      .then((r) => r.json())
-      .then(setMeta)
-      .catch(() => setError("seed 데이터를 찾을 수 없습니다."));
-  }, []);
-
-  function append(s: string) {
-    setLog((l) => [...l, s]);
-  }
-
-  async function run() {
-    if (!meta) return;
-    setRunning(true);
-    setError("");
-    setLog([]);
-    setProgress(0);
-    try {
-      append("마스터·캠페인 적재 중…");
-      const m = await fetch(`/api/seed?key=${KEY}&phase=master`, { method: "POST" });
-      const md = await m.json();
-      if (!m.ok) throw new Error(md.error);
-      append(`상품 ${md.products}개 · 캠페인 ${md.promotions}개 완료`);
-
-      let total = 0;
-      for (let i = 0; i < meta.dailyChunks; i++) {
-        const res = await fetch(`/api/seed?key=${KEY}&phase=daily&chunk=${i}`, {
-          method: "POST",
-        });
-        const d = await res.json();
-        if (!res.ok) throw new Error(d.error);
-        total += d.inserted;
-        setProgress(Math.round(((i + 1) / meta.dailyChunks) * 100));
-        append(`일별 매출 ${total.toLocaleString()} / ${meta.dailyTotal.toLocaleString()}행`);
-      }
-      setDone(true);
-      append("✅ 모든 데이터 적재 완료!");
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "실패");
-    } finally {
-      setRunning(false);
-    }
-  }
-
   return (
     <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
-      <h1 className="text-xl font-semibold">초기 데이터 적재</h1>
-      <p className="mt-1 text-sm text-neutral-500">
-        첨부된 마스터·일별 매출·캠페인 시트를 한 번에 적재합니다. (중복 시 덮어쓰기)
-      </p>
-
-      {meta && (
-        <div className="mt-5 grid max-w-md grid-cols-3 gap-3">
-          <Mini label="상품" value={meta.products} />
-          <Mini label="일별 행" value={meta.dailyTotal} />
-          <Mini label="캠페인" value={meta.promotions} />
-        </div>
-      )}
-
-      <div className="mt-6 max-w-md">
-        {!done ? (
-          <button
-            onClick={run}
-            disabled={running || !meta}
-            className="w-full rounded-xl bg-neutral-900 px-4 py-3 text-sm font-medium text-white hover:bg-neutral-700 disabled:opacity-50"
-          >
-            {running ? `적재 중… ${progress}%` : "데이터 적재 시작"}
-          </button>
-        ) : (
-          <Link
-            href="/"
-            className="block w-full rounded-xl bg-neutral-900 px-4 py-3 text-center text-sm font-medium text-white hover:bg-neutral-700"
-          >
-            대시보드로 이동 →
-          </Link>
-        )}
-
-        {running && (
-          <div className="mt-3 h-2 w-full overflow-hidden rounded-full bg-neutral-200">
-            <div
-              className="h-full bg-neutral-900 transition-all"
-              style={{ width: `${progress}%` }}
-            />
-          </div>
-        )}
-
-        {error && (
-          <p className="mt-3 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700">
-            {error} — 다시 시도하면 이어서 진행됩니다.
-          </p>
-        )}
-
-        {log.length > 0 && (
-          <ul className="mt-4 space-y-1 rounded-lg bg-neutral-50 p-3 text-xs text-neutral-500">
-            {log.map((l, i) => (
-              <li key={i}>{l}</li>
-            ))}
-          </ul>
-        )}
+      <h1 className="text-xl font-semibold">초기 데이터 적재 (비활성)</h1>
+      <div className="mt-4 max-w-xl rounded-2xl bg-amber-50 px-4 py-3 text-sm text-amber-800">
+        seed 라우트는 영구 비활성화됐어요. 과거 동일 데이터가 다른 source 이름으로
+        중복 적재돼 매출이 약 2배로 부풀려진 사고가 있었기 때문에, 안전성을 위해
+        seed 경로를 닫았습니다.
       </div>
-    </div>
-  );
-}
-
-function Mini({ label, value }: { label: string; value: number }) {
-  return (
-    <div className="rounded-xl border border-neutral-200 bg-white p-3 text-center">
-      <div className="text-lg font-semibold">{value.toLocaleString()}</div>
-      <div className="text-xs text-neutral-400">{label}</div>
+      <p className="mt-4 max-w-xl text-sm text-neutral-600">
+        초기 데이터는{" "}
+        <Link href="/upload" className="font-medium text-brand-600 underline">
+          데이터 업로드
+        </Link>{" "}
+        페이지에서 원본 엑셀 파일을 직접 올려주세요. (마스터 → 일별 매출 → 캠페인 순)
+      </p>
     </div>
   );
 }

--- a/promo-analytics/app/(dash)/upload/page.tsx
+++ b/promo-analytics/app/(dash)/upload/page.tsx
@@ -84,6 +84,44 @@ function UploadCard({ def }: { def: CardDef }) {
         const rows = parse.parseDailySales(buf);
         if (rows.length === 0) throw new Error("유효한 행이 없습니다.");
 
+        // 다른 source의 동일 기간·동일 상품 데이터 중복 경고
+        const allDates = rows.map((r) => r.sale_date);
+        const minDate = allDates.reduce((a, b) => (a < b ? a : b));
+        const maxDate = allDates.reduce((a, b) => (a > b ? a : b));
+        const baseNamesList = [...new Set(rows.map((r) => r.base_name))];
+        setP({ phase: "uploading", message: "기존 데이터 중복 확인 중…" });
+        const { count: existingCount, error: cntErr } = await supabase
+          .from("daily_sales")
+          .select("*", { count: "exact", head: true })
+          .gte("sale_date", minDate)
+          .lte("sale_date", maxDate)
+          .in("base_name", baseNamesList)
+          .neq("source_file", file.name);
+        if (cntErr) throw cntErr;
+        if (existingCount && existingCount > 0) {
+          const { data: srcSample } = await supabase
+            .from("daily_sales")
+            .select("source_file")
+            .gte("sale_date", minDate)
+            .lte("sale_date", maxDate)
+            .in("base_name", baseNamesList)
+            .neq("source_file", file.name)
+            .limit(200);
+          const srcSet = [
+            ...new Set((srcSample ?? []).map((r) => r.source_file as string)),
+          ];
+          const ok = window.confirm(
+            `같은 기간(${minDate} ~ ${maxDate})에 다른 파일에서 적재된 데이터가 ${existingCount.toLocaleString()}건 있어요.\n` +
+              `기존 source: ${srcSet.join(", ") || "(이름 없음)"}\n\n` +
+              `옵션 표기가 같으면 덮어써지지만, 다르면 별도 행으로 추가돼 매출이 중복 합산될 수 있어요.\n\n` +
+              `그래도 진행할까요?`,
+          );
+          if (!ok) {
+            setP({ phase: "idle", message: "" });
+            return;
+          }
+        }
+
         setP({ phase: "uploading", message: `상품 매칭 중… (${rows.length}행)` });
         const productMap = await products.ensureProducts(
           supabase,

--- a/promo-analytics/app/api/seed/route.ts
+++ b/promo-analytics/app/api/seed/route.ts
@@ -1,157 +1,22 @@
 import { NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
 
 export const runtime = "nodejs";
-export const maxDuration = 60;
 
-const SEED_KEY = "felis-seed-2026";
+// 비활성화: 사용자 데이터 정리 작업(2026-06-04) 후 동일 데이터가 다른 source_file로
+// 중복 적재되는 사고를 막기 위해 seed 라우트를 영구 닫는다.
+// 다시 켜려면 git 히스토리에서 0d8180f 직전 버전을 복원하거나, 별도 보호 단계를 추가하라.
 
-type DailyFile = { cols: string[]; rows: [string, string, string, number, number][] };
-type ProductSeed = {
-  base_name: string;
-  dr_code: string | null;
-  cost: number | null;
-  consumer_price: number | null;
-  regular_price: number | null;
-};
-type PromoSeed = {
-  name: string;
-  code: string | null;
-  start_date: string | null;
-  end_date: string | null;
-  sales: {
-    base_name: string;
-    option_info: string;
-    revenue: number;
-    order_count: number;
-    aov: number;
-    fee: number;
-    cost: number;
-    quantity: number;
-  }[];
+const DISABLED_PAYLOAD = {
+  error:
+    "seed 라우트는 영구 비활성화됐어요. " +
+    "초기 데이터는 데이터 업로드 페이지(/upload)에서 (4).xlsx 같은 원본을 직접 올려주세요. " +
+    "(과거에 seed로 적재된 데이터와 업로드 데이터가 중복으로 합산되던 사고가 있었기 때문)",
 };
 
-function originOf(req: Request): string {
-  const proto = req.headers.get("x-forwarded-proto") ?? "https";
-  const host = req.headers.get("x-forwarded-host") ?? req.headers.get("host");
-  return host ? `${proto}://${host}` : new URL(req.url).origin;
+export function POST() {
+  return NextResponse.json(DISABLED_PAYLOAD, { status: 410 });
 }
 
-async function loadJson<T>(req: Request, path: string): Promise<T> {
-  const res = await fetch(`${originOf(req)}${path}`, { cache: "no-store" });
-  if (!res.ok) throw new Error(`${path} 로드 실패 (${res.status})`);
-  const text = await res.text();
-  try {
-    return JSON.parse(text) as T;
-  } catch {
-    throw new Error(`${path} 응답이 JSON이 아닙니다 (인증/경로 확인)`);
-  }
-}
-
-function chunk<T>(arr: T[], size: number): T[][] {
-  const out: T[][] = [];
-  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
-  return out;
-}
-
-export async function POST(req: Request) {
-  const { searchParams } = new URL(req.url);
-  if (searchParams.get("key") !== SEED_KEY)
-    return NextResponse.json({ error: "잘못된 키" }, { status: 403 });
-
-  const phase = searchParams.get("phase");
-  const supabase = await createClient();
-
-  try {
-    // ── 마스터 + 프로모션 ──
-    if (phase === "master") {
-      const products = await loadJson<ProductSeed[]>(req, "/seed/products.json");
-      for (const b of chunk(products, 500)) {
-        const { error } = await supabase
-          .from("products")
-          .upsert(b, { onConflict: "base_name" });
-        if (error) throw error;
-      }
-
-      const { data: prods } = await supabase.from("products").select("id, base_name");
-      const map = new Map((prods ?? []).map((p) => [p.base_name, p.id]));
-
-      const promos = await loadJson<PromoSeed[]>(req, "/seed/promotions.json");
-      let promoCount = 0;
-      for (const p of promos) {
-        if (!p.start_date || !p.end_date) continue;
-        if (p.code)
-          await supabase.from("promotions").delete().eq("code", p.code);
-        else await supabase.from("promotions").delete().eq("name", p.name);
-
-        const { data: ins, error: pErr } = await supabase
-          .from("promotions")
-          .insert({
-            name: p.name,
-            code: p.code,
-            start_date: p.start_date,
-            end_date: p.end_date,
-          })
-          .select("id")
-          .single();
-        if (pErr) throw pErr;
-
-        const sales = p.sales.map((s) => ({
-          promotion_id: ins.id,
-          product_id: map.get(s.base_name) ?? null,
-          base_name: s.base_name,
-          option_info: s.option_info,
-          revenue: s.revenue,
-          order_count: s.order_count,
-          aov: s.aov,
-          fee: s.fee,
-          cost: s.cost,
-          quantity: s.quantity,
-        }));
-        for (const b of chunk(sales, 500)) {
-          const { error } = await supabase.from("promotion_sales").insert(b);
-          if (error) throw error;
-        }
-        promoCount++;
-      }
-      return NextResponse.json({
-        ok: true,
-        products: products.length,
-        promotions: promoCount,
-      });
-    }
-
-    // ── 일별 매출 (청크 단위) ──
-    if (phase === "daily") {
-      const idx = Number(searchParams.get("chunk") ?? "0");
-      const file = await loadJson<DailyFile>(req, `/seed/daily-${idx}.json`);
-
-      const { data: prods } = await supabase.from("products").select("id, base_name");
-      const map = new Map((prods ?? []).map((p) => [p.base_name, p.id]));
-
-      const records = file.rows.map((r) => ({
-        sale_date: r[0],
-        base_name: r[1],
-        option_info: r[2] ?? "",
-        revenue: r[3],
-        quantity: r[4],
-        product_id: map.get(r[1]) ?? null,
-        source_file: "seed",
-      }));
-      for (const b of chunk(records, 2000)) {
-        const { error } = await supabase
-          .from("daily_sales")
-          .upsert(b, { onConflict: "sale_date,base_name,option_info" });
-        if (error) throw error;
-      }
-      return NextResponse.json({ ok: true, inserted: records.length });
-    }
-
-    return NextResponse.json({ error: "phase 누락" }, { status: 400 });
-  } catch (e) {
-    return NextResponse.json(
-      { error: e instanceof Error ? e.message : "적재 실패" },
-      { status: 500 },
-    );
-  }
+export function GET() {
+  return NextResponse.json(DISABLED_PAYLOAD, { status: 410 });
 }


### PR DESCRIPTION
## 배경
이번 세션에서 `daily_sales`에 `seed`(1년치)와 `(4).xlsx`(2년치) 두 source가 동시 적재돼 1년치 매출이 정확히 2배 부풀린 사고를 확인. 데이터는 정리했고, 같은 사고 재발 방지를 위한 안전장치 두 가지.

## 1) seed 라우트 영구 비활성화
- `/api/seed`: 모든 메서드가 HTTP 410(Gone) + 안내 메시지
- `/seed`: '비활성' 안내 페이지로 교체. `/upload`로 유도
- 다시 켜고 싶으면 git 히스토리에서 복원

## 2) 일별 매출 업로드 시 사전 중복 경고
파일 파싱 후, 같은 기간(min~max `sale_date`) + 같은 `base_name` 집합에 **다른 `source_file`의 기존 행**이 있으면 `confirm()` 띄움:

```
같은 기간(2025-06-03 ~ 2026-06-02)에 다른 파일에서 적재된 데이터가 45,375건 있어요.
기존 source: seed

옵션 표기가 같으면 덮어써지지만, 다르면 별도 행으로 추가돼 매출이 중복 합산될 수 있어요.

그래도 진행할까요?
```

명시적 OK가 있어야 적재 진행.

## 검증
- [x] tsc / eslint / next build 통과
- [x] dev 서버에서 `/api/seed` 호출 → 인증 → 410 응답 확인

https://claude.ai/code/session_01LrmgvVDVpa2YxPf5mQVHSv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LrmgvVDVpa2YxPf5mQVHSv)_