### PR TITLE
S3: 달성률 + 캠페인 상세

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/Achievement.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/Achievement.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import type {
+  PlanVsActualRow,
+  PlanVsActualSummary,
+  PlanVsActualOption,
+} from "@/lib/types";
+import { won, wonShort, pct, num } from "@/lib/format";
+
+export default function Achievement({
+  promotionId,
+  summary,
+  rows,
+  options,
+  optionInfos,
+}: {
+  promotionId: string;
+  summary: PlanVsActualSummary | null;
+  rows: PlanVsActualRow[];
+  options: PlanVsActualOption[];
+  optionInfos: string[];
+}) {
+  if (!summary || !summary.has_confirmed_plan) {
+    return (
+      <section className="mt-6">
+        <h2 className="mb-2 text-sm font-semibold text-neutral-700">달성률 (계획 대비 실적)</h2>
+        <div className="rounded-[24px] bg-white card-soft p-6 text-sm text-neutral-500">
+          확정된 가격 가이드(플랜)가 없습니다.{" "}
+          <Link href={`/promotions/${promotionId}/plan`} className="text-brand-600 hover:underline">
+            플랜을 확정
+          </Link>
+          하면 SKU·옵션 단위 달성률이 표시됩니다.
+        </div>
+      </section>
+    );
+  }
+
+  const planRows = rows.filter((r) => r.status !== "unplanned");
+  const unplanned = rows.filter((r) => r.status === "unplanned");
+
+  return (
+    <section className="mt-6">
+      <h2 className="mb-2 text-sm font-semibold text-neutral-700">달성률 (계획 대비 실적)</h2>
+
+      {/* 3종 카드 */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <AchCard
+          label="매출 달성률"
+          ach={summary.ach_revenue}
+          actual={summary.actual_revenue_total}
+          expected={summary.expected_revenue_total}
+          primary
+        />
+        <AchCard
+          label="수량 달성률"
+          ach={summary.ach_qty}
+          actual={summary.actual_qty_total}
+          expected={summary.expected_qty_total}
+          isQty
+          lowData={summary.quantity_reliable === false}
+        />
+        <AchCard
+          label="공헌이익 달성률"
+          ach={summary.ach_contribution}
+          actual={summary.actual_contribution_total}
+          expected={summary.expected_contribution_total}
+        />
+      </div>
+
+      {/* SKU 단위 가이드 vs 실적 */}
+      <div className="mt-4 overflow-x-auto rounded-[24px] bg-white card-soft">
+        <table className="w-full min-w-[720px] text-sm">
+          <thead className="bg-neutral-50 text-left text-xs text-neutral-500">
+            <tr>
+              <th className="px-3 py-2.5 font-medium">SKU</th>
+              <th className="px-3 py-2.5 text-right font-medium">기대 매출</th>
+              <th className="px-3 py-2.5 text-right font-medium">실 매출</th>
+              <th className="px-3 py-2.5 text-right font-medium">매출 달성</th>
+              <th className="px-3 py-2.5 text-right font-medium">기대 수량</th>
+              <th className="px-3 py-2.5 text-right font-medium">실 수량</th>
+              <th className="px-3 py-2.5 text-right font-medium">공헌 달성</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-neutral-100">
+            {planRows.map((r) => (
+              <tr key={r.product_id} className={r.status === "unsold" ? "bg-red-50/40" : ""}>
+                <td className="px-3 py-2.5">
+                  {r.base_name}
+                  {r.status === "unsold" && (
+                    <span className="ml-1.5 rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-medium text-red-600">
+                      미판매
+                    </span>
+                  )}
+                </td>
+                <td className="px-3 py-2.5 text-right text-neutral-500">{won(r.expected_revenue)}</td>
+                <td className="px-3 py-2.5 text-right">{won(r.actual_revenue)}</td>
+                <td className="px-3 py-2.5 text-right">
+                  <AchPct v={r.ach_revenue} />
+                </td>
+                <td className="px-3 py-2.5 text-right text-neutral-500">{num(r.expected_qty)}</td>
+                <td className="px-3 py-2.5 text-right">{num(r.actual_qty)}</td>
+                <td className="px-3 py-2.5 text-right">
+                  <AchPct v={r.ach_contribution} />
+                </td>
+              </tr>
+            ))}
+            {planRows.length === 0 && (
+              <tr>
+                <td colSpan={7} className="px-3 py-4 text-center text-xs text-neutral-400">
+                  계획된 SKU가 없습니다.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* 옵션 단위 보조 */}
+      <div className="mt-4">
+        <h3 className="mb-2 text-xs font-semibold text-neutral-500">옵션 단위 (보조)</h3>
+        <div className="space-y-2">
+          {options.map((o) => (
+            <OptionRow
+              key={o.option_id}
+              promotionId={promotionId}
+              opt={o}
+              optionInfos={optionInfos}
+            />
+          ))}
+          {options.length === 0 && (
+            <p className="text-xs text-neutral-400">옵션이 없습니다.</p>
+          )}
+        </div>
+      </div>
+
+      {/* 계획 외 판매 */}
+      {unplanned.length > 0 && (
+        <details className="mt-4 rounded-[20px] bg-amber-50/60 p-4">
+          <summary className="cursor-pointer text-sm font-medium text-amber-800">
+            계획 외 판매 — {unplanned.length}개 SKU · 매출 {wonShort(summary.unplanned_revenue)} · 공헌{" "}
+            {wonShort(summary.unplanned_contribution)}
+            <span className="ml-1 text-xs font-normal text-amber-600">
+              (전체 달성률 분모에서 제외)
+            </span>
+          </summary>
+          <div className="mt-3 overflow-x-auto">
+            <table className="w-full text-left text-xs">
+              <thead className="text-amber-700/70">
+                <tr>
+                  <th className="py-1 pr-3">SKU</th>
+                  <th className="py-1 pr-3 text-right">실 매출</th>
+                  <th className="py-1 text-right">실 수량</th>
+                </tr>
+              </thead>
+              <tbody>
+                {unplanned.map((r) => (
+                  <tr key={r.product_id} className="border-t border-amber-100">
+                    <td className="py-1 pr-3">{r.base_name}</td>
+                    <td className="py-1 pr-3 text-right">{won(r.actual_revenue)}</td>
+                    <td className="py-1 text-right">{num(r.actual_qty)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </details>
+      )}
+    </section>
+  );
+}
+
+function AchCard({
+  label,
+  ach,
+  actual,
+  expected,
+  primary,
+  isQty,
+  lowData,
+}: {
+  label: string;
+  ach: number | null;
+  actual: number | null;
+  expected: number | null;
+  primary?: boolean;
+  isQty?: boolean;
+  lowData?: boolean;
+}) {
+  const fmt = isQty ? num : wonShort;
+  return (
+    <div className={`rounded-[20px] p-4 ${primary ? "bg-brand-50" : "bg-white card-soft"}`}>
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs text-neutral-500">{label}</span>
+        {lowData && (
+          <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700">
+            데이터 부족
+          </span>
+        )}
+      </div>
+      <div className="mt-1 text-2xl font-semibold">
+        {ach != null ? pct(ach, 0) : "—"}
+      </div>
+      <div className="mt-0.5 text-xs text-neutral-400">
+        {fmt(actual)} / {fmt(expected)}
+      </div>
+    </div>
+  );
+}
+
+function AchPct({ v }: { v: number | null }) {
+  if (v == null) return <span className="text-neutral-300">—</span>;
+  const color = v >= 1 ? "text-green-600" : v <= 0 ? "text-red-500" : "text-neutral-700";
+  return <span className={color}>{pct(v, 0)}</span>;
+}
+
+function OptionRow({
+  promotionId,
+  opt,
+  optionInfos,
+}: {
+  promotionId: string;
+  opt: PlanVsActualOption;
+  optionInfos: string[];
+}) {
+  const router = useRouter();
+  const [editing, setEditing] = useState(false);
+  const [selected, setSelected] = useState<string[]>(opt.match_patterns ?? []);
+  const [busy, setBusy] = useState(false);
+
+  function toggle(info: string) {
+    setSelected((prev) =>
+      prev.includes(info) ? prev.filter((x) => x !== info) : [...prev, info],
+    );
+  }
+
+  async function saveMapping() {
+    setBusy(true);
+    const res = await fetch(
+      `/api/promotions/${promotionId}/plan/options/${opt.option_id}/mapping`,
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ match_patterns: selected }),
+      },
+    );
+    setBusy(false);
+    if (res.ok) {
+      setEditing(false);
+      router.refresh();
+    }
+  }
+
+  return (
+    <div className="rounded-[16px] bg-white card-soft p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium">{opt.option_label}</span>
+          {opt.matched ? (
+            <span className="rounded bg-green-100 px-1.5 py-0.5 text-[10px] font-medium text-green-700">
+              매칭됨
+            </span>
+          ) : (
+            <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700">
+              옵션 매핑 필요
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-3 text-xs text-neutral-500">
+          <span>
+            예상 {wonShort(opt.expected_revenue)} → 실적 {wonShort(opt.actual_revenue)}
+          </span>
+          <span className="font-medium">
+            <AchPct v={opt.ach_revenue} />
+          </span>
+          <button
+            onClick={() => setEditing((v) => !v)}
+            className="rounded-lg border border-neutral-200 px-2 py-1 text-xs hover:bg-neutral-50"
+          >
+            {editing ? "닫기" : "매핑"}
+          </button>
+        </div>
+      </div>
+
+      {editing && (
+        <div className="mt-3 border-t border-neutral-100 pt-3">
+          <p className="mb-2 text-xs text-neutral-500">
+            이 옵션에 해당하는 실적 옵션정보를 선택하세요 (부분일치).
+          </p>
+          {optionInfos.length === 0 ? (
+            <p className="text-xs text-neutral-400">
+              실적 데이터에 옵션정보가 없습니다. (수량·옵션 컬럼 미보유)
+            </p>
+          ) : (
+            <div className="max-h-56 space-y-1 overflow-auto">
+              {optionInfos.map((info) => (
+                <label key={info} className="flex items-start gap-2 text-xs">
+                  <input
+                    type="checkbox"
+                    className="mt-0.5"
+                    checked={selected.includes(info)}
+                    onChange={() => toggle(info)}
+                  />
+                  <span className="break-all">{info}</span>
+                </label>
+              ))}
+            </div>
+          )}
+          <div className="mt-3 flex gap-2">
+            <button
+              onClick={saveMapping}
+              disabled={busy}
+              className="rounded-lg bg-brand-500 px-3 py-1.5 text-xs font-medium text-white hover:bg-brand-600 disabled:opacity-50"
+            >
+              매핑 저장
+            </button>
+            <span className="self-center text-[11px] text-neutral-400">
+              확정 플랜이어도 매핑은 수정 가능합니다.
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/promo-analytics/app/(dash)/promotions/[id]/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/page.tsx
@@ -6,10 +6,14 @@ import type {
   MeasurementRow,
   PromotionSummary,
   PromotionNote,
+  PlanVsActualRow,
+  PlanVsActualSummary,
+  PlanVsActualOption,
 } from "@/lib/types";
 import { won, wonShort, pct, daysBetween } from "@/lib/format";
 import UpliftChart from "./UpliftChart";
 import Notes from "./Notes";
+import Achievement from "./Achievement";
 
 export const dynamic = "force-dynamic";
 
@@ -57,6 +61,33 @@ export default async function PromotionDetail({
     expected_revenue_total: number | null;
     expected_contribution_total: number | null;
   } | null;
+
+  // 달성률 (S3): 확정 플랜 vs 실적 + 옵션 매핑용 distinct option_info
+  const [
+    { data: pvaSummary },
+    { data: pvaRows },
+    { data: pvaOptions },
+    { data: optInfoRows },
+  ] = await Promise.all([
+    supabase.rpc("plan_vs_actual_summary", { p_id: id }),
+    supabase.rpc("plan_vs_actual", { p_id: id }),
+    supabase.rpc("plan_vs_actual_options", { p_id: id }),
+    supabase
+      .from("promotion_sales")
+      .select("option_info")
+      .eq("promotion_id", id)
+      .not("option_info", "is", null),
+  ]);
+  const achSummary = (pvaSummary?.[0] as PlanVsActualSummary) ?? null;
+  const achRows = (pvaRows as PlanVsActualRow[]) ?? [];
+  const achOptions = (pvaOptions as PlanVsActualOption[]) ?? [];
+  const optionInfos = [
+    ...new Set(
+      ((optInfoRows as { option_info: string | null }[]) ?? [])
+        .map((r) => (r.option_info ?? "").trim())
+        .filter((s) => s.length > 0),
+    ),
+  ].sort();
 
   const mains = rows.filter((r) => r.is_main);
   const chartData = rows
@@ -156,9 +187,6 @@ export default async function PromotionDetail({
                 계산하세요.
               </p>
             )}
-            <p className="mt-1 text-xs text-neutral-300">
-              달성률(계획 대비 실적)은 다음 단계에서 표시됩니다.
-            </p>
           </div>
           <Link
             href={`/promotions/${id}/plan`}
@@ -168,6 +196,15 @@ export default async function PromotionDetail({
           </Link>
         </div>
       </div>
+
+      {/* 달성률 (S3) */}
+      <Achievement
+        promotionId={id}
+        summary={achSummary}
+        rows={achRows}
+        options={achOptions}
+        optionInfos={optionInfos}
+      />
 
       <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-5">
         {/* 측정 테이블 */}

--- a/promo-analytics/app/api/promotions/[id]/plan/options/[optionId]/mapping/route.ts
+++ b/promo-analytics/app/api/promotions/[id]/plan/options/[optionId]/mapping/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export const runtime = "nodejs";
+
+// 옵션 매칭 패턴(match_patterns)만 수정. 사후 분석 메타데이터이므로 confirmed 플랜이어도 허용.
+// (expected_*/frozen_* 등 다른 필드는 변경 경로 없음)
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string; optionId: string }> },
+) {
+  try {
+    const { id, optionId } = await params;
+    const body = (await req.json()) as { match_patterns?: unknown };
+    const supabase = await createClient();
+
+    // 옵션 → 플랜 → 이 캠페인 소속 확인
+    const { data: opt } = await supabase
+      .from("campaign_plan_options")
+      .select("id, campaign_plan_id")
+      .eq("id", optionId)
+      .single();
+    if (!opt)
+      return NextResponse.json({ error: "옵션을 찾을 수 없습니다" }, { status: 404 });
+    const { data: plan } = await supabase
+      .from("campaign_plans")
+      .select("id")
+      .eq("id", opt.campaign_plan_id)
+      .eq("promotion_id", id)
+      .single();
+    if (!plan)
+      return NextResponse.json({ error: "플랜을 찾을 수 없습니다" }, { status: 404 });
+
+    const clean = Array.isArray(body.match_patterns)
+      ? [
+          ...new Set(
+            body.match_patterns
+              .map((s) => String(s).trim())
+              .filter((s) => s.length > 0),
+          ),
+        ]
+      : [];
+
+    const { error } = await supabase
+      .from("campaign_plan_options")
+      .update({ match_patterns: clean, updated_at: new Date().toISOString() })
+      .eq("id", optionId);
+    if (error) throw error;
+
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : "매핑 저장 실패" },
+      { status: 500 },
+    );
+  }
+}

--- a/promo-analytics/lib/types.ts
+++ b/promo-analytics/lib/types.ts
@@ -178,3 +178,56 @@ export type CampaignPlanOptionItem = {
   frozen_cost: number | null;
   sort: number;
 };
+
+// ─────────────────────────────────────────────
+// S3: 달성률 (plan_vs_actual 함수 반환)
+// ─────────────────────────────────────────────
+
+export type PlanVsActualRow = {
+  product_id: string;
+  base_name: string;
+  expected_qty: number;
+  expected_revenue: number;
+  expected_contribution: number;
+  actual_qty: number;
+  actual_revenue: number;
+  actual_contribution: number;
+  ach_qty: number | null;
+  ach_revenue: number | null;
+  ach_contribution: number | null;
+  status: "matched" | "unsold" | "unplanned";
+};
+
+export type PlanVsActualSummary = {
+  has_confirmed_plan: boolean;
+  expected_revenue_total: number | null;
+  actual_revenue_total: number | null;
+  ach_revenue: number | null;
+  expected_qty_total: number | null;
+  actual_qty_total: number | null;
+  ach_qty: number | null;
+  expected_contribution_total: number | null;
+  actual_contribution_total: number | null;
+  ach_contribution: number | null;
+  unplanned_revenue: number | null;
+  unplanned_qty: number | null;
+  unplanned_contribution: number | null;
+  matched_sku_count: number | null;
+  unsold_sku_count: number | null;
+  unplanned_sku_count: number | null;
+  quantity_reliable: boolean | null;
+  snapshot_mult: number | null;
+};
+
+export type PlanVsActualOption = {
+  option_id: string;
+  option_label: string;
+  expected_option_qty: number;
+  expected_revenue: number | null;
+  expected_contribution: number | null;
+  match_patterns: string[];
+  matched: boolean;
+  actual_revenue: number;
+  actual_qty: number;
+  ach_revenue: number | null;
+};

--- a/promo-analytics/supabase/migrations/0008_plan_vs_actual.sql
+++ b/promo-analytics/supabase/migrations/0008_plan_vs_actual.sql
@@ -1,0 +1,209 @@
+-- 0008: 달성률 (S3) — 확정 플랜(frozen) vs promotion_sales(실적)
+-- 함수 3분할: plan_vs_actual / plan_vs_actual_summary / plan_vs_actual_options
+-- 공헌이익은 양쪽 모두 plan rate_card_snapshot.mult 사용(비용구조 차 아닌 실제 성과만 반영).
+
+-- per-SKU 달성률
+create or replace function promo.plan_vs_actual(p_id uuid)
+returns table (
+  product_id uuid,
+  base_name text,
+  expected_qty numeric,
+  expected_revenue numeric,
+  expected_contribution numeric,
+  actual_qty numeric,
+  actual_revenue numeric,
+  actual_contribution numeric,
+  ach_qty numeric,
+  ach_revenue numeric,
+  ach_contribution numeric,
+  status text
+)
+language sql
+stable
+set search_path = ''
+as $$
+  with plan as (
+    select id, (rate_card_snapshot->>'mult')::numeric as mult
+    from promo.campaign_plans
+    where promotion_id = p_id and is_current and status = 'confirmed'
+    limit 1
+  ),
+  exp as (
+    select i.product_id,
+           max(i.base_name) as base_name,
+           sum(o.expected_option_qty * i.sku_qty_per_option) as expected_qty,
+           sum(o.expected_option_qty * i.sku_qty_per_option * i.unit_sale_price) as expected_revenue,
+           sum(o.expected_option_qty * i.sku_qty_per_option *
+               (i.unit_sale_price * (select mult from plan) - coalesce(i.frozen_cost,0))) as expected_contribution
+    from promo.campaign_plan_options o
+    join promo.campaign_plan_option_items i on i.campaign_plan_option_id = o.id
+    where o.campaign_plan_id = (select id from plan)
+    group by i.product_id
+  ),
+  act as (
+    select ps.product_id,
+           max(ps.base_name) as base_name,
+           sum(ps.quantity) as actual_qty,
+           sum(ps.revenue) as actual_revenue,
+           sum(ps.revenue) * (select mult from plan) - sum(coalesce(ps.cost,0)) as actual_contribution
+    from promo.promotion_sales ps
+    where ps.promotion_id = p_id
+      and ps.product_id is not null
+      and exists (select 1 from plan)
+    group by ps.product_id
+  ),
+  j as (
+    select
+      coalesce(e.product_id, a.product_id) as product_id,
+      coalesce(e.base_name, a.base_name) as base_name,
+      coalesce(e.expected_qty,0) as expected_qty,
+      coalesce(e.expected_revenue,0) as expected_revenue,
+      coalesce(e.expected_contribution,0) as expected_contribution,
+      coalesce(a.actual_qty,0) as actual_qty,
+      coalesce(a.actual_revenue,0) as actual_revenue,
+      coalesce(a.actual_contribution,0) as actual_contribution,
+      (e.product_id is not null and (coalesce(e.expected_qty,0) > 0 or coalesce(e.expected_revenue,0) > 0)) as has_exp,
+      (a.product_id is not null and (coalesce(a.actual_qty,0) <> 0 or coalesce(a.actual_revenue,0) <> 0)) as has_act
+    from exp e
+    full outer join act a on a.product_id = e.product_id
+  )
+  select
+    product_id, base_name, expected_qty, expected_revenue, expected_contribution,
+    actual_qty, actual_revenue, actual_contribution,
+    case when expected_qty > 0 then actual_qty/expected_qty else null end as ach_qty,
+    case when expected_revenue > 0 then actual_revenue/expected_revenue else null end as ach_revenue,
+    case when expected_contribution > 0 then actual_contribution/expected_contribution else null end as ach_contribution,
+    case
+      when has_exp and has_act then 'matched'
+      when has_exp and not has_act then 'unsold'
+      else 'unplanned'
+    end as status
+  from j
+  where has_exp or has_act;
+$$;
+
+-- 옵션 단위 보조 (match_patterns ↔ option_info 정규화 부분일치)
+create or replace function promo.plan_vs_actual_options(p_id uuid)
+returns table (
+  option_id uuid,
+  option_label text,
+  expected_option_qty numeric,
+  expected_revenue numeric,
+  expected_contribution numeric,
+  match_patterns text[],
+  matched boolean,
+  actual_revenue numeric,
+  actual_qty numeric,
+  ach_revenue numeric
+)
+language sql
+stable
+set search_path = ''
+as $$
+  with plan as (
+    select id from promo.campaign_plans
+    where promotion_id = p_id and is_current and status = 'confirmed' limit 1
+  )
+  select
+    o.id, o.option_label, o.expected_option_qty, o.expected_revenue, o.expected_contribution,
+    o.match_patterns,
+    coalesce(act.matched, false) as matched,
+    coalesce(act.actual_revenue, 0) as actual_revenue,
+    coalesce(act.actual_qty, 0) as actual_qty,
+    case when coalesce(o.expected_revenue,0) > 0 then coalesce(act.actual_revenue,0)/o.expected_revenue else null end as ach_revenue
+  from promo.campaign_plan_options o
+  left join lateral (
+    select sum(ps.revenue) as actual_revenue, sum(ps.quantity) as actual_qty, count(*) > 0 as matched
+    from promo.promotion_sales ps
+    where ps.promotion_id = p_id
+      and coalesce(array_length(o.match_patterns,1),0) > 0
+      and exists (
+        select 1 from unnest(o.match_patterns) pat
+        where length(btrim(pat)) > 0
+          and position(
+            lower(regexp_replace(pat, '\s', '', 'g'))
+            in lower(regexp_replace(coalesce(ps.option_info,''), '\s', '', 'g'))
+          ) > 0
+      )
+  ) act on true
+  where o.campaign_plan_id = (select id from plan)
+  order by o.sort;
+$$;
+
+-- 전체 요약 (항상 1행)
+create or replace function promo.plan_vs_actual_summary(p_id uuid)
+returns table (
+  has_confirmed_plan boolean,
+  expected_revenue_total numeric,
+  actual_revenue_total numeric,
+  ach_revenue numeric,
+  expected_qty_total numeric,
+  actual_qty_total numeric,
+  ach_qty numeric,
+  expected_contribution_total numeric,
+  actual_contribution_total numeric,
+  ach_contribution numeric,
+  unplanned_revenue numeric,
+  unplanned_qty numeric,
+  unplanned_contribution numeric,
+  matched_sku_count int,
+  unsold_sku_count int,
+  unplanned_sku_count int,
+  quantity_reliable boolean,
+  snapshot_mult numeric
+)
+language plpgsql
+stable
+set search_path = ''
+as $$
+declare
+  v_has boolean;
+  v_mult numeric;
+begin
+  select true, (rate_card_snapshot->>'mult')::numeric
+    into v_has, v_mult
+  from promo.campaign_plans
+  where promotion_id = p_id and is_current and status = 'confirmed'
+  limit 1;
+
+  if not coalesce(v_has, false) then
+    return query select false,
+      null::numeric, null::numeric, null::numeric,
+      null::numeric, null::numeric, null::numeric,
+      null::numeric, null::numeric, null::numeric,
+      null::numeric, null::numeric, null::numeric,
+      null::int, null::int, null::int,
+      null::boolean, null::numeric;
+    return;
+  end if;
+
+  return query
+  with rows as (
+    select * from promo.plan_vs_actual(p_id)
+  ),
+  exp_rows as (select * from rows where status in ('matched','unsold')),
+  unp_rows as (select * from rows where status = 'unplanned')
+  select
+    true,
+    coalesce(sum(e.expected_revenue),0),
+    coalesce(sum(e.actual_revenue),0),
+    case when coalesce(sum(e.expected_revenue),0) > 0 then sum(e.actual_revenue)/sum(e.expected_revenue) else null end,
+    coalesce(sum(e.expected_qty),0),
+    coalesce(sum(e.actual_qty),0),
+    case when coalesce(sum(e.expected_qty),0) > 0 then sum(e.actual_qty)/sum(e.expected_qty) else null end,
+    coalesce(sum(e.expected_contribution),0),
+    coalesce(sum(e.actual_contribution),0),
+    case when coalesce(sum(e.expected_contribution),0) > 0 then sum(e.actual_contribution)/sum(e.expected_contribution) else null end,
+    (select coalesce(sum(actual_revenue),0) from unp_rows),
+    (select coalesce(sum(actual_qty),0) from unp_rows),
+    (select coalesce(sum(actual_contribution),0) from unp_rows),
+    (select count(*)::int from rows where status = 'matched'),
+    (select count(*)::int from rows where status = 'unsold'),
+    (select count(*)::int from unp_rows),
+    (coalesce(sum(e.actual_qty),0) > 0),
+    v_mult
+  from exp_rows e;
+end;
+$$;
+
+grant execute on all functions in schema promo to authenticated;


### PR DESCRIPTION
## 개요

S0 로드맵의 **S3 — 달성률 + 캠페인 상세**입니다. 확정 플랜(frozen)과 `promotion_sales`(실적)를 비교해 **매출·수량·공헌이익 달성률**을 산출하고, 캠페인 상세에 SKU 단위 가이드 vs 실적 표 + 전체 달성률 3종 카드 + 옵션 단위 보조 + 계획 외 판매를 표시합니다.

> 1 세션 = 1 PR. `main` 기준 분기. (대시보드/히스토리 달성률은 S4, 목적 슬라이스는 S5 — 미포함)

## 변경 사항

### 마이그레이션 `0008_plan_vs_actual` (additive · `apply_migration` 적용 완료)
함수 3분할 (measurement/summary idiom 계승):
- `promo.plan_vs_actual(uuid)` — per-SKU: 기대(frozen 집계) vs 실적(`promotion_sales` product_id 합산) + 달성률 3종 + `status`(matched/unsold/unplanned). full outer join. **공헌이익은 양쪽 모두 `snapshot.mult` 사용**(비용구조 차 아닌 실제 성과만 반영)
- `promo.plan_vs_actual_options(uuid)` — 옵션 `match_patterns` ↔ `option_info` 정규화(공백·대소문자) 부분일치 자동 매칭 + ach
- `promo.plan_vs_actual_summary(uuid)` — 전체 3종 달성률(**Σactual/Σexpected 금액 가중평균, 계획외 분모 제외**) + 계획외 합계 + status별 카운트 + `quantity_reliable` + `snapshot_mult`. 확정 플랜 없으면 `has_confirmed_plan=false`

**검증**: 임시 확정 플랜으로 populated 경로 확인 — 기대 300,000(10×3×10,000) / matched 3 / unplanned 50(분모 제외) / `quantity_reliable=true`, 옵션 1행. 확인 후 테스트 데이터 **즉시 정리**(plans 0). no-plan 경로도 `has_confirmed_plan=false` 1행 정상.

### 코드
- `lib/types.ts`: `PlanVsActualRow` / `PlanVsActualSummary` / `PlanVsActualOption`
- `PATCH /api/promotions/[id]/plan/options/[optionId]/mapping` — **`match_patterns`만 수정, confirmed 플랜이어도 허용**(사후 분석 메타데이터). 그 외 필드 변경 경로 없음
- 캠페인 상세 `/promotions/[id]` 달성률 자리 구현(`Achievement` 클라이언트 컴포넌트):
  - 확정 플랜 없으면 안내 상태(플랜 확정 링크)
  - **전체 달성률 3종 카드**(매출/수량/공헌). 수량은 `quantity_reliable=false`면 "데이터 부족" 배지
  - **SKU 단위 가이드 vs 실적 표** — status별 스타일(미판매=빨강 0%)
  - **옵션 단위 보조** — 미매칭 "옵션 매핑 필요" 배지 + 경량 수동 매핑(distinct `option_info` 멀티셀렉트 → mapping API → 즉시 갱신)
  - **계획 외 판매** 섹션(접이식) — 측정엔진 후광효과와 구분, 전체 달성률 분모에서 제외

## 설계 결정 반영
- 기준 플랜 = `is_current AND status='confirmed'` 1개
- 기대공헌 = Σ(option_qty×sku_qty×(unit_sale_price×snapshot.mult − frozen_cost)) / 실공헌 = Σrevenue×snapshot.mult − Σcost
- 엣지: 계획외(expected=0)=별도 섹션·분모 제외 / 미판매(actual=0)=0% / 전체=금액 가중평균
- `match_patterns`는 confirmed 예외(메타데이터)

## 검수 (사용자 확인 필요)
- [ ] 확정 플랜 있는 캠페인: SKU 표·3종 카드·전체 달성률(가중평균) 수기 대조
- [ ] 계획외 SKU가 분모 제외+별도 섹션 / 미판매 0%
- [ ] 옵션 자동 매칭 + 수동 매핑 저장(확정 플랜에서도)
- [ ] 확정 플랜 없는 캠페인: 비활성 상태
- [ ] **catch A**: 임의 SKU 원가 기준(VAT±) 대조 — 플랜 `frozen_cost`(=products.cost VAT+) vs `promotion_sales.cost`. 어긋나면 실원가 산식 전환 검토
- [ ] Vercel 프리뷰 Ready

> ⚠️ 로컬 `node_modules` 없어 타입체크는 **Vercel 빌드가 게이트**. SQL은 실데이터로 populated/no-plan 양 경로 검증 완료.

S3 완료, 검수 후 다음 지시 대기.

https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ)_