### PR TITLE
S4: 대시보드·히스토리 달성률 노출

### DIFF
--- a/promo-analytics/app/(dash)/DashCharts.tsx
+++ b/promo-analytics/app/(dash)/DashCharts.tsx
@@ -3,13 +3,65 @@
 import {
   Area,
   AreaChart,
+  Line,
+  LineChart,
+  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
+  YAxis,
 } from "recharts";
 import { wonShort } from "@/lib/format";
 
 const BRAND = "#e76f51";
+
+// 캠페인별 달성률 추세 — 매출/공헌 달성률 라인 (확정 플랜 보유, 시작일 순)
+export function AchievementTrend({
+  data,
+}: {
+  data: { label: string; revenue: number | null; contribution: number | null }[];
+}) {
+  if (data.length === 0)
+    return (
+      <div className="flex h-[150px] items-center justify-center text-sm text-neutral-300">
+        확정 플랜 데이터가 쌓이면 달성률 추세가 표시됩니다.
+      </div>
+    );
+  return (
+    <ResponsiveContainer width="100%" height={170}>
+      <LineChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+        <XAxis
+          dataKey="label"
+          fontSize={10}
+          stroke="#bcb8b3"
+          tickLine={false}
+          axisLine={false}
+          interval="preserveStartEnd"
+        />
+        <YAxis
+          fontSize={10}
+          stroke="#bcb8b3"
+          tickLine={false}
+          axisLine={false}
+          width={38}
+          tickFormatter={(v: number) => `${Math.round(v * 100)}%`}
+        />
+        <ReferenceLine y={1} stroke="#d4d4d4" strokeDasharray="3 3" />
+        <Tooltip
+          formatter={(v, n) =>
+            [
+              v != null ? `${Math.round(Number(v) * 100)}%` : "—",
+              n === "revenue" ? "매출 달성" : "공헌 달성",
+            ] as [string, string]
+          }
+          contentStyle={{ borderRadius: 14, border: "none", boxShadow: "0 8px 24px -8px rgba(0,0,0,.2)", fontSize: 12 }}
+        />
+        <Line type="monotone" dataKey="revenue" stroke={BRAND} strokeWidth={2.5} dot={{ r: 3 }} connectNulls />
+        <Line type="monotone" dataKey="contribution" stroke="#2f2d2b" strokeWidth={2} dot={{ r: 2 }} connectNulls />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}
 
 // 월별 증분 — 오렌지 영역 스파크라인
 export function MonthlyArea({

--- a/promo-analytics/app/(dash)/library/LibraryTable.tsx
+++ b/promo-analytics/app/(dash)/library/LibraryTable.tsx
@@ -17,16 +17,28 @@ export type LibraryRow = {
   halo_share: number | null;
   contribution: number;
   uplift_per_day: number;
+  has_confirmed_plan: boolean;
+  ach_revenue: number | null;
+  ach_contribution: number | null;
+  quantity_reliable: boolean | null;
 };
 
 type Scored = LibraryRow & { score: number };
 
-type SortKey = "score" | "total_uplift" | "uplift_per_day" | "contribution";
+type SortKey =
+  | "score"
+  | "total_uplift"
+  | "uplift_per_day"
+  | "contribution"
+  | "ach_revenue"
+  | "ach_contribution";
 const SORTS: { key: SortKey; label: string }[] = [
   { key: "score", label: "종합점수" },
   { key: "total_uplift", label: "총 기여" },
   { key: "uplift_per_day", label: "일평균 기여" },
   { key: "contribution", label: "공헌이익" },
+  { key: "ach_revenue", label: "매출 달성률" },
+  { key: "ach_contribution", label: "공헌 달성률" },
 ];
 
 export default function LibraryTable({ data }: { data: LibraryRow[] }) {
@@ -126,9 +138,25 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
               <Stat label="총 기여" value={wonShort(r.total_uplift)} bold />
               <Stat label="간접비중" value={pct(r.halo_share)} />
               <Stat label="공헌이익" value={wonShort(r.contribution)} />
-              <Stat label="일평균 기여" value={wonShort(r.uplift_per_day)} />
+              <Stat
+                label="매출 달성"
+                value={
+                  r.has_confirmed_plan
+                    ? r.ach_revenue != null
+                      ? pct(r.ach_revenue, 0)
+                      : "—"
+                    : "플랜없음"
+                }
+              />
+              <Stat
+                label="공헌 달성"
+                value={
+                  r.has_confirmed_plan && r.ach_contribution != null
+                    ? pct(r.ach_contribution, 0)
+                    : "—"
+                }
+              />
               <Stat label="할인" value={r.discount_rate != null ? pct(r.discount_rate, 0) : "—"} />
-              {r.purpose && <Stat label="목적" value={r.purpose} truncate />}
             </dl>
           </li>
         ))}
@@ -141,7 +169,7 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
 
       {/* 데스크톱: 테이블 */}
       <div className="hidden overflow-x-auto rounded-[24px] bg-white card-soft md:block">
-        <table className="w-full min-w-[760px] text-sm">
+        <table className="w-full min-w-[900px] text-sm">
           <thead className="bg-neutral-50 text-left text-xs text-neutral-500">
             <tr>
               <th className="px-4 py-3 text-center font-medium">종합점수</th>
@@ -151,6 +179,8 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
               <th className="px-4 py-3 text-right font-medium">총 기여</th>
               <th className="px-4 py-3 text-right font-medium">간접비중</th>
               <th className="px-4 py-3 text-right font-medium">공헌이익</th>
+              <th className="px-4 py-3 text-right font-medium">매출 달성률</th>
+              <th className="px-4 py-3 text-right font-medium">공헌 달성률</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-neutral-100">
@@ -182,11 +212,20 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
                 <td className="px-4 py-3 text-right font-semibold tabular-nums">{wonShort(r.total_uplift)}</td>
                 <td className="px-4 py-3 text-right tabular-nums text-neutral-600">{pct(r.halo_share)}</td>
                 <td className="px-4 py-3 text-right tabular-nums text-neutral-600">{wonShort(r.contribution)}</td>
+                <td className="px-4 py-3 text-right">
+                  <AchCell v={r.ach_revenue} hasPlan={r.has_confirmed_plan} />
+                  {r.has_confirmed_plan && r.quantity_reliable === false && (
+                    <div className="text-[10px] text-amber-600">수량 데이터부족</div>
+                  )}
+                </td>
+                <td className="px-4 py-3 text-right">
+                  <AchCell v={r.ach_contribution} hasPlan={r.has_confirmed_plan} />
+                </td>
               </tr>
             ))}
             {rows.length === 0 && (
               <tr>
-                <td colSpan={7} className="px-4 py-10 text-center text-neutral-400">
+                <td colSpan={9} className="px-4 py-10 text-center text-neutral-400">
                   조건에 맞는 캠페인이 없습니다.
                 </td>
               </tr>
@@ -250,4 +289,16 @@ function Tag({ children }: { children: React.ReactNode }) {
   return (
     <span className="rounded-full bg-neutral-100 px-2 py-0.5 text-xs text-neutral-600">{children}</span>
   );
+}
+
+function AchCell({ v, hasPlan }: { v: number | null; hasPlan: boolean }) {
+  if (!hasPlan)
+    return (
+      <span className="rounded-full bg-neutral-100 px-2 py-0.5 text-[11px] text-neutral-400">
+        플랜없음
+      </span>
+    );
+  if (v == null) return <span className="text-neutral-300">—</span>;
+  const c = v >= 1 ? "text-green-600" : v < 0.7 ? "text-red-500" : "text-neutral-700";
+  return <span className={`font-medium tabular-nums ${c}`}>{pct(v, 0)}</span>;
 }

--- a/promo-analytics/app/(dash)/library/page.tsx
+++ b/promo-analytics/app/(dash)/library/page.tsx
@@ -1,20 +1,24 @@
 import { createClient } from "@/lib/supabase/server";
-import type { Promotion, PromotionSummary } from "@/lib/types";
+import type { Promotion, PromotionSummary, CampaignAchievement } from "@/lib/types";
 import LibraryTable, { type LibraryRow } from "./LibraryTable";
 
 export const dynamic = "force-dynamic";
 
 export default async function LibraryPage() {
   const supabase = await createClient();
-  const { data: promos } = await supabase
-    .from("promotions")
-    .select("*")
-    .order("start_date", { ascending: false });
+  const [{ data: promos }, { data: achData }] = await Promise.all([
+    supabase.from("promotions").select("*").order("start_date", { ascending: false }),
+    supabase.rpc("campaign_achievements"),
+  ]);
+  const achMap = new Map<string, CampaignAchievement>(
+    ((achData as CampaignAchievement[]) ?? []).map((a) => [a.promotion_id, a]),
+  );
 
   const rows: LibraryRow[] = await Promise.all(
     (promos ?? []).map(async (p: Promotion) => {
       const { data } = await supabase.rpc("promotion_summary", { p_id: p.id });
       const s = (data?.[0] as PromotionSummary) ?? null;
+      const a = achMap.get(p.id) ?? null;
       return {
         id: p.id,
         name: p.name,
@@ -29,6 +33,10 @@ export default async function LibraryPage() {
         contribution: s?.contribution ?? 0,
         uplift_per_day:
           s && s.promo_days > 0 ? s.total_uplift / s.promo_days : 0,
+        has_confirmed_plan: a?.has_confirmed_plan ?? false,
+        ach_revenue: a?.ach_revenue ?? null,
+        ach_contribution: a?.ach_contribution ?? null,
+        quantity_reliable: a?.quantity_reliable ?? null,
       };
     }),
   );

--- a/promo-analytics/app/(dash)/page.tsx
+++ b/promo-analytics/app/(dash)/page.tsx
@@ -1,8 +1,19 @@
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
-import type { Promotion, PromotionSummary, MeasurementRow } from "@/lib/types";
+import type {
+  Promotion,
+  PromotionSummary,
+  MeasurementRow,
+  CampaignAchievement,
+} from "@/lib/types";
 import { won, wonShort, pct } from "@/lib/format";
-import { MonthlyArea, Concentric, Donut, BaselineVsPromo } from "./DashCharts";
+import {
+  MonthlyArea,
+  Concentric,
+  Donut,
+  BaselineVsPromo,
+  AchievementTrend,
+} from "./DashCharts";
 
 export const dynamic = "force-dynamic";
 
@@ -25,12 +36,29 @@ type OverallMetrics = {
 
 export default async function Dashboard() {
   const supabase = await createClient();
-  const [{ data: promos }, { data: overallData }] = await Promise.all([
-    supabase.from("promotions").select("*").order("start_date", { ascending: false }),
-    supabase.rpc("overall_baseline_metrics"),
-  ]);
+  const [{ data: promos }, { data: overallData }, { data: achData }] =
+    await Promise.all([
+      supabase.from("promotions").select("*").order("start_date", { ascending: false }),
+      supabase.rpc("overall_baseline_metrics"),
+      supabase.rpc("campaign_achievements"),
+    ]);
 
   const overall = (overallData?.[0] as OverallMetrics | undefined) ?? null;
+
+  // 달성률 (S4): 확정 플랜 보유 캠페인만, 매출(expected_revenue_total) 가중평균
+  const ach = (achData as CampaignAchievement[]) ?? [];
+  const withPlan = ach.filter((a) => a.has_confirmed_plan);
+  const wAchRevenue = weightedAvg(
+    withPlan.map((a) => ({ v: a.ach_revenue, w: a.expected_revenue_total })),
+  );
+  const wAchContribution = weightedAvg(
+    withPlan.map((a) => ({ v: a.ach_contribution, w: a.expected_revenue_total })),
+  );
+  const achTrend = withPlan.map((a) => ({
+    label: a.start_date.slice(2, 7).replace("-", "."),
+    revenue: a.ach_revenue,
+    contribution: a.ach_contribution,
+  }));
 
   const rows: Row[] = await Promise.all(
     (promos ?? []).map(async (p: Promotion) => {
@@ -163,6 +191,34 @@ export default async function Dashboard() {
         <Kpi label="평균 운영 기간" value={`${avgDuration.toFixed(1)}일`} sub={`캠페인 ${n}건 평균`} />
       </div>
 
+      {/* 달성률 (계획 대비 실적) — S4 */}
+      <div className="mt-3 grid gap-3 sm:mt-4 sm:gap-4 lg:grid-cols-3">
+        <Card>
+          <CardTitle>최근 캠페인 평균 달성률</CardTitle>
+          {withPlan.length > 0 ? (
+            <div className="space-y-3">
+              <AchStat label="매출 달성률 (가중)" v={wAchRevenue} primary />
+              <AchStat label="공헌이익 달성률 (가중)" v={wAchContribution} />
+              <p className="text-xs text-neutral-400">
+                확정 플랜 {withPlan.length}건 기준 · 예상매출 가중평균
+              </p>
+            </div>
+          ) : (
+            <p className="py-6 text-sm text-neutral-400">
+              확정 플랜 데이터 없음 — 캠페인 플랜을 확정하면 달성률이 집계됩니다.
+            </p>
+          )}
+        </Card>
+        <Card className="lg:col-span-2">
+          <CardTitle>캠페인별 달성률 추세</CardTitle>
+          <AchievementTrend data={achTrend} />
+          <p className="mt-1 text-xs text-neutral-400">
+            <span className="text-brand-600">●</span> 매출 달성률{" "}
+            <span className="ml-2 text-neutral-700">●</span> 공헌이익 달성률 · 점선 = 100%(계획 달성)
+          </p>
+        </Card>
+      </div>
+
       {/* 상시 vs 행사 비교 (비교 기준) */}
       <div className="mt-3 grid gap-3 sm:mt-4 sm:gap-4 lg:grid-cols-3">
         <Card className="lg:col-span-2">
@@ -270,6 +326,47 @@ export default async function Dashboard() {
 
 function sum(a: number[]) {
   return a.reduce((x, y) => x + y, 0);
+}
+
+// 금액 가중평균 (v=비율, w=가중치). 유효한(v·w 모두 존재, w>0) 항목만.
+function weightedAvg(
+  items: { v: number | null; w: number | null }[],
+): number | null {
+  let num = 0;
+  let den = 0;
+  for (const { v, w } of items) {
+    if (v == null || w == null || w <= 0) continue;
+    num += v * w;
+    den += w;
+  }
+  return den > 0 ? num / den : null;
+}
+
+function AchStat({
+  label,
+  v,
+  primary,
+}: {
+  label: string;
+  v: number | null;
+  primary?: boolean;
+}) {
+  const color =
+    v == null
+      ? "text-neutral-300"
+      : v >= 1
+        ? "text-green-600"
+        : v < 0.7
+          ? "text-red-500"
+          : "text-neutral-900";
+  return (
+    <div>
+      <div className="text-xs text-neutral-400">{label}</div>
+      <div className={`mt-0.5 font-bold tabular-nums ${primary ? "text-3xl" : "text-2xl"} ${color}`}>
+        {v != null ? pct(v, 0) : "—"}
+      </div>
+    </div>
+  );
 }
 
 function Kpi({

--- a/promo-analytics/lib/types.ts
+++ b/promo-analytics/lib/types.ts
@@ -231,3 +231,21 @@ export type PlanVsActualOption = {
   actual_qty: number;
   ach_revenue: number | null;
 };
+
+// S4: 캠페인별 달성률 (campaign_achievements 함수 반환)
+export type CampaignAchievement = {
+  promotion_id: string;
+  name: string;
+  start_date: string;
+  end_date: string;
+  confirmed_at: string | null;
+  has_confirmed_plan: boolean;
+  ach_revenue: number | null;
+  ach_qty: number | null;
+  ach_contribution: number | null;
+  expected_revenue_total: number | null;
+  actual_revenue_total: number | null;
+  expected_contribution_total: number | null;
+  actual_contribution_total: number | null;
+  quantity_reliable: boolean | null;
+};

--- a/promo-analytics/supabase/migrations/0009_campaign_achievements.sql
+++ b/promo-analytics/supabase/migrations/0009_campaign_achievements.sql
@@ -1,0 +1,38 @@
+-- 0009: 캠페인별 달성률 단일 소스 (S4) — 대시보드/히스토리 공용
+-- plan_vs_actual_summary 로직 재사용(중복 SQL 지양). 확정 플랜 없는 캠페인도 행 반환.
+create or replace function promo.campaign_achievements()
+returns table (
+  promotion_id uuid,
+  name text,
+  start_date date,
+  end_date date,
+  confirmed_at timestamptz,
+  has_confirmed_plan boolean,
+  ach_revenue numeric,
+  ach_qty numeric,
+  ach_contribution numeric,
+  expected_revenue_total numeric,
+  actual_revenue_total numeric,
+  expected_contribution_total numeric,
+  actual_contribution_total numeric,
+  quantity_reliable boolean
+)
+language sql
+stable
+set search_path = ''
+as $$
+  select
+    p.id, p.name, p.start_date, p.end_date, cp.confirmed_at,
+    coalesce(s.has_confirmed_plan, false),
+    s.ach_revenue, s.ach_qty, s.ach_contribution,
+    s.expected_revenue_total, s.actual_revenue_total,
+    s.expected_contribution_total, s.actual_contribution_total,
+    s.quantity_reliable
+  from promo.promotions p
+  left join lateral (select * from promo.plan_vs_actual_summary(p.id)) s on true
+  left join promo.campaign_plans cp
+    on cp.promotion_id = p.id and cp.is_current and cp.status = 'confirmed'
+  order by p.start_date;
+$$;
+
+grant execute on all functions in schema promo to authenticated;


### PR DESCRIPTION
## 개요

S0 로드맵의 **S4 — 대시보드·히스토리 달성률 노출**입니다. S3의 캠페인별 달성률을 **대시보드(평균 달성률 KPI + 추세)** 와 **히스토리 목록(달성률 컬럼/배지)** 으로 끌어올립니다. 확정 플랜이 있는 캠페인만 집계 대상.

> 1 세션 = 1 PR. `main` 기준 분기. 달성률 계산은 **S3 함수 단일 출처 재사용**(S4에서 재구현 없음). (목적 슬라이스 S5·예측 통합 S6 미포함)

## 변경 사항

### 마이그레이션 `0009_campaign_achievements` (additive · `apply_migration` 적용 완료)
- `promo.campaign_achievements()` — 확정 플랜 보유 캠페인 달성률 단일 소스. 내부적으로 `plan_vs_actual_summary`를 lateral join으로 재사용(SQL 중복 없음). 확정 플랜 없는 캠페인도 행 반환(`has_confirmed_plan=false`)
- **검증**: 22개 캠페인 반환, 현재 확정 플랜 0건 → 전부 `has_confirmed_plan=false` 정상

### 대시보드 `/` (`page.tsx` + `DashCharts.tsx`)
- **"최근 캠페인 평균 달성률" 카드**: 매출·공헌 **가중평균**(`expected_revenue_total` 가중 — 단순평균 금지, 소형 캠페인 과대반영 방지) + 대상 캠페인 수
- **`AchievementTrend` 차트**: 캠페인별 매출/공헌 달성률 라인(시작일 순, recharts, 100% 기준선). 기존 Bento 톤 유지
- 확정 플랜 0건이면 "확정 플랜 데이터 없음"

### 히스토리 `/library`
- 데스크톱 테이블: **매출/공헌 달성률 컬럼 + 정렬** + 배지(`플랜없음`=has_confirmed_plan false / `수량 데이터부족`=quantity_reliable false). 기존 점수·목적·간접비중 컬럼 공존
- 모바일 카드: 매출/공헌 달성 stat

### 타입
- `lib/types.ts`: `CampaignAchievement`

## 설계 결정 반영
- 단일 소스 함수, 가중평균(단순평균 X), 집계 대상=`has_confirmed_plan`, 추세=시작일 순, 수량 신뢰도 배지, 달성률 재계산 금지(S3 함수 재사용)

## 검수 (사용자 확인 필요)
- [ ] (확정 플랜이 생긴 뒤) 평균이 가중평균인지 수기 대조 — 큰 캠페인 영향 큼
- [ ] 플랜 없는 캠페인이 평균·추세에서 제외 + 히스토리 "플랜없음" 배지
- [ ] 수량 데이터 부족 캠페인 배지
- [ ] 히스토리 달성률 정렬 동작
- [ ] Vercel 프리뷰 Ready

> ⚠️ 현재 DB에 확정 플랜 0건이라 화면상 빈 상태가 기본입니다(데이터 의존). 함수는 22캠페인 반환 검증 완료. 로컬 `node_modules` 없어 타입체크는 **Vercel 빌드가 게이트**.

S4 완료, 검수 후 다음 지시 대기.

https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ)_