### PR TITLE
S5.2: 대시보드 목적 슬라이스

### DIFF
--- a/promo-analytics/app/(dash)/DashCharts.tsx
+++ b/promo-analytics/app/(dash)/DashCharts.tsx
@@ -15,6 +15,80 @@ import { wonShort } from "@/lib/format";
 
 const BRAND = "#e76f51";
 
+// 목적별 비중 바 (가중 기여매출/공헌) — value 점유율
+export function PurposeShareBars({
+  data,
+}: {
+  data: { purpose: string; value: number }[];
+}) {
+  const sorted = data.filter((d) => d.value > 0).sort((a, b) => b.value - a.value);
+  const total = sorted.reduce((s, d) => s + d.value, 0);
+  const items = sorted.slice(0, 8);
+  if (items.length === 0)
+    return <div className="py-6 text-sm text-neutral-300">데이터가 없습니다.</div>;
+  return (
+    <div className="space-y-2.5">
+      {items.map((d) => {
+        const share = total > 0 ? d.value / total : 0;
+        return (
+          <div key={d.purpose}>
+            <div className="mb-1 flex items-center justify-between gap-2 text-xs">
+              <span className="min-w-0 flex-1 truncate font-medium text-neutral-700">
+                {d.purpose}
+              </span>
+              <span className="shrink-0 text-neutral-500">
+                {wonShort(d.value)} · {Math.round(share * 100)}%
+              </span>
+            </div>
+            <div className="h-2.5 overflow-hidden rounded-full bg-neutral-100">
+              <div className="h-full rounded-full bg-brand-500" style={{ width: `${share * 100}%` }} />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// 목적별 평균 적합도 바 (0~100) + 데이터부족 배지
+export function PurposeFitBars({
+  data,
+}: {
+  data: { purpose: string; score: number | null; reliable: boolean }[];
+}) {
+  const items = data
+    .filter((d) => d.score != null)
+    .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+    .slice(0, 8);
+  if (items.length === 0)
+    return <div className="py-6 text-sm text-neutral-300">적합도 데이터가 없습니다.</div>;
+  return (
+    <div className="space-y-2.5">
+      {items.map((d) => {
+        const s = Math.max(0, Math.min(100, d.score ?? 0));
+        return (
+          <div key={d.purpose}>
+            <div className="mb-1 flex items-center justify-between gap-2 text-xs">
+              <span className="min-w-0 flex-1 truncate font-medium text-neutral-700">
+                {d.purpose}
+                {!d.reliable && (
+                  <span className="ml-1 rounded bg-amber-100 px-1 text-[10px] text-amber-700">
+                    데이터 부족
+                  </span>
+                )}
+              </span>
+              <span className="shrink-0 tabular-nums text-neutral-500">{Math.round(s)}</span>
+            </div>
+            <div className="h-2.5 overflow-hidden rounded-full bg-neutral-100">
+              <div className="h-full rounded-full bg-neutral-700" style={{ width: `${s}%` }} />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 // 캠페인별 달성률 추세 — 매출/공헌 달성률 라인 (확정 플랜 보유, 시작일 순)
 export function AchievementTrend({
   data,

--- a/promo-analytics/app/(dash)/page.tsx
+++ b/promo-analytics/app/(dash)/page.tsx
@@ -5,6 +5,7 @@ import type {
   PromotionSummary,
   MeasurementRow,
   CampaignAchievement,
+  PurposeMetric,
 } from "@/lib/types";
 import { won, wonShort, pct } from "@/lib/format";
 import {
@@ -13,6 +14,8 @@ import {
   Donut,
   BaselineVsPromo,
   AchievementTrend,
+  PurposeShareBars,
+  PurposeFitBars,
 } from "./DashCharts";
 
 export const dynamic = "force-dynamic";
@@ -36,14 +39,35 @@ type OverallMetrics = {
 
 export default async function Dashboard() {
   const supabase = await createClient();
-  const [{ data: promos }, { data: overallData }, { data: achData }] =
-    await Promise.all([
-      supabase.from("promotions").select("*").order("start_date", { ascending: false }),
-      supabase.rpc("overall_baseline_metrics"),
-      supabase.rpc("campaign_achievements"),
-    ]);
+  const [
+    { data: promos },
+    { data: overallData },
+    { data: achData },
+    { data: pmData },
+  ] = await Promise.all([
+    supabase.from("promotions").select("*").order("start_date", { ascending: false }),
+    supabase.rpc("overall_baseline_metrics"),
+    supabase.rpc("campaign_achievements"),
+    supabase.rpc("purpose_metrics"),
+  ]);
 
   const overall = (overallData?.[0] as OverallMetrics | undefined) ?? null;
+
+  // 목적 슬라이스 (S5.2): 목적별 가중 기여매출/공헌 + 평균 적합도
+  const pm = (pmData as PurposeMetric[]) ?? [];
+  const purposeUplift = pm.map((p) => ({
+    purpose: p.purpose,
+    value: Number(p.weighted_uplift) || 0,
+  }));
+  const purposeContribution = pm.map((p) => ({
+    purpose: p.purpose,
+    value: Number(p.weighted_contribution) || 0,
+  }));
+  const purposeFit = pm.map((p) => ({
+    purpose: p.purpose,
+    score: p.avg_fit_score != null ? Number(p.avg_fit_score) : null,
+    reliable: p.data_reliable,
+  }));
 
   // 달성률 (S4): 확정 플랜 보유 캠페인만, 매출(expected_revenue_total) 가중평균
   const ach = (achData as CampaignAchievement[]) ?? [];
@@ -218,6 +242,27 @@ export default async function Dashboard() {
           </p>
         </Card>
       </div>
+
+      {/* 목적 슬라이스 (S5.2) */}
+      {pm.length > 0 && (
+        <div className="mt-3 grid gap-3 sm:mt-4 sm:gap-4 lg:grid-cols-3">
+          <Card>
+            <CardTitle>목적별 기여 매출 비중</CardTitle>
+            <PurposeShareBars data={purposeUplift} />
+          </Card>
+          <Card>
+            <CardTitle>목적별 공헌이익 비중</CardTitle>
+            <PurposeShareBars data={purposeContribution} />
+          </Card>
+          <Card>
+            <CardTitle>목적별 평균 적합도</CardTitle>
+            <PurposeFitBars data={purposeFit} />
+            <p className="mt-2 text-xs text-neutral-400">
+              같은 목적 캠페인 간 상대 점수(0~100) · 가중치는 캠페인 편집에서 조정
+            </p>
+          </Card>
+        </div>
+      )}
 
       {/* 상시 vs 행사 비교 (비교 기준) */}
       <div className="mt-3 grid gap-3 sm:mt-4 sm:gap-4 lg:grid-cols-3">

--- a/promo-analytics/lib/types.ts
+++ b/promo-analytics/lib/types.ts
@@ -234,6 +234,14 @@ export type PlanVsActualOption = {
 
 // S5: 목적 가중 / 적합도
 export type PurposeWeight = { purpose: string; weight: number };
+export type PurposeMetric = {
+  purpose: string;
+  weighted_uplift: number;
+  weighted_contribution: number;
+  campaign_count: number;
+  avg_fit_score: number | null;
+  data_reliable: boolean;
+};
 export type PurposeFit = {
   purpose: string;
   fit_metric_raw: number | null;

--- a/promo-analytics/supabase/migrations/0011_purpose_metrics.sql
+++ b/promo-analytics/supabase/migrations/0011_purpose_metrics.sql
@@ -1,0 +1,43 @@
+-- 0011: 목적별 가중 집계 (S5.2) — 대시보드/히스토리 공용
+-- 목적별 값 = Σ_campaigns(metric × effective_weight). 단일목적(주목적 1.0)=100% 귀속(중복 0).
+create or replace function promo.purpose_metrics()
+returns table (
+  purpose text,
+  weighted_uplift numeric,
+  weighted_contribution numeric,
+  campaign_count int,
+  avg_fit_score numeric,
+  data_reliable boolean
+)
+language sql
+stable
+set search_path = ''
+as $$
+  with cw as (
+    select w.purpose, pr.id as promotion_id, w.weight,
+           coalesce(s.total_uplift, 0)  as uplift,
+           coalesce(s.contribution, 0)  as contribution
+    from promo.promotions pr
+    cross join lateral promo.effective_purpose_weights(pr.id) w
+    left join lateral promo.promotion_summary(pr.id) s on true
+    where w.weight > 0
+  ),
+  fit as (
+    select pr.id as promotion_id, f.purpose, f.fit_score_0_100, f.data_reliable
+    from promo.promotions pr
+    cross join lateral promo.purpose_fit(pr.id) f
+  )
+  select
+    cw.purpose,
+    sum(cw.uplift * cw.weight)        as weighted_uplift,
+    sum(cw.contribution * cw.weight)  as weighted_contribution,
+    count(distinct cw.promotion_id)::int as campaign_count,
+    avg(fit.fit_score_0_100)          as avg_fit_score,
+    bool_and(coalesce(fit.data_reliable, true)) as data_reliable
+  from cw
+  left join fit on fit.promotion_id = cw.promotion_id and fit.purpose = cw.purpose
+  group by cw.purpose
+  order by sum(cw.uplift * cw.weight) desc nulls last;
+$$;
+
+grant execute on all functions in schema promo to authenticated;


### PR DESCRIPTION
## 개요

S5의 **하위 2번 — 5.2: 대시보드 목적 슬라이스**입니다. 5.1의 가중·적합도 함수를 소비해 목적별 가중 집계를 대시보드에 노출합니다.

> S5 분할의 5.2만. (5.3~5.6·S6 미포함)

## 변경 사항

### 마이그레이션 `0011_purpose_metrics` (additive · `apply_migration` 적용 완료)
- `promo.purpose_metrics()` — 목적별 `Σ(metric × effective_weight)`: `weighted_uplift` / `weighted_contribution` / `campaign_count` / `avg_fit_score` / `data_reliable`. `effective_purpose_weights·promotion_summary·purpose_fit`를 lateral로 가중집계(화면 재계산 없음, 5.3도 재사용 가능)
- **검증**: 단일 목적 캠페인 `campaign_count=1` → 그 목적에 **100% 귀속(중복 0)**, "신제품 런칭" 3건은 정규화 동작. (현재 대부분 legacy free-text `purpose`라 그대로 그룹화 — 편집에서 표준 목적 설정 시 통합됨)

### 코드
- `lib/types.ts`: `PurposeMetric`
- `DashCharts.tsx`: `PurposeShareBars`(목적별 비중 바, top 8 · 점유율은 전체 합 기준) + `PurposeFitBars`(평균 적합도 0~100 + "데이터 부족" 배지)
- `app/(dash)/page.tsx`: **목적별 기여매출 비중 · 공헌이익 비중 카드 + 평균 적합도 카드**. 기존 Bento 톤 유지. 목적 데이터 없으면 섹션 숨김

## 설계 결정 반영
- `Σ(metric × weight)` 단일 출처(함수), 단일목적 100% 귀속, 수량 의존(적합도) 데이터부족 배지, 신규비중 미구현

## 검수
- [ ] 목적별 비중 카드·적합도 카드 표시
- [ ] 단일 목적 캠페인 100% 귀속(중복 0)
- [ ] (표준 목적 설정·가중 조정 시) 집계 반영
- [ ] Vercel 프리뷰 Ready

> ⚠️ 타입체크는 Vercel 빌드가 게이트. SQL은 실데이터 검증 완료.

S5.2 완료, 검수 후 5.3 대기.

https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ)_