### PR TITLE
S5.1: 목적 가중 스키마 + 가중 편집 + 적합도 함수

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/edit/EditForm.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/edit/EditForm.tsx
@@ -13,11 +13,13 @@ export default function EditForm({
   products,
   initialMainIds,
   options,
+  initialWeights,
 }: {
   promo: Promotion;
   products: ProductItem[];
   initialMainIds: string[];
   options: Options;
+  initialWeights: Record<string, number>;
 }) {
   const router = useRouter();
   const [name, setName] = useState(promo.name);
@@ -28,6 +30,8 @@ export default function EditForm({
   const [purposes, setPurposes] = useState<string[]>(
     promo.purposes ?? (promo.purpose ? [promo.purpose] : []),
   );
+  const [purposeWeights, setPurposeWeights] =
+    useState<Record<string, number>>(initialWeights);
   const [startDate, setStartDate] = useState(promo.start_date ?? "");
   const [endDate, setEndDate] = useState(promo.end_date ?? "");
   const [discountRate, setDiscountRate] = useState(
@@ -53,6 +57,12 @@ export default function EditForm({
   function togglePurpose(t: string) {
     setPurposes((p) => (p.includes(t) ? p.filter((x) => x !== t) : [...p, t]));
   }
+  // 목적 가중치: 저장값 우선, 없으면 주목적(0번)=1.0 / 보조=0.0
+  const weightOf = (p: string, i: number) => purposeWeights[p] ?? (i === 0 ? 1 : 0);
+  function setWeight(p: string, v: number) {
+    setPurposeWeights((w) => ({ ...w, [p]: Number.isNaN(v) ? 0 : v }));
+  }
+  const weightSum = purposes.reduce((s, p, i) => s + weightOf(p, i), 0);
   function toggleMain(id: string) {
     setMainIds((m) => (m.includes(id) ? m.filter((x) => x !== id) : [...m, id]));
   }
@@ -84,6 +94,7 @@ export default function EditForm({
         season_tag: seasonTag || null,
         purposes,
         purpose: purposes[0] ?? null,
+        purpose_weights: purposes.map((p, i) => ({ purpose: p, weight: weightOf(p, i) })),
         start_date: startDate,
         end_date: endDate,
         benefits: Object.keys(benefits).length ? benefits : null,
@@ -149,6 +160,36 @@ export default function EditForm({
             브랜딩 + 세일즈처럼 섞인 캠페인도 모두 체크해주세요. ‘설정 → 캠페인 목적’에서 항목을 추가할 수 있어요.
           </p>
         </Field>
+
+        {purposes.length > 0 && (
+          <Field label="목적 가중치 (집계·랭킹·예측에 사용)">
+            <div className="space-y-2 rounded-xl border border-neutral-200 p-3">
+              {purposes.map((p, i) => (
+                <div key={p} className="flex items-center gap-3">
+                  <span className="w-36 shrink-0 truncate text-sm text-neutral-700">{p}</span>
+                  <input
+                    type="number"
+                    step="0.1"
+                    min="0"
+                    max="1"
+                    value={weightOf(p, i)}
+                    onChange={(e) => setWeight(p, Number(e.target.value))}
+                    className="w-24 rounded-lg border border-neutral-200 px-2 py-1 text-right text-sm focus:border-brand-400 focus:outline-none"
+                  />
+                  {i === 0 && (
+                    <span className="rounded-full bg-brand-50 px-2 py-0.5 text-[11px] text-brand-600">
+                      주목적
+                    </span>
+                  )}
+                </div>
+              ))}
+              <p className="text-xs text-neutral-400">
+                합계 {weightSum.toFixed(1)} · 기본은 주목적 1.0 / 보조 0.0(주목적 귀속, 중복
+                카운트 없음). 보조 목적에도 성과를 나눠 귀속하려면 0.7 / 0.3 처럼 조정하세요.
+              </p>
+            </div>
+          </Field>
+        )}
 
         <Field label="시즈널리티">
           <SingleChips options={options.seasonalities} value={seasonTag} onChange={setSeasonTag} />

--- a/promo-analytics/app/(dash)/promotions/[id]/edit/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/edit/page.tsx
@@ -48,6 +48,15 @@ export default async function EditPromotion({
   const mainIds = (mains ?? []).map((m) => m.product_id);
   const options = await loadOptions(supabase);
 
+  // 목적 가중치 (S5) — 저장된 값 로드
+  const { data: weightRows } = await supabase
+    .from("promotion_purpose_weights")
+    .select("purpose, weight")
+    .eq("promotion_id", id);
+  const initialWeights: Record<string, number> = {};
+  for (const w of weightRows ?? [])
+    initialWeights[w.purpose as string] = Number(w.weight);
+
   return (
     <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
       <EditForm
@@ -55,6 +64,7 @@ export default async function EditPromotion({
         products={products}
         initialMainIds={mainIds}
         options={options}
+        initialWeights={initialWeights}
       />
     </div>
   );

--- a/promo-analytics/app/api/promotions/[id]/route.ts
+++ b/promo-analytics/app/api/promotions/[id]/route.ts
@@ -12,8 +12,9 @@ export async function PATCH(
     const body = await req.json();
     const supabase = await createClient();
 
-    const { main_product_ids, ...fields } = body as {
+    const { main_product_ids, purpose_weights, ...fields } = body as {
       main_product_ids?: string[];
+      purpose_weights?: { purpose: string; weight: number }[];
       [k: string]: unknown;
     };
 
@@ -57,6 +58,27 @@ export async function PATCH(
               product_id: pid,
             })),
           );
+        if (error) throw error;
+      }
+    }
+
+    // 목적 가중치 재설정 (전체 교체) — S5
+    if (Array.isArray(purpose_weights)) {
+      await supabase
+        .from("promotion_purpose_weights")
+        .delete()
+        .eq("promotion_id", id);
+      const rows = purpose_weights
+        .filter((w) => w && typeof w.purpose === "string" && w.purpose.trim())
+        .map((w) => ({
+          promotion_id: id,
+          purpose: w.purpose.trim(),
+          weight: Number(w.weight) || 0,
+        }));
+      if (rows.length > 0) {
+        const { error } = await supabase
+          .from("promotion_purpose_weights")
+          .insert(rows);
         if (error) throw error;
       }
     }

--- a/promo-analytics/lib/constants.ts
+++ b/promo-analytics/lib/constants.ts
@@ -29,3 +29,30 @@ export const PURPOSE_TAGS = [
   "리뉴얼",
   "회원 활성화",
 ];
+
+// 목적별 적합도(purpose_fit) 대표 지표 — 단일 출처(편집 용이). purpose_fit() SQL과 의미 일치.
+export type PurposeFitMeta = {
+  label: string;
+  source: string;
+  quantityDependent?: boolean; // 수량 의존 → "데이터 부족" 배지 대상
+};
+export const PURPOSE_FIT_METRIC: Record<string, PurposeFitMeta> = {
+  세일즈: { label: "증분율 (uplift %)", source: "promotion_summary" },
+  재고소진: {
+    label: "수량 달성률",
+    source: "plan_vs_actual_summary.ach_qty",
+    quantityDependent: true,
+  },
+  브랜딩: {
+    label: "구매 건수",
+    source: "promotion_sales.order_count",
+    quantityDependent: true,
+  },
+};
+export const DEFAULT_PURPOSE_FIT: PurposeFitMeta = {
+  label: "증분율 (uplift %)",
+  source: "promotion_summary (fallback)",
+};
+export function purposeFitMeta(purpose: string): PurposeFitMeta {
+  return PURPOSE_FIT_METRIC[purpose] ?? DEFAULT_PURPOSE_FIT;
+}

--- a/promo-analytics/lib/types.ts
+++ b/promo-analytics/lib/types.ts
@@ -232,6 +232,15 @@ export type PlanVsActualOption = {
   ach_revenue: number | null;
 };
 
+// S5: 목적 가중 / 적합도
+export type PurposeWeight = { purpose: string; weight: number };
+export type PurposeFit = {
+  purpose: string;
+  fit_metric_raw: number | null;
+  fit_score_0_100: number | null;
+  data_reliable: boolean;
+};
+
 // S4: 캠페인별 달성률 (campaign_achievements 함수 반환)
 export type CampaignAchievement = {
   promotion_id: string;

--- a/promo-analytics/supabase/migrations/0010_purpose_weights.sql
+++ b/promo-analytics/supabase/migrations/0010_purpose_weights.sql
@@ -1,0 +1,98 @@
+-- 0010: 목적 가중 (S5.1) — promotion_purpose_weights + effective_purpose_weights + purpose_fit
+-- 목적별 기여 = Σ(metric × weight). 기본: 주목적(purposes[1])=1.0, 보조=0.0(편집 가능).
+
+create table if not exists promo.promotion_purpose_weights (
+  promotion_id uuid not null references promo.promotions(id) on delete cascade,
+  purpose      text not null,
+  weight       numeric not null default 0,
+  primary key (promotion_id, purpose)
+);
+
+alter table promo.promotion_purpose_weights enable row level security;
+drop policy if exists promotion_purpose_weights_auth on promo.promotion_purpose_weights;
+create policy promotion_purpose_weights_auth on promo.promotion_purpose_weights
+  for all to authenticated using (true) with check (true);
+
+-- 유효 가중치: 저장된 weight>0 행이 있으면 그것, 없으면 주목적(purposes[1]→purpose) = 1.0 폴백
+create or replace function promo.effective_purpose_weights(p_id uuid)
+returns table (purpose text, weight numeric)
+language sql
+stable
+set search_path = ''
+as $$
+  with saved as (
+    select purpose, weight
+    from promo.promotion_purpose_weights
+    where promotion_id = p_id and weight <> 0
+  )
+  select purpose, weight from saved
+  union all
+  select coalesce((pr.purposes)[1], pr.purpose) as purpose, 1.0 as weight
+  from promo.promotions pr
+  where pr.id = p_id
+    and not exists (select 1 from saved)
+    and coalesce((pr.purposes)[1], pr.purpose) is not null;
+$$;
+
+-- 목적 적합도: 캠페인의 각 목적에 대해 대표지표 raw + 같은목적 모집단 min-max 정규화(0~100) + 신뢰도
+create or replace function promo.purpose_fit(p_id uuid)
+returns table (
+  purpose text,
+  fit_metric_raw numeric,
+  fit_score_0_100 numeric,
+  data_reliable boolean
+)
+language sql
+stable
+set search_path = ''
+as $$
+  with base as (
+    select pr.id as promotion_id,
+      (select case when (s.actual_revenue - s.total_uplift) > 0
+                then s.total_uplift / (s.actual_revenue - s.total_uplift) else null end
+       from promo.promotion_summary(pr.id) s) as uplift_pct,
+      (select ach_qty from promo.plan_vs_actual_summary(pr.id)) as ach_qty,
+      (select quantity_reliable from promo.plan_vs_actual_summary(pr.id)) as qty_reliable,
+      (select coalesce(sum(ps.order_count),0) from promo.promotion_sales ps where ps.promotion_id = pr.id) as order_cnt
+    from promo.promotions pr
+  ),
+  cp as (
+    select pr.id as promotion_id, w.purpose
+    from promo.promotions pr
+    cross join lateral promo.effective_purpose_weights(pr.id) w
+    where w.weight > 0
+  ),
+  metric as (
+    select cp.promotion_id, cp.purpose,
+      case
+        when cp.purpose = '재고소진' then b.ach_qty
+        when cp.purpose = '브랜딩'   then b.order_cnt
+        else b.uplift_pct
+      end as raw,
+      case
+        when cp.purpose = '재고소진' then coalesce(b.qty_reliable, false)
+        when cp.purpose = '브랜딩'   then (b.order_cnt > 0)
+        else true
+      end as reliable
+    from cp join base b on b.promotion_id = cp.promotion_id
+  ),
+  bounds as (
+    select purpose, min(raw) as mn, max(raw) as mx
+    from metric where raw is not null
+    group by purpose
+  )
+  select m.purpose, m.raw,
+    case
+      when bd.mx > bd.mn then round((m.raw - bd.mn) / (bd.mx - bd.mn) * 100, 1)
+      when m.raw is not null then 100
+      else null
+    end as fit_score_0_100,
+    m.reliable
+  from metric m
+  left join bounds bd on bd.purpose = m.purpose
+  where m.promotion_id = p_id
+  order by m.purpose;
+$$;
+
+grant all on all tables in schema promo to authenticated;
+grant execute on all functions in schema promo to authenticated;


### PR DESCRIPTION
## 개요

S5(목적 슬라이스)의 **하위 1번 — 5.1: 목적 가중 스키마 + 가중 편집 + 적합도 함수**입니다. 이후 5.2~5.6(대시보드·히스토리·상세·시뮬레이터·추천)이 의존하는 토대입니다.

> S5는 5.1~5.6으로 분할, 각 하위 = 1 PR. 이번 PR = **5.1만**. (5.1 완료 전 5.2~5.6 착수 금지)

## 변경 사항

### 마이그레이션 `0010_purpose_weights` (additive · `apply_migration` 적용 완료)
- `promo.promotion_purpose_weights(promotion_id, purpose, weight)` + RLS
- `promo.effective_purpose_weights(p_id)` — 저장된 `weight>0` 행 있으면 사용, 없으면 **주목적(`purposes[1]`→`purpose`) = 1.0 폴백**
- `promo.purpose_fit(p_id)` — 목적별 대표지표 raw + **같은 목적 모집단 min-max 정규화(0~100)** + `data_reliable`. 세일즈/기타=증분율, 재고소진=수량 달성률, 브랜딩=구매 건수
- **검증**: 폴백(legacy `purpose` 단일값에도 동작)·정규화·purpose_fit 반환 확인

### 코드
- `lib/constants.ts`: `PURPOSE_FIT_METRIC` 단일 출처(편집 용이) + `purposeFitMeta()`. 수량 의존 지표 플래그(`quantityDependent`)
- `lib/types.ts`: `PurposeWeight` / `PurposeFit`
- `PATCH /api/promotions/[id]`: `purpose_weights` 전체 교체 저장
- `/promotions/[id]/edit`: 선택한 목적별 **가중치 입력 UI**(주목적 1.0 / 보조 0.0 기본, 합계 표기). 저장 시 함께 반영

## 설계 결정 반영
- 가중 모델 `Σ(metric × weight)`, 기본 주목적 귀속(중복 카운트 없음), 보조 가중은 0.7/0.3 등 조정 가능
- fit 매핑 constants 단일 출처, 수량 의존 배지 대상 표시(5.2+에서 사용)
- 신규 비중 미구현(데이터 부재)

## 검수
- [ ] 편집 화면에서 목적 선택 → 가중치 입력 → 저장 → 재진입 시 값 유지
- [ ] (보조 가중 0.7/0.3 저장 시) `effective_purpose_weights` 반영
- [ ] Vercel 프리뷰 Ready

> ⚠️ 로컬 `node_modules` 없어 타입체크는 **Vercel 빌드가 게이트**. SQL은 실데이터로 폴백/정규화 검증 완료.

S5.1 완료, 검수 후 다음(5.2) 지시 대기.

https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ)_