### PR TITLE
S5.3: 히스토리 목적 슬라이스

### DIFF
--- a/promo-analytics/app/(dash)/library/LibraryTable.tsx
+++ b/promo-analytics/app/(dash)/library/LibraryTable.tsx
@@ -21,6 +21,7 @@ export type LibraryRow = {
   ach_revenue: number | null;
   ach_contribution: number | null;
   quantity_reliable: boolean | null;
+  fits: { purpose: string; score: number | null; reliable: boolean }[];
 };
 
 type Scored = LibraryRow & { score: number };
@@ -31,7 +32,8 @@ type SortKey =
   | "uplift_per_day"
   | "contribution"
   | "ach_revenue"
-  | "ach_contribution";
+  | "ach_contribution"
+  | "purpose_fit";
 const SORTS: { key: SortKey; label: string }[] = [
   { key: "score", label: "종합점수" },
   { key: "total_uplift", label: "총 기여" },
@@ -39,12 +41,23 @@ const SORTS: { key: SortKey; label: string }[] = [
   { key: "contribution", label: "공헌이익" },
   { key: "ach_revenue", label: "매출 달성률" },
   { key: "ach_contribution", label: "공헌 달성률" },
+  { key: "purpose_fit", label: "목적 적합도" },
 ];
+
+// 행의 적합도 점수 (목적 필터 활성 시 그 목적들 중 max, 아니면 전체 max)
+function rowFitScore(r: LibraryRow, filter: string[]): number {
+  const pool = filter.length
+    ? r.fits.filter((f) => filter.includes(f.purpose))
+    : r.fits;
+  const scores = pool.map((f) => f.score).filter((s): s is number => s != null);
+  return scores.length ? Math.max(...scores) : -1;
+}
 
 export default function LibraryTable({ data }: { data: LibraryRow[] }) {
   const [type, setType] = useState("");
   const [season, setSeason] = useState("");
   const [sort, setSort] = useState<SortKey>("score");
+  const [purposeFilter, setPurposeFilter] = useState<string[]>([]);
 
   const types = useMemo(
     () => [...new Set(data.map((d) => d.promo_type).filter(Boolean) as string[])],
@@ -54,6 +67,14 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
     () => [...new Set(data.map((d) => d.season_tag).filter(Boolean) as string[])],
     [data],
   );
+  const purposes = useMemo(
+    () => [...new Set(data.flatMap((d) => d.fits.map((f) => f.purpose)))],
+    [data],
+  );
+  const togglePurpose = (p: string) =>
+    setPurposeFilter((prev) =>
+      prev.includes(p) ? prev.filter((x) => x !== p) : [...prev, p],
+    );
 
   // 종합 점수 = 공헌이익 0.4 · 일평균 기여 0.3 · 효율(기여/할인) 0.2 · 간접비중 0.1
   const scored = useMemo<Scored[]>(() => {
@@ -73,11 +94,23 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
   }, [data]);
 
   const rows = useMemo(() => {
-    return scored
+    const filtered = scored
       .filter((d) => (type ? d.promo_type === type : true))
       .filter((d) => (season ? d.season_tag === season : true))
-      .sort((a, b) => (b[sort] ?? 0) - (a[sort] ?? 0));
-  }, [scored, type, season, sort]);
+      .filter((d) =>
+        purposeFilter.length
+          ? d.fits.some((f) => purposeFilter.includes(f.purpose))
+          : true,
+      );
+    if (sort === "purpose_fit") {
+      return [...filtered].sort(
+        (a, b) => rowFitScore(b, purposeFilter) - rowFitScore(a, purposeFilter),
+      );
+    }
+    return filtered.sort(
+      (a, b) => ((b[sort] as number) ?? 0) - ((a[sort] as number) ?? 0),
+    );
+  }, [scored, type, season, sort, purposeFilter]);
 
   return (
     <div>
@@ -99,6 +132,39 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
           ))}
         </div>
       </div>
+
+      {/* 목적 필터 (다중) + 분포 — S5.3 */}
+      {purposes.length > 0 && (
+        <div className="mb-4">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="text-xs text-neutral-500">목적:</span>
+            {purposes.map((p) => (
+              <button
+                key={p}
+                onClick={() => togglePurpose(p)}
+                className={`max-w-[14rem] truncate rounded-full border px-2.5 py-1 text-xs transition ${
+                  purposeFilter.includes(p)
+                    ? "border-brand-500 bg-brand-500 text-white"
+                    : "border-neutral-200 text-neutral-600 hover:bg-neutral-50"
+                }`}
+              >
+                {p}
+              </button>
+            ))}
+            {purposeFilter.length > 0 && (
+              <button
+                onClick={() => setPurposeFilter([])}
+                className="text-xs text-neutral-400 hover:text-neutral-600"
+              >
+                초기화
+              </button>
+            )}
+          </div>
+          {purposeFilter.length > 0 && (
+            <PurposeDistribution rows={rows} purposes={purposeFilter} />
+          )}
+        </div>
+      )}
 
       {/* 모바일: 카드 리스트 */}
       <ul className="space-y-2 md:hidden">
@@ -157,6 +223,13 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
                 }
               />
               <Stat label="할인" value={r.discount_rate != null ? pct(r.discount_rate, 0) : "—"} />
+              <Stat
+                label="목적 적합도"
+                value={(() => {
+                  const f = rowFitScore(r, purposeFilter);
+                  return f < 0 ? "—" : String(Math.round(f));
+                })()}
+              />
             </dl>
           </li>
         ))}
@@ -169,7 +242,7 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
 
       {/* 데스크톱: 테이블 */}
       <div className="hidden overflow-x-auto rounded-[24px] bg-white card-soft md:block">
-        <table className="w-full min-w-[900px] text-sm">
+        <table className="w-full min-w-[1000px] text-sm">
           <thead className="bg-neutral-50 text-left text-xs text-neutral-500">
             <tr>
               <th className="px-4 py-3 text-center font-medium">종합점수</th>
@@ -181,6 +254,7 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
               <th className="px-4 py-3 text-right font-medium">공헌이익</th>
               <th className="px-4 py-3 text-right font-medium">매출 달성률</th>
               <th className="px-4 py-3 text-right font-medium">공헌 달성률</th>
+              <th className="px-4 py-3 text-right font-medium">목적 적합도</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-neutral-100">
@@ -221,11 +295,14 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
                 <td className="px-4 py-3 text-right">
                   <AchCell v={r.ach_contribution} hasPlan={r.has_confirmed_plan} />
                 </td>
+                <td className="px-4 py-3 text-right">
+                  <FitBadge score={rowFitScore(r, purposeFilter)} />
+                </td>
               </tr>
             ))}
             {rows.length === 0 && (
               <tr>
-                <td colSpan={9} className="px-4 py-10 text-center text-neutral-400">
+                <td colSpan={10} className="px-4 py-10 text-center text-neutral-400">
                   조건에 맞는 캠페인이 없습니다.
                 </td>
               </tr>
@@ -288,6 +365,70 @@ function Select({
 function Tag({ children }: { children: React.ReactNode }) {
   return (
     <span className="rounded-full bg-neutral-100 px-2 py-0.5 text-xs text-neutral-600">{children}</span>
+  );
+}
+
+function FitBadge({ score }: { score: number }) {
+  if (score < 0) return <span className="text-neutral-300">—</span>;
+  const c =
+    score >= 70
+      ? "bg-brand-50 text-brand-600"
+      : score >= 40
+        ? "bg-neutral-100 text-neutral-600"
+        : "bg-neutral-100 text-neutral-400";
+  return (
+    <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium tabular-nums ${c}`}>
+      {Math.round(score)}
+    </span>
+  );
+}
+
+// 선택 목적별 적합도 분포 (필터된 캠페인 점수를 트랙 위 점으로)
+function PurposeDistribution({
+  rows,
+  purposes,
+}: {
+  rows: LibraryRow[];
+  purposes: string[];
+}) {
+  return (
+    <div className="mt-2 space-y-2 rounded-xl bg-neutral-50 p-3">
+      {purposes.map((p) => {
+        const pts = rows
+          .map((r) => r.fits.find((f) => f.purpose === p))
+          .filter((x): x is { purpose: string; score: number | null; reliable: boolean } => !!x);
+        const scores = pts.map((x) => x.score).filter((s): s is number => s != null);
+        const avg = scores.length
+          ? scores.reduce((a, b) => a + b, 0) / scores.length
+          : null;
+        const anyUnreliable = pts.some((x) => !x.reliable);
+        return (
+          <div key={p}>
+            <div className="mb-1 flex items-center justify-between text-[11px] text-neutral-500">
+              <span className="truncate">
+                {p} · {scores.length}건
+                {anyUnreliable && (
+                  <span className="ml-1 rounded bg-amber-100 px-1 text-[10px] text-amber-700">
+                    데이터 부족
+                  </span>
+                )}
+              </span>
+              <span>평균 {avg != null ? Math.round(avg) : "—"}</span>
+            </div>
+            <div className="relative h-5 rounded-full bg-white">
+              {scores.map((s, i) => (
+                <span
+                  key={i}
+                  title={String(Math.round(s))}
+                  className="absolute top-1/2 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-brand-500/70"
+                  style={{ left: `${Math.min(100, Math.max(0, s))}%` }}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
   );
 }
 

--- a/promo-analytics/app/(dash)/library/page.tsx
+++ b/promo-analytics/app/(dash)/library/page.tsx
@@ -1,18 +1,38 @@
 import { createClient } from "@/lib/supabase/server";
-import type { Promotion, PromotionSummary, CampaignAchievement } from "@/lib/types";
+import type {
+  Promotion,
+  PromotionSummary,
+  CampaignAchievement,
+  CampaignFit,
+} from "@/lib/types";
 import LibraryTable, { type LibraryRow } from "./LibraryTable";
 
 export const dynamic = "force-dynamic";
 
 export default async function LibraryPage() {
   const supabase = await createClient();
-  const [{ data: promos }, { data: achData }] = await Promise.all([
+  const [{ data: promos }, { data: achData }, { data: fitData }] = await Promise.all([
     supabase.from("promotions").select("*").order("start_date", { ascending: false }),
     supabase.rpc("campaign_achievements"),
+    supabase.rpc("campaign_fits"),
   ]);
   const achMap = new Map<string, CampaignAchievement>(
     ((achData as CampaignAchievement[]) ?? []).map((a) => [a.promotion_id, a]),
   );
+  // 캠페인별 목적 적합도 묶기
+  const fitMap = new Map<
+    string,
+    { purpose: string; score: number | null; reliable: boolean }[]
+  >();
+  for (const f of (fitData as CampaignFit[]) ?? []) {
+    const arr = fitMap.get(f.promotion_id) ?? [];
+    arr.push({
+      purpose: f.purpose,
+      score: f.fit_score_0_100 != null ? Number(f.fit_score_0_100) : null,
+      reliable: f.data_reliable,
+    });
+    fitMap.set(f.promotion_id, arr);
+  }
 
   const rows: LibraryRow[] = await Promise.all(
     (promos ?? []).map(async (p: Promotion) => {
@@ -37,6 +57,7 @@ export default async function LibraryPage() {
         ach_revenue: a?.ach_revenue ?? null,
         ach_contribution: a?.ach_contribution ?? null,
         quantity_reliable: a?.quantity_reliable ?? null,
+        fits: fitMap.get(p.id) ?? [],
       };
     }),
   );

--- a/promo-analytics/lib/types.ts
+++ b/promo-analytics/lib/types.ts
@@ -249,6 +249,14 @@ export type PurposeFit = {
   data_reliable: boolean;
 };
 
+// campaign_fits() 반환 (전 캠페인 × 목적 적합도)
+export type CampaignFit = {
+  promotion_id: string;
+  purpose: string;
+  fit_score_0_100: number | null;
+  data_reliable: boolean;
+};
+
 // S4: 캠페인별 달성률 (campaign_achievements 함수 반환)
 export type CampaignAchievement = {
   promotion_id: string;

--- a/promo-analytics/supabase/migrations/0012_campaign_fits.sql
+++ b/promo-analytics/supabase/migrations/0012_campaign_fits.sql
@@ -1,0 +1,18 @@
+-- 0012: 캠페인×목적 적합도 배치 로더 (S5.3) — 히스토리 목록 필터/정렬/분포용
+create or replace function promo.campaign_fits()
+returns table (
+  promotion_id uuid,
+  purpose text,
+  fit_score_0_100 numeric,
+  data_reliable boolean
+)
+language sql
+stable
+set search_path = ''
+as $$
+  select pr.id, f.purpose, f.fit_score_0_100, f.data_reliable
+  from promo.promotions pr
+  cross join lateral promo.purpose_fit(pr.id) f;
+$$;
+
+grant execute on all functions in schema promo to authenticated;


### PR DESCRIPTION
## 개요

S5 하위 **5.3 — 히스토리(`/library`) 목적 슬라이스**. 5.1 적합도를 소비해 목록에 목적 필터·정렬·분포를 추가합니다.

> 5.3만. (5.4~5.6·S6 미포함)

## 변경 사항
### 마이그레이션 `0012_campaign_fits` (additive · 적용 완료)
- `promo.campaign_fits()` — 전 캠페인 × 목적 적합도 배치 로더(`purpose_fit` lateral). 검증: 18캠페인/16목적 반환

### 코드
- `lib/types.ts`: `CampaignFit`
- `library/page.tsx`: `campaign_fits` 로드 → 캠페인별 `fits[]` 결합
- `LibraryTable`:
  - **목적 다중 필터(칩)** — 선택 목적을 effective_weight>0(fits 보유)로 매칭
  - **정렬 "목적 적합도"** — 필터 활성 시 그 목적들 중 max fit, 없으면 전체 max
  - **선택 목적 점수 분포** — 트랙 위 점 + 평균·건수·"데이터 부족" 배지
  - 데스크톱 **적합도 컬럼** + 모바일 적합도 stat
  - 기존 점수·목적·달성률 컬럼과 공존. 적합도/필터/정렬은 5.1·0012 단일 출처 소비(재계산 없음)

## 검수
- [ ] 목적 필터·"목적 적합도" 정렬·분포 동작
- [ ] `data_reliable=false` 배지
- [ ] Vercel 프리뷰 Ready

S5.3 완료, 검수 후 5.4 대기.

https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ)_