### PR TITLE
S1: 가격 마스터 스키마 + 업로드/파서

### DIFF
--- a/promo-analytics/app/(dash)/upload/page.tsx
+++ b/promo-analytics/app/(dash)/upload/page.tsx
@@ -334,11 +334,22 @@ type PMPreview = {
   mult: number;
 };
 
-function pickDefaultSheet(sheets: string[], includes: string[]): string {
-  const hit = sheets.find((s) =>
-    includes.some((k) => s.replace(/\s+/g, "").includes(k)),
-  );
-  return hit ?? sheets[0] ?? "";
+// 예정값 시트 — 현재 마스터로 적재하면 안 됨 (그린푸드=원가 변경예정, 가격인상=8월초 인상예정)
+const FUTURE_SHEET_MARKERS = ["인상", "인하", "예정", "그린푸드"];
+
+function isFutureSheet(name: string): boolean {
+  const n = name.replace(/\s+/g, "");
+  return FUTURE_SHEET_MARKERS.some((m) => n.includes(m));
+}
+
+/** 예정 시트를 제외하고, prefer 키워드를 순서대로 만족하는 첫 시트를 기본값으로 */
+function pickDefaultSheet(sheets: string[], prefer: string[]): string {
+  const current = sheets.filter((s) => !isFutureSheet(s));
+  for (const k of prefer) {
+    const hit = current.find((s) => s.replace(/\s+/g, "").includes(k));
+    if (hit) return hit;
+  }
+  return current[0] ?? sheets[0] ?? "";
 }
 
 /** 현재 rate card에서 공헌이익 승수 mult = 1 − (수수료+광고+물류+적립) 산출 */
@@ -435,6 +446,17 @@ function PriceMasterCard() {
 
   async function handleLoad() {
     if (!bufRef.current) return;
+    if (isFutureSheet(itemSheet) || isFutureSheet(guideSheet)) {
+      const bad = [itemSheet, guideSheet].filter(isFutureSheet).join(", ");
+      const ok = window.confirm(
+        `선택한 시트(${bad})는 '예정값'(원가 변경·가격 인상 예정)으로 보입니다.\n` +
+          `현재 가격 마스터로 적재하면 안 됩니다. 그래도 진행할까요?`,
+      );
+      if (!ok) {
+        setP({ phase: "idle", message: "취소됨" });
+        return;
+      }
+    }
     try {
       const parse = await import("@/lib/parse");
       const products = await import("@/lib/products");
@@ -675,6 +697,19 @@ function PriceMasterCard() {
         </div>
       )}
 
+      {sheets.some(isFutureSheet) && (
+        <p className="mt-2 text-xs text-amber-600">
+          예정값 시트(적재 금지):{" "}
+          <b>{sheets.filter(isFutureSheet).join(", ")}</b> — 원가 변경·가격 인상 예정분이라
+          현재 가격 마스터로 적재하지 마세요.
+        </p>
+      )}
+      {(isFutureSheet(itemSheet) || isFutureSheet(guideSheet)) && (
+        <p className="mt-1 text-xs font-medium text-red-600">
+          ⚠️ 지금 예정값 시트가 선택돼 있습니다. 현재값 시트(예: 가격가이드_2026)로 바꿔주세요.
+        </p>
+      )}
+
       {sheets.length > 0 && (
         <div className="mt-3 flex gap-2">
           <button
@@ -740,7 +775,14 @@ function PriceMasterCard() {
                   {preview.sample.map((c, i) => (
                     <tr key={i} className="border-t border-neutral-100">
                       <td className="py-1 pr-3">{c.base_name ?? c.dr_code ?? "—"}</td>
-                      <td className="py-1 pr-3">{c.config_type}</td>
+                      <td className="py-1 pr-3">
+                        {c.config_type}
+                        {c.free_shipping && (
+                          <span className="ml-1 rounded bg-sky-100 px-1 text-[10px] text-sky-700">
+                            무배
+                          </span>
+                        )}
+                      </td>
                       <td className="py-1 pr-3 text-right">{won(c.sale_price)}</td>
                       <td className="py-1 pr-3 text-right">{won(c.list_price)}</td>
                       <td className="py-1 pr-3 text-right">

--- a/promo-analytics/app/(dash)/upload/page.tsx
+++ b/promo-analytics/app/(dash)/upload/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
+import { won, pct } from "@/lib/format";
+import type { ParsedPriceConfig } from "@/lib/parse";
 
 type Kind = "master" | "daily" | "promotion";
 
@@ -42,6 +44,7 @@ export default function UploadPage() {
         {CARDS.map((c) => (
           <UploadCard key={c.key} def={c} />
         ))}
+        <PriceMasterCard />
       </div>
     </div>
   );
@@ -253,7 +256,7 @@ function UploadCard({ def }: { def: CardDef }) {
     }
   }
 
-  const pct =
+  const pctVal =
     p.total && p.total > 0 && p.done != null ? Math.round((p.done / p.total) * 100) : null;
 
   return (
@@ -294,11 +297,11 @@ function UploadCard({ def }: { def: CardDef }) {
           }`}
         >
           <div>{p.message}</div>
-          {pct != null && p.phase === "uploading" && (
+          {pctVal != null && p.phase === "uploading" && (
             <div className="mt-1.5 h-1.5 overflow-hidden rounded-full bg-white/60">
               <div
                 className="h-full bg-brand-500 transition-all"
-                style={{ width: `${pct}%` }}
+                style={{ width: `${pctVal}%` }}
               />
             </div>
           )}
@@ -306,4 +309,495 @@ function UploadCard({ def }: { def: CardDef }) {
       )}
     </div>
   );
+}
+
+// ─────────────────────────────────────────────
+// ④ 가격 마스터 (S1) — 워크북 1개에서 품목 + 가격가이드 두 시트를 적재
+// ─────────────────────────────────────────────
+
+type Skip = { reason: string; count: number };
+
+type CostLookup = {
+  cost: number | null;
+  consumer_price: number | null;
+  regular_price: number | null;
+};
+
+type PMPreview = {
+  itemCount: number;
+  configCount: number;
+  matchedConfigCount: number | null; // 적재 시 산출 (미리보기 단계는 null)
+  itemSkipped: Skip[];
+  guideSkipped: Skip[];
+  unmatched: number; // 가격가이드 행 중 품목 매칭 실패
+  sample: ParsedPriceConfig[];
+  mult: number;
+};
+
+function pickDefaultSheet(sheets: string[], includes: string[]): string {
+  const hit = sheets.find((s) =>
+    includes.some((k) => s.replace(/\s+/g, "").includes(k)),
+  );
+  return hit ?? sheets[0] ?? "";
+}
+
+/** 현재 rate card에서 공헌이익 승수 mult = 1 − (수수료+광고+물류+적립) 산출 */
+async function fetchMult(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: any,
+): Promise<number> {
+  const { data } = await supabase
+    .from("rate_card")
+    .select("fee_rate, ad_rate, logistics_rate, reward_rate")
+    .eq("is_current", true)
+    .order("effective_from", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (!data) return 0.715;
+  const sum =
+    Number(data.fee_rate) +
+    Number(data.ad_rate) +
+    Number(data.logistics_rate) +
+    Number(data.reward_rate);
+  return 1 - sum;
+}
+
+function PriceMasterCard() {
+  const bufRef = useRef<ArrayBuffer | null>(null);
+  const [fileName, setFileName] = useState<string>("");
+  const [sheets, setSheets] = useState<string[]>([]);
+  const [itemSheet, setItemSheet] = useState<string>("");
+  const [guideSheet, setGuideSheet] = useState<string>("");
+  const [preview, setPreview] = useState<PMPreview | null>(null);
+  const [p, setP] = useState<Progress>({ phase: "idle", message: "" });
+
+  const busy =
+    p.phase === "reading" || p.phase === "parsing" || p.phase === "uploading";
+
+  async function handleFile(file: File) {
+    try {
+      setPreview(null);
+      setP({ phase: "reading", message: `${file.name} 읽는 중…` });
+      const buf = await file.arrayBuffer();
+      bufRef.current = buf;
+      setFileName(file.name);
+      const parse = await import("@/lib/parse");
+      const names = parse.sheetNames(buf);
+      setSheets(names);
+      setItemSheet(pickDefaultSheet(names, ["품목"]));
+      setGuideSheet(pickDefaultSheet(names, ["가격가이드", "가이드", "가격"]));
+      setP({
+        phase: "idle",
+        message: "",
+      });
+    } catch (e) {
+      setP({ phase: "error", message: errMsg(e) });
+    }
+  }
+
+  async function handlePreview() {
+    if (!bufRef.current) return;
+    try {
+      setP({ phase: "parsing", message: "엑셀 파싱 중 (미리보기)…" });
+      const parse = await import("@/lib/parse");
+      const supabase = createClient();
+      const mult = await fetchMult(supabase);
+      const wb = parse.readWorkbook(bufRef.current);
+      const item = parse.parseItemMaster(wb, itemSheet);
+      const lookup = new Map<string, CostLookup>(
+        item.rows
+          .filter((r) => r.dr_code)
+          .map((r): [string, CostLookup] => [
+            r.dr_code as string,
+            {
+              cost: r.cost,
+              consumer_price: r.consumer_price,
+              regular_price: r.regular_price,
+            },
+          ]),
+      );
+      const guide = parse.parsePriceGuide(wb, guideSheet, { mult, lookup });
+      setPreview({
+        itemCount: item.rows.length,
+        configCount: guide.configs.length,
+        matchedConfigCount: null,
+        itemSkipped: item.skipped,
+        guideSkipped: guide.skipped,
+        unmatched: 0,
+        sample: guide.configs.slice(0, 10),
+        mult,
+      });
+      setP({ phase: "idle", message: "" });
+    } catch (e) {
+      setP({ phase: "error", message: errMsg(e) });
+    }
+  }
+
+  async function handleLoad() {
+    if (!bufRef.current) return;
+    try {
+      const parse = await import("@/lib/parse");
+      const products = await import("@/lib/products");
+      const supabase = createClient();
+      const mult = await fetchMult(supabase);
+      const wb = parse.readWorkbook(bufRef.current);
+
+      setP({ phase: "parsing", message: "엑셀 파싱 중…" });
+      const item = parse.parseItemMaster(wb, itemSheet);
+      const lookup = new Map<string, CostLookup>(
+        item.rows
+          .filter((r) => r.dr_code)
+          .map((r): [string, CostLookup] => [
+            r.dr_code as string,
+            {
+              cost: r.cost,
+              consumer_price: r.consumer_price,
+              regular_price: r.regular_price,
+            },
+          ]),
+      );
+      const guide = parse.parsePriceGuide(wb, guideSheet, { mult, lookup });
+      if (item.rows.length === 0 && guide.configs.length === 0)
+        throw new Error("적재할 품목·구성이 없습니다. 시트 지정을 확인하세요.");
+
+      // 1) 품목 upsert (base_name 고유키 — 기존 인프라 재사용, dr_code/원가/가격은 필드로 갱신)
+      setP({ phase: "uploading", message: `품목 ${item.rows.length}건 반영 중…` });
+      const itemPayload = dedupBy(item.rows, (r) => r.base_name).map((r) => ({
+        base_name: r.base_name,
+        dr_code: r.dr_code,
+        cost: r.cost,
+        cost_vat_excluded: r.cost_vat_excluded,
+        consumer_price: r.consumer_price,
+        regular_price: r.regular_price,
+      }));
+      if (itemPayload.length > 0) {
+        const { error } = await supabase
+          .from("products")
+          .upsert(itemPayload, { onConflict: "base_name" });
+        if (error) throw error;
+      }
+
+      // 2) 전체 products 로드 → dr_code/base_name 으로 product_id 해석 맵
+      const { data: allProducts, error: pErr } = await supabase
+        .from("products")
+        .select("id, base_name, dr_code");
+      if (pErr) throw pErr;
+      const byDr = new Map<string, { id: string; base_name: string }>();
+      const byBase = new Map<string, { id: string; base_name: string }>();
+      for (const pr of allProducts ?? []) {
+        const v = { id: pr.id as string, base_name: pr.base_name as string };
+        if (pr.dr_code) byDr.set(pr.dr_code as string, v);
+        byBase.set(pr.base_name as string, v);
+      }
+
+      // 3) 카테고리 갱신 (가격가이드 시트 → products.category, 기존 품목만)
+      const catByDr = new Map<string, string>();
+      const catByBase = new Map<string, string>();
+      for (const c of guide.categories) {
+        if (c.dr_code) catByDr.set(c.dr_code, c.category);
+        if (c.base_name) catByBase.set(c.base_name, c.category);
+      }
+      const catPayload: { base_name: string; category: string }[] = [];
+      for (const pr of allProducts ?? []) {
+        const cat =
+          (pr.dr_code && catByDr.get(pr.dr_code as string)) ||
+          catByBase.get(pr.base_name as string);
+        if (cat) catPayload.push({ base_name: pr.base_name as string, category: cat });
+      }
+      if (catPayload.length > 0) {
+        const { error } = await supabase
+          .from("products")
+          .upsert(catPayload, { onConflict: "base_name" });
+        if (error) throw error;
+      }
+
+      // 4) configs: product_id 해석 + (product_id, config_type) 중복 제거
+      const recMap = new Map<
+        string,
+        {
+          product_id: string;
+          base_name: string;
+          config_type: string;
+          pack_count: number;
+          free_shipping: boolean;
+          list_price: number | null;
+          sale_price: number;
+          discount_rate_consumer: number | null;
+          discount_rate_regular: number | null;
+          unit_cost_total: number | null;
+          contribution: number | null;
+          contribution_rate: number | null;
+          source_file: string;
+        }
+      >();
+      let unmatched = 0;
+      for (const c of guide.configs) {
+        const match =
+          (c.dr_code && byDr.get(c.dr_code)) ||
+          (c.base_name && byBase.get(c.base_name)) ||
+          null;
+        if (!match) {
+          unmatched++;
+          continue;
+        }
+        const key = `${match.id}::${c.config_type}`;
+        recMap.set(key, {
+          product_id: match.id,
+          base_name: match.base_name,
+          config_type: c.config_type,
+          pack_count: c.pack_count,
+          free_shipping: c.free_shipping,
+          list_price: c.list_price,
+          sale_price: c.sale_price,
+          discount_rate_consumer: c.discount_rate_consumer,
+          discount_rate_regular: c.discount_rate_regular,
+          unit_cost_total: c.unit_cost_total,
+          contribution: c.contribution,
+          contribution_rate: c.contribution_rate,
+          source_file: fileName,
+        });
+      }
+      const records = [...recMap.values()];
+
+      // 5) 다른 source_file 의 기존 구성 존재 시 경고 (PR #27 confirm 패턴)
+      const { count: otherCount } = await supabase
+        .from("product_price_configs")
+        .select("*", { count: "exact", head: true })
+        .neq("source_file", fileName);
+      if (otherCount && otherCount > 0) {
+        const ok = window.confirm(
+          `다른 파일에서 적재된 가격 구성이 ${otherCount.toLocaleString()}건 있어요.\n` +
+            `같은 (품목 × 구성)은 이번 값으로 덮어써집니다.\n\n그래도 진행할까요?`,
+        );
+        if (!ok) {
+          setP({ phase: "idle", message: "취소됨" });
+          return;
+        }
+      }
+
+      // 6) upsert by (product_id, config_type)
+      const batches = products.chunk(records, 500);
+      let done = 0;
+      for (const [i, batch] of batches.entries()) {
+        setP({
+          phase: "uploading",
+          message: `구성 ${i + 1}/${batches.length} 배치 적재 중…`,
+          done,
+          total: records.length,
+        });
+        const { error } = await supabase
+          .from("product_price_configs")
+          .upsert(batch, { onConflict: "product_id,config_type" });
+        if (error) throw error;
+        done += batch.length;
+      }
+
+      setPreview((prev) =>
+        prev ? { ...prev, matchedConfigCount: records.length, unmatched } : prev,
+      );
+      setP({
+        phase: "ok",
+        message:
+          `품목 ${itemPayload.length}건 · 구성 ${records.length}건 반영 완료` +
+          (unmatched > 0 ? ` · 품목 매칭 실패 ${unmatched}건(skip)` : ""),
+      });
+    } catch (e) {
+      setP({ phase: "error", message: errMsg(e) });
+    }
+  }
+
+  const pctVal =
+    p.total && p.total > 0 && p.done != null
+      ? Math.round((p.done / p.total) * 100)
+      : null;
+
+  return (
+    <div className="rounded-[24px] bg-white card-soft p-5">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="font-medium">④ 가격 마스터 (가격가이드 워크북)</h2>
+          <p className="mt-1 text-sm text-neutral-500">
+            품목 시트 + 가격가이드 시트를 한 번에 적재합니다. SKU × 구성(단품/2·3·4·5묶음)별
+            할인율·공헌이익은 rate card로 자동 계산합니다. 재업로드 시 중복 없이 갱신됩니다.
+          </p>
+        </div>
+        <label
+          className={`shrink-0 cursor-pointer rounded-xl border border-neutral-200 px-4 py-2 text-sm font-medium hover:bg-neutral-50 ${
+            busy ? "pointer-events-none opacity-50" : ""
+          }`}
+        >
+          파일 선택
+          <input
+            type="file"
+            accept=".xlsx,.xls"
+            className="hidden"
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) handleFile(f);
+              e.target.value = "";
+            }}
+          />
+        </label>
+      </div>
+
+      {sheets.length > 0 && (
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          <label className="text-sm">
+            <span className="text-neutral-500">품목 시트</span>
+            <select
+              className="mt-1 w-full rounded-lg border border-neutral-200 px-2.5 py-2 text-sm"
+              value={itemSheet}
+              onChange={(e) => setItemSheet(e.target.value)}
+              disabled={busy}
+            >
+              {sheets.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="text-sm">
+            <span className="text-neutral-500">가격가이드 시트</span>
+            <select
+              className="mt-1 w-full rounded-lg border border-neutral-200 px-2.5 py-2 text-sm"
+              value={guideSheet}
+              onChange={(e) => setGuideSheet(e.target.value)}
+              disabled={busy}
+            >
+              {sheets.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      )}
+
+      {sheets.length > 0 && (
+        <div className="mt-3 flex gap-2">
+          <button
+            type="button"
+            onClick={handlePreview}
+            disabled={busy || !itemSheet || !guideSheet}
+            className="rounded-xl border border-neutral-200 px-4 py-2 text-sm font-medium hover:bg-neutral-50 disabled:opacity-50"
+          >
+            미리보기 (dry-run)
+          </button>
+          <button
+            type="button"
+            onClick={handleLoad}
+            disabled={busy || !preview}
+            className="rounded-xl bg-brand-500 px-4 py-2 text-sm font-medium text-white hover:bg-brand-600 disabled:opacity-50"
+          >
+            적재
+          </button>
+        </div>
+      )}
+
+      {preview && (
+        <div className="mt-4 rounded-xl border border-neutral-200 p-3 text-sm">
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-neutral-700">
+            <span>
+              품목 <b>{preview.itemCount.toLocaleString()}</b>건
+            </span>
+            <span>
+              구성 <b>{preview.configCount.toLocaleString()}</b>건
+            </span>
+            {preview.matchedConfigCount != null && (
+              <span>
+                적재 <b>{preview.matchedConfigCount.toLocaleString()}</b>건
+              </span>
+            )}
+            <span className="text-neutral-400">
+              공헌이익 승수 mult = {preview.mult.toFixed(3)}
+            </span>
+          </div>
+          {(preview.itemSkipped.length > 0 || preview.guideSkipped.length > 0) && (
+            <div className="mt-1.5 text-xs text-amber-600">
+              {[...preview.itemSkipped, ...preview.guideSkipped]
+                .map((s) => `${s.reason} ${s.count}건`)
+                .join(" · ")}
+            </div>
+          )}
+          {preview.sample.length > 0 && (
+            <div className="mt-3 overflow-x-auto">
+              <table className="w-full text-left text-xs">
+                <thead className="text-neutral-400">
+                  <tr>
+                    <th className="py-1 pr-3">품목</th>
+                    <th className="py-1 pr-3">구성</th>
+                    <th className="py-1 pr-3 text-right">판매가</th>
+                    <th className="py-1 pr-3 text-right">정가</th>
+                    <th className="py-1 pr-3 text-right">할인(소비자)</th>
+                    <th className="py-1 pr-3 text-right">할인(상시)</th>
+                    <th className="py-1 pr-3 text-right">공헌이익</th>
+                    <th className="py-1 text-right">공헌이익률</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {preview.sample.map((c, i) => (
+                    <tr key={i} className="border-t border-neutral-100">
+                      <td className="py-1 pr-3">{c.base_name ?? c.dr_code ?? "—"}</td>
+                      <td className="py-1 pr-3">{c.config_type}</td>
+                      <td className="py-1 pr-3 text-right">{won(c.sale_price)}</td>
+                      <td className="py-1 pr-3 text-right">{won(c.list_price)}</td>
+                      <td className="py-1 pr-3 text-right">
+                        {pct(c.discount_rate_consumer)}
+                      </td>
+                      <td className="py-1 pr-3 text-right">
+                        {pct(c.discount_rate_regular)}
+                      </td>
+                      <td className="py-1 pr-3 text-right">{won(c.contribution)}</td>
+                      <td className="py-1 text-right">{pct(c.contribution_rate)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              <p className="mt-1.5 text-[11px] text-neutral-400">
+                상위 {preview.sample.length}행 미리보기. 매핑·건수를 확인한 뒤 [적재]를 누르세요.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {p.phase !== "idle" && p.message && (
+        <div
+          className={`mt-3 rounded-lg px-3 py-2 text-sm ${
+            p.phase === "error"
+              ? "bg-red-50 text-red-700"
+              : p.phase === "ok"
+                ? "bg-green-50 text-green-700"
+                : "bg-neutral-100 text-neutral-600"
+          }`}
+        >
+          <div>{p.message}</div>
+          {pctVal != null && p.phase === "uploading" && (
+            <div className="mt-1.5 h-1.5 overflow-hidden rounded-full bg-white/60">
+              <div
+                className="h-full bg-brand-500 transition-all"
+                style={{ width: `${pctVal}%` }}
+              />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function errMsg(e: unknown): string {
+  return e instanceof Error
+    ? e.message
+    : typeof e === "object" && e && "message" in e
+      ? String((e as { message: unknown }).message)
+      : "임포트 실패";
+}
+
+function dedupBy<T>(arr: T[], key: (t: T) => string): T[] {
+  const m = new Map<string, T>();
+  for (const it of arr) m.set(key(it), it);
+  return [...m.values()];
 }

--- a/promo-analytics/lib/parse.ts
+++ b/promo-analytics/lib/parse.ts
@@ -363,6 +363,9 @@ export type PriceGuideResult = {
   skipped: Skip[];
 };
 
+/** 공식몰 기본 혜택: 5만원 이상 결제 시 배송비 무료 (구성 판매가가 이 값 이상이면 free_shipping) */
+export const FREE_SHIP_THRESHOLD = 50000;
+
 /** 가격/원가/소비자가/상시가 fallback (시트값 우선, 없으면 품목 시트 lookup) */
 function pick(sheetVal: number, lookupVal: number | null | undefined): number | null {
   if (sheetVal && sheetVal > 0) return sheetVal;
@@ -402,8 +405,10 @@ export function parsePriceGuide(
       string,
       { cost: number | null; consumer_price: number | null; regular_price: number | null }
     >;
+    freeShipThreshold?: number;
   },
 ): PriceGuideResult {
+  const freeShipAt = opts.freeShipThreshold ?? FREE_SHIP_THRESHOLD;
   const rows = sheetRows(wb, sheetName);
   const h = findHeaderRowAll(rows, ["품목코드", "소비자가"]);
   if (h < 0)
@@ -454,7 +459,8 @@ export function parsePriceGuide(
       category: cat,
       config_type,
       pack_count: pack,
-      free_shipping: false,
+      // 공식몰 기본 혜택: 판매가 5만원 이상이면 자동 무료배송
+      free_shipping: sale >= freeShipAt,
       list_price: list,
       sale_price: sale,
       discount_rate_consumer: drc,

--- a/promo-analytics/lib/parse.ts
+++ b/promo-analytics/lib/parse.ts
@@ -50,6 +50,51 @@ function firstSheetRows(buf: ArrayBuffer): unknown[][] {
   return XLSX.utils.sheet_to_json(ws, { header: 1, blankrows: false });
 }
 
+/** 워크북 객체 (여러 시트를 이름으로 지정해 파싱할 때 한 번만 읽어 재사용) */
+export function readWorkbook(buf: ArrayBuffer): XLSX.WorkBook {
+  return XLSX.read(buf, { cellDates: true });
+}
+
+/** 워크북의 시트 이름 목록 */
+export function sheetNames(buf: ArrayBuffer): string[] {
+  return readWorkbook(buf).SheetNames;
+}
+
+/** 지정 시트를 2차원 배열로 */
+function sheetRows(wb: XLSX.WorkBook, sheetName: string): unknown[][] {
+  const ws = wb.Sheets[sheetName];
+  if (!ws) throw new Error(`시트를 찾을 수 없습니다: ${sheetName}`);
+  return XLSX.utils.sheet_to_json(ws, { header: 1, blankrows: false });
+}
+
+/** 헤더 셀을 공백 제거·소문자만 적용해 반환 (VAT+/VAT− 구분처럼 부호를 보존해야 할 때) */
+function rawHeader(header: unknown[]): string[] {
+  return header.map((h) => String(h ?? "").replace(/\s+/g, "").toLowerCase());
+}
+
+/** 원시 헤더(부호 보존) 기준으로 조건에 맞는 첫 컬럼 인덱스 */
+function findColRaw(header: unknown[], test: (raw: string) => boolean): number {
+  return rawHeader(header).findIndex(test);
+}
+
+/** 주어진 키워드를 '모두' 포함하는 첫 헤더 행 (병합/주석 밴드가 섞인 시트용) */
+function findHeaderRowAll(rows: unknown[][], keys: string[], maxScan = 20): number {
+  for (let i = 0; i < Math.min(rows.length, maxScan); i++) {
+    const normed = rows[i].map(norm);
+    if (keys.every((k) => normed.some((c) => c.includes(norm(k))))) return i;
+  }
+  return -1;
+}
+
+/** 행에 데이터가 한 칸이라도 있는지 (빈 행을 skip 카운트에서 제외) */
+function rowHasData(r: unknown[]): boolean {
+  return r.some((c) => String(c ?? "").trim() !== "");
+}
+
+function skipToArr(m: Map<string, number>): { reason: string; count: number }[] {
+  return [...m.entries()].map(([reason, count]) => ({ reason, count }));
+}
+
 /** 헤더 행 탐색: 후보 키워드가 가장 많이 매칭되는 행 (상위 15행 내) */
 function findHeaderRow(rows: unknown[][], keys: string[]): number {
   let best = -1,
@@ -220,4 +265,236 @@ export function parseMaster(buf: ArrayBuffer): MasterRow[] {
 export function extractPromoCode(name: string): string | null {
   const m = name.match(/CF_P_\d{4,6}/i);
   return m ? m[0] : null;
+}
+
+// ─────────────────────────────────────────────
+// ④ 가격 마스터 (S1) — 품목 시트 + 가격가이드 시트
+// ─────────────────────────────────────────────
+
+export type Skip = { reason: string; count: number };
+
+/** 품목 시트 → products upsert 페이로드 */
+export type ItemMasterRow = {
+  base_name: string;
+  dr_code: string | null;
+  cost: number | null; // 제품원가 (VAT+)
+  cost_vat_excluded: number | null; // 제품원가 (VAT−)
+  consumer_price: number | null;
+  regular_price: number | null;
+};
+
+export type ItemMasterResult = {
+  rows: ItemMasterRow[];
+  skipped: Skip[];
+};
+
+/**
+ * 품목 시트 파싱.
+ * 매핑: 품목코드→dr_code, 품목명→base_name, 제품원가(VAT+)→cost,
+ *       제품원가(VAT−)→cost_vat_excluded, 소비자가(VAT+)→consumer_price, 상시가(VAT+)→regular_price
+ */
+export function parseItemMaster(
+  wb: XLSX.WorkBook,
+  sheetName: string,
+): ItemMasterResult {
+  const rows = sheetRows(wb, sheetName);
+  const h = findHeaderRow(rows, ["품목코드", "품목명", "원가", "소비자가", "상시가"]);
+  if (h < 0)
+    throw new Error(
+      "품목 시트 헤더를 찾을 수 없습니다 (품목코드/품목명/원가/소비자가/상시가).",
+    );
+  const header = rows[h];
+  const cCode = findCol(header, ["품목코드", "코드"]);
+  const cName = findCol(header, ["품목명", "상품명"]);
+  // 원가는 VAT+/VAT− 둘 다 norm 시 같은 문자열이 되므로 부호를 보존한 원시 매칭 사용
+  const cCostPlus = findColRaw(header, (s) => s.includes("원가") && /vat[+＋]/.test(s));
+  const cCostMinus = findColRaw(
+    header,
+    (s) => s.includes("원가") && /vat[-−－]/.test(s),
+  );
+  const cCostAny = findCol(header, ["원가"]);
+  const cCost = cCostPlus >= 0 ? cCostPlus : cCostAny;
+  const cConsumer = findCol(header, ["소비자가"]);
+  const cRegular = findCol(header, ["상시가"]);
+
+  const out: ItemMasterRow[] = [];
+  const skip = new Map<string, number>();
+  const bump = (r: string) => skip.set(r, (skip.get(r) ?? 0) + 1);
+
+  for (let i = h + 1; i < rows.length; i++) {
+    const r = rows[i];
+    const name = String(r[cName] ?? "").trim();
+    if (!name || name === "-") {
+      if (rowHasData(r)) bump("품목명 없음");
+      continue;
+    }
+    out.push({
+      base_name: name,
+      dr_code: cCode >= 0 ? String(r[cCode] ?? "").trim() || null : null,
+      cost: cCost >= 0 ? toNum(r[cCost]) || null : null,
+      cost_vat_excluded: cCostMinus >= 0 ? toNum(r[cCostMinus]) || null : null,
+      consumer_price: cConsumer >= 0 ? toNum(r[cConsumer]) || null : null,
+      regular_price: cRegular >= 0 ? toNum(r[cRegular]) || null : null,
+    });
+  }
+  return { rows: out, skipped: skipToArr(skip) };
+}
+
+/** 가격가이드 시트 → product_price_configs 페이로드 + 카테고리 수집 */
+export type ParsedPriceConfig = {
+  dr_code: string | null;
+  base_name: string | null;
+  category: string | null;
+  config_type: "단품" | "2묶음" | "3묶음" | "4묶음" | "5묶음";
+  pack_count: number;
+  free_shipping: boolean;
+  list_price: number | null;
+  sale_price: number;
+  discount_rate_consumer: number | null;
+  discount_rate_regular: number | null;
+  unit_cost_total: number | null;
+  contribution: number | null;
+  contribution_rate: number | null;
+};
+
+export type PriceGuideResult = {
+  configs: ParsedPriceConfig[];
+  categories: { dr_code: string | null; base_name: string | null; category: string }[];
+  skipped: Skip[];
+};
+
+/** 가격/원가/소비자가/상시가 fallback (시트값 우선, 없으면 품목 시트 lookup) */
+function pick(sheetVal: number, lookupVal: number | null | undefined): number | null {
+  if (sheetVal && sheetVal > 0) return sheetVal;
+  return lookupVal ?? null;
+}
+
+/** N묶음 '가격' 컬럼 탐지 — 할인율·공헌이익·수량 컬럼을 배제하고 가격 컬럼만 선택 */
+function findPackPriceCol(header: unknown[], token: string): number {
+  const raw = rawHeader(header);
+  const t = token.toLowerCase();
+  const excluded = (s: string) => /할인|율|공헌|마진|이익|수량|개수|원가/.test(s);
+  // 1) 토큰 + 가격성 단어
+  let idx = raw.findIndex(
+    (s) => s.includes(t) && /(가격|판매가|세트가|금액|단가)/.test(s) && !excluded(s),
+  );
+  if (idx >= 0) return idx;
+  // 2) 토큰 + 비배제
+  idx = raw.findIndex((s) => s.includes(t) && !excluded(s));
+  if (idx >= 0) return idx;
+  // 3) 토큰 매칭 아무거나
+  return raw.findIndex((s) => s.includes(t));
+}
+
+/**
+ * 가격가이드 시트 파싱.
+ * - 헤더행 = '품목코드'와 '소비자가'를 모두 포함하는 행으로 자동 탐지, 데이터는 그 다음 행부터
+ * - 단품/2·3·4·5묶음 구성 생성. 가격 셀이 비면 그 구성은 skip
+ * - 할인율·공헌이익은 시트값을 읽지 않고 계산식으로 산출 (mult = rate card 승수)
+ * - 시트에 원가/소비자가/상시가가 없으면 품목 시트 lookup으로 보완
+ */
+export function parsePriceGuide(
+  wb: XLSX.WorkBook,
+  sheetName: string,
+  opts: {
+    mult: number;
+    lookup?: Map<
+      string,
+      { cost: number | null; consumer_price: number | null; regular_price: number | null }
+    >;
+  },
+): PriceGuideResult {
+  const rows = sheetRows(wb, sheetName);
+  const h = findHeaderRowAll(rows, ["품목코드", "소비자가"]);
+  if (h < 0)
+    throw new Error(
+      "가격가이드 시트 헤더를 찾을 수 없습니다 ('품목코드'와 '소비자가'가 같은 행에 있어야 합니다).",
+    );
+  const header = rows[h];
+  const cCode = findCol(header, ["품목코드", "코드"]);
+  const cName = findCol(header, ["품목명", "상품명"]);
+  const cCat = findCol(header, ["카테고리", "분류"]);
+  const cConsumer = findCol(header, ["소비자가"]);
+  const cRegular = findCol(header, ["상시가"]);
+  const cCostPlus = findColRaw(header, (s) => s.includes("원가") && /vat[+＋]/.test(s));
+  const cCostAny = findCol(header, ["원가"]);
+  const cCost = cCostPlus >= 0 ? cCostPlus : cCostAny;
+  const packCols: Record<number, number> = {
+    2: findPackPriceCol(header, "2묶음"),
+    3: findPackPriceCol(header, "3묶음"),
+    4: findPackPriceCol(header, "4묶음"),
+    5: findPackPriceCol(header, "5묶음"),
+  };
+
+  const configs: ParsedPriceConfig[] = [];
+  const categories: PriceGuideResult["categories"] = [];
+  const skip = new Map<string, number>();
+  const bump = (r: string) => skip.set(r, (skip.get(r) ?? 0) + 1);
+
+  const make = (
+    config_type: ParsedPriceConfig["config_type"],
+    pack: number,
+    sale: number,
+    cp: number | null,
+    rp: number | null,
+    cost: number | null,
+    name: string | null,
+    dr: string | null,
+    cat: string | null,
+  ): ParsedPriceConfig => {
+    const list = cp && cp > 0 ? cp * pack : null;
+    const drc = list && list > 0 ? (list - sale) / list : null;
+    const drr = rp && rp > 0 ? (rp * pack - sale) / (rp * pack) : null;
+    const uct = cost && cost > 0 ? cost * pack : null;
+    const contribution = uct != null ? sale * opts.mult - uct : null;
+    const crate = contribution != null && sale > 0 ? contribution / sale : null;
+    return {
+      dr_code: dr,
+      base_name: name,
+      category: cat,
+      config_type,
+      pack_count: pack,
+      free_shipping: false,
+      list_price: list,
+      sale_price: sale,
+      discount_rate_consumer: drc,
+      discount_rate_regular: drr,
+      unit_cost_total: uct,
+      contribution,
+      contribution_rate: crate,
+    };
+  };
+
+  for (let i = h + 1; i < rows.length; i++) {
+    const r = rows[i];
+    const dr = cCode >= 0 ? String(r[cCode] ?? "").trim() || null : null;
+    const name = cName >= 0 ? String(r[cName] ?? "").trim() || null : null;
+    if (!dr && !name) {
+      if (rowHasData(r)) bump("품목코드·품목명 모두 없음");
+      continue;
+    }
+    const cat = cCat >= 0 ? String(r[cCat] ?? "").trim() || null : null;
+    const look = dr && opts.lookup ? opts.lookup.get(dr) : undefined;
+    const cp = pick(cConsumer >= 0 ? toNum(r[cConsumer]) : 0, look?.consumer_price);
+    const rp = pick(cRegular >= 0 ? toNum(r[cRegular]) : 0, look?.regular_price);
+    const cost = pick(cCost >= 0 ? toNum(r[cCost]) : 0, look?.cost);
+
+    if (cat && (dr || name)) categories.push({ dr_code: dr, base_name: name, category: cat });
+
+    // 단품: 판매가 = 상시가
+    if (rp && rp > 0) configs.push(make("단품", 1, rp, cp, rp, cost, name, dr, cat));
+    else bump("단품: 상시가 없음");
+
+    // N묶음: 묶음 가격 컬럼 값이 있을 때만
+    for (const n of [2, 3, 4, 5] as const) {
+      const col = packCols[n];
+      if (col < 0) continue;
+      const price = toNum(r[col]);
+      if (!price || price <= 0) continue; // 값 없으면 정상 skip (카운트하지 않음)
+      configs.push(
+        make(`${n}묶음`, n, price, cp, rp, cost, name, dr, cat),
+      );
+    }
+  }
+  return { configs, categories, skipped: skipToArr(skip) };
 }

--- a/promo-analytics/lib/parse.ts
+++ b/promo-analytics/lib/parse.ts
@@ -451,6 +451,8 @@ export function parsePriceGuide(
     const drc = list && list > 0 ? (list - sale) / list : null;
     const drr = rp && rp > 0 ? (rp * pack - sale) / (rp * pack) : null;
     const uct = cost && cost > 0 ? cost * pack : null;
+    // 물류비는 개별 차감하지 않고 rate card 평균(12%)으로 고정 — 무료배송 여부와 무관하게
+    // 변동비는 mult에 일괄 반영. free_shipping은 정보용 플래그일 뿐 공헌이익을 바꾸지 않는다.
     const contribution = uct != null ? sale * opts.mult - uct : null;
     const crate = contribution != null && sale > 0 ? contribution / sale : null;
     return {

--- a/promo-analytics/lib/types.ts
+++ b/promo-analytics/lib/types.ts
@@ -3,9 +3,45 @@ export type Product = {
   base_name: string;
   dr_code: string | null;
   category: string | null;
-  cost: number | null;
+  cost: number | null; // 제품원가 (VAT+)
+  cost_vat_excluded: number | null; // 제품원가 (VAT−), 참고용
   consumer_price: number | null;
   regular_price: number | null;
+};
+
+// promo.rate_card — 변동비율 파라미터 (단일 current 행 + 이력)
+export type RateCard = {
+  id: string;
+  fee_rate: number; // 수수료 (기본 0.045)
+  ad_rate: number; // 광고비 (기본 0.10)
+  logistics_rate: number; // 물류비 (기본 0.12)
+  reward_rate: number; // 적립금 (기본 0.02)
+  effective_from: string;
+  is_current: boolean;
+  note: string | null;
+  created_at: string;
+};
+
+// 가격 마스터 구성 종류 (v1: 단품 + N묶음)
+export type PriceConfigType = "단품" | "2묶음" | "3묶음" | "4묶음" | "5묶음";
+
+// promo.product_price_configs — SKU × 판매구성 마스터
+export type ProductPriceConfig = {
+  id: string;
+  product_id: string;
+  base_name: string;
+  config_type: PriceConfigType;
+  pack_count: number; // 1~5
+  free_shipping: boolean;
+  list_price: number | null; // 소비자가 × pack_count
+  sale_price: number; // 판매가 (구성별)
+  discount_rate_consumer: number | null; // (list_price − sale_price)/list_price
+  discount_rate_regular: number | null; // (상시가×pack − sale_price)/(상시가×pack)
+  unit_cost_total: number | null; // 원가(VAT+) × pack_count
+  contribution: number | null; // sale_price × mult − unit_cost_total
+  contribution_rate: number | null; // contribution / sale_price
+  source_file: string | null;
+  updated_at: string;
 };
 
 export type Promotion = {

--- a/promo-analytics/supabase/migrations/0006_price_master.sql
+++ b/promo-analytics/supabase/migrations/0006_price_master.sql
@@ -1,0 +1,58 @@
+-- 0006: 가격 마스터 (L1) — rate card + product_price_configs + products 정합 컬럼
+-- S1: 가격 가이드 / 달성률 로드맵의 L1 가격 마스터 계층.
+-- additive only. 기존 products.cost 값 등 기존 데이터는 건드리지 않음(업로드 적재 시 교정).
+
+-- (1) rate card 파라미터 (단일 current 행 + 이력)
+create table if not exists promo.rate_card (
+  id              uuid primary key default gen_random_uuid(),
+  fee_rate        numeric not null default 0.045,  -- 수수료(자사몰)
+  ad_rate         numeric not null default 0.10,   -- 광고비
+  logistics_rate  numeric not null default 0.12,   -- 물류비
+  reward_rate     numeric not null default 0.02,   -- 적립금
+  effective_from  timestamptz not null default now(),
+  is_current      boolean not null default true,
+  note            text,
+  created_at      timestamptz not null default now()
+);
+
+-- 초기 1행 시드 (current 행이 없을 때만). 변동비율 합 = 0.285, 공헌이익 승수 = 0.715
+insert into promo.rate_card (fee_rate, ad_rate, logistics_rate, reward_rate, is_current, note)
+select 0.045, 0.10, 0.12, 0.02, true, '자사몰 기본 rate card (S1 초기 시드)'
+where not exists (select 1 from promo.rate_card where is_current = true);
+
+alter table promo.rate_card enable row level security;
+drop policy if exists rate_card_auth on promo.rate_card;
+create policy rate_card_auth on promo.rate_card for all to authenticated using (true) with check (true);
+
+-- (2) products 정합 컬럼 (additive). 기존 cost 값은 건드리지 않음 — 업로드 적재 시 교정.
+alter table promo.products add column if not exists cost_vat_excluded numeric;
+
+-- (3) SKU × 판매구성 마스터
+create table if not exists promo.product_price_configs (
+  id                     uuid primary key default gen_random_uuid(),
+  product_id             uuid not null references promo.products(id) on delete cascade,
+  base_name              text not null,
+  config_type            text not null,         -- '단품' | '2묶음' | '3묶음' | '4묶음' | '5묶음'
+  pack_count             int  not null,         -- 1~5 (같은 SKU 수량)
+  free_shipping          boolean not null default false,
+  list_price             numeric,               -- 정가 = 소비자가 × pack_count
+  sale_price             numeric not null,      -- 판매가(구성별)
+  discount_rate_consumer numeric,               -- (list_price - sale_price)/list_price
+  discount_rate_regular  numeric,               -- (상시가×pack - sale_price)/(상시가×pack)
+  unit_cost_total        numeric,               -- 원가(VAT+) × pack_count
+  contribution           numeric,               -- sale_price × mult − unit_cost_total
+  contribution_rate      numeric,               -- contribution / sale_price
+  source_file            text,
+  updated_at             timestamptz not null default now(),
+  unique (product_id, config_type)
+);
+create index if not exists product_price_configs_product_idx
+  on promo.product_price_configs (product_id);
+
+alter table promo.product_price_configs enable row level security;
+drop policy if exists product_price_configs_auth on promo.product_price_configs;
+create policy product_price_configs_auth on promo.product_price_configs for all to authenticated using (true) with check (true);
+
+grant all on all tables in schema promo to authenticated;
+grant all on all sequences in schema promo to authenticated;
+grant execute on all functions in schema promo to authenticated;


### PR DESCRIPTION
## 개요

가격 가이드 / 달성률 / 목적 슬라이스 로드맵(S0)의 **S1 — L1 가격 마스터 계층**입니다. 워크북(`가격가이드.xlsx`)을 업로드해 전 SKU 가격·마진 마스터를 적재합니다. 단위 공헌이익은 시트값이 아니라 **DB의 rate card로 계산**하고, 재업로드 시 **upsert(중복방지)** 합니다.

> 1 세션 = 1 PR. S1 범위만 구현했습니다. (S2 `campaign_plans`/옵션 BOM, 정기구독·무배·추가구성 구성은 미포함)

## 변경 사항

### 마이그레이션 `0006_price_master` (additive · `apply_migration`으로 적용 완료)
- `promo.rate_card` — 변동비율 파라미터(단일 current 행 + 이력). 초기 시드 `0.045 / 0.10 / 0.12 / 0.02` → 변동비율 합 0.285, **공헌이익 승수 mult = 0.715**
- `promo.products.cost_vat_excluded` 컬럼 추가 (기존 `cost`는 VAT+로 통일 — 값은 업로드 적재 시 교정, 마이그레이션에서 기존 값 미변경)
- `promo.product_price_configs` — SKU × 구성 마스터, `unique(product_id, config_type)` (재업로드 upsert 키)
- 세 테이블 RLS: `authenticated` → `for all using(true) with check(true)`

검증(remote DB): current rate_card 1행 · mult = **0.7150** · `product_price_configs` 0행(업로드 대기) · `cost_vat_excluded` 존재 · PostgREST 스키마 캐시 리로드 완료.

### `lib/types.ts`
- `RateCard`, `ProductPriceConfig`, `PriceConfigType` 행 타입 + `Product.cost_vat_excluded`

### `lib/parse.ts`
- `readWorkbook` / `sheetNames` — 워크북 1회 읽어 여러 시트 재사용, 시트명 목록
- `parseItemMaster(wb, sheetName)` — 품목 시트 → `products` upsert 페이로드. VAT+/VAT−는 norm 시 동일 문자열이 되므로 **부호 보존 원시 매칭**으로 구분
- `parsePriceGuide(wb, sheetName, { mult, lookup })` — 헤더행 = `품목코드`+`소비자가` 동시 포함 행 자동 탐지(병합/주석 밴드 대응). 단품/2·3·4·5묶음 구성 생성, 가격 셀 비면 skip. **할인율·공헌이익은 시트값을 읽지 않고 계산식으로 산출**. 원가/소비자가/상시가 누락 시 품목 시트 lookup 보완
- 두 파서 모두 스킵 행을 사유와 함께 카운트해 반환 (dry-run)

계산식 (rate card mult를 DB에서 읽어 적용, 상수 하드코딩 없음):
```
list_price             = consumer_price × pack_count
discount_rate_consumer = (list_price − sale_price) / list_price
discount_rate_regular  = (regular_price × pack − sale_price) / (regular_price × pack)
unit_cost_total        = cost(VAT+) × pack_count
contribution           = sale_price × mult − unit_cost_total
contribution_rate      = contribution / sale_price
```

### `/upload` — 4번째 "가격 마스터" 카드
- 워크북 선택 → 품목/가격가이드 시트 **드롭다운**(스마트 기본값: 이름에 `품목` / `가격가이드` 포함, 하드코딩 없음)
- **미리보기(dry-run)**: 품목 n건 / 구성 n건 / 스킵 사유 + 상위 10행 파싱 결과 테이블(판매가·정가·할인율·공헌이익·공헌이익률)
- **적재**: `products` upsert(by `base_name` — 기존 인프라 재사용, `dr_code`/원가/가격을 필드로 갱신) → `product_price_configs` upsert(by `product_id, config_type`, `source_file` 기록, chunk 분할) → 카테고리 갱신
- 다른 `source_file` 구성 존재 시 confirm 경고 (PR #27 패턴). 모든 쓰기는 브라우저 supabase 클라이언트(새 API 라우트 없음, xlsx 브라우저 파싱 유지)

## 설계 메모
- **products upsert 키**: 지시서는 `dr_code` 기준을 언급했으나, 현재 `products`의 고유 제약은 `base_name`이고 앱 전체(daily_sales/promotion_sales)가 `base_name`으로 조인하므로 **`base_name` upsert + `dr_code`는 필드 갱신**으로 구현했습니다. 가격가이드 구성은 `dr_code` 우선(→ base_name 폴백)으로 `product_id`를 해석합니다. dirty할 수 있는 `dr_code`에 unique 인덱스를 추가하는 스키마 리스크를 피하면서 "재업로드 중복 없이 upsert" 요건을 충족합니다.
- 무배/정기구독/추가구성 구성은 v1 미적재(0007+에서 `config_type` 확장으로 흡수).

## 검수 (사용자 확인 필요)
- [ ] 실제 `가격가이드.xlsx` 업로드 → 미리보기 매핑·건수 확인 → 적재 → `products` 갱신 + `product_price_configs` 적재 확인
- [ ] 재업로드 2회차에 행 수 증가 없이 갱신만 되는지(중복방지) 확인
- [ ] 임의 SKU 1개의 contribution 수기 검산(sale_price×0.715 − cost×pack) 대조
- [ ] Vercel 프리뷰 빌드 Ready

> ⚠️ 이 환경엔 `node_modules`가 없어 로컬 빌드/타입체크를 못 돌렸습니다. 타입 안전성은 검토했고(특히 Map 튜플 추론), **Vercel 프리뷰 빌드가 컴파일 게이트**입니다.

S1 완료, 검수 후 다음 지시 대기.

https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ)_