### PR TITLE
S5.4: 캠페인 상세 목적 블록

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/PurposeBlock.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/PurposeBlock.tsx
@@ -1,0 +1,94 @@
+import { won, wonShort, pct, num } from "@/lib/format";
+
+export type PurposeMetricRow = {
+  purpose: string;
+  weight: number;
+  kind: "sales" | "stock" | "branding" | "other";
+  uplift: number | null;
+  contribution: number | null;
+  uplift_pct: number | null;
+  ach_qty: number | null;
+  qty_reliable: boolean;
+  order_count: number | null;
+};
+
+// S5.4: 캠페인 상세 — 목적별 핵심 지표 블록 (가중·구분 표시). 계산은 5.1/측정 함수 단일 출처.
+export default function PurposeBlock({ rows }: { rows: PurposeMetricRow[] }) {
+  if (rows.length === 0) return null;
+  return (
+    <section className="mt-6">
+      <h2 className="mb-2 text-sm font-semibold text-neutral-700">목적별 핵심 지표</h2>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {rows.map((r) => (
+          <div key={r.purpose} className="rounded-[20px] bg-white p-4 card-soft">
+            <div className="flex items-center justify-between gap-2">
+              <span className="min-w-0 truncate text-sm font-semibold text-neutral-800">
+                {r.purpose}
+              </span>
+              <span className="shrink-0 rounded-full bg-neutral-100 px-2 py-0.5 text-[11px] text-neutral-500">
+                가중치 {r.weight}
+              </span>
+            </div>
+            <div className="mt-3 space-y-1.5 text-sm">
+              {r.kind === "stock" ? (
+                <Metric
+                  label="수량 달성률"
+                  value={r.ach_qty != null ? pct(r.ach_qty, 0) : "—"}
+                  badge={!r.qty_reliable ? "데이터 부족" : undefined}
+                  primary
+                />
+              ) : r.kind === "branding" ? (
+                <>
+                  <Metric label="구매 건수" value={num(r.order_count)} primary />
+                  <p className="text-[11px] text-neutral-400">
+                    신규 비중: 회원·수량 데이터 확보 후 제공 예정
+                  </p>
+                </>
+              ) : (
+                <>
+                  <Metric label="증분 매출" value={won(r.uplift)} primary />
+                  <Metric label="공헌이익" value={wonShort(r.contribution)} />
+                  {r.uplift_pct != null && (
+                    <Metric label="증분율" value={pct(r.uplift_pct, 0)} />
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+      <p className="mt-2 text-xs text-neutral-400">
+        목적별로 보는 관점이 다릅니다 — 세일즈=증분·공헌, 재고소진=수량 달성률, 브랜딩=구매 건수.
+        가중치는 캠페인 편집에서 조정합니다.
+      </p>
+    </section>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  badge,
+  primary,
+}: {
+  label: string;
+  value: string;
+  badge?: string;
+  primary?: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <span className="text-neutral-500">
+        {label}
+        {badge && (
+          <span className="ml-1 rounded bg-amber-100 px-1 text-[10px] text-amber-700">
+            {badge}
+          </span>
+        )}
+      </span>
+      <span className={`tabular-nums ${primary ? "font-semibold text-neutral-900" : "text-neutral-700"}`}>
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/promo-analytics/app/(dash)/promotions/[id]/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/page.tsx
@@ -14,6 +14,7 @@ import { won, wonShort, pct, daysBetween } from "@/lib/format";
 import UpliftChart from "./UpliftChart";
 import Notes from "./Notes";
 import Achievement from "./Achievement";
+import PurposeBlock, { type PurposeMetricRow } from "./PurposeBlock";
 
 export const dynamic = "force-dynamic";
 
@@ -88,6 +89,43 @@ export default async function PromotionDetail({
         .filter((s) => s.length > 0),
     ),
   ].sort();
+
+  // 목적별 핵심 지표 (S5.4): 유효 가중치 × 측정·달성률·구매건수
+  const [{ data: ewData }, { data: ocData }] = await Promise.all([
+    supabase.rpc("effective_purpose_weights", { p_id: id }),
+    supabase.from("promotion_sales").select("order_count").eq("promotion_id", id),
+  ]);
+  const orderCount = ((ocData as { order_count: number | null }[]) ?? []).reduce(
+    (s, r) => s + (Number(r.order_count) || 0),
+    0,
+  );
+  const upliftPct =
+    summary && summary.actual_revenue - summary.total_uplift > 0
+      ? summary.total_uplift / (summary.actual_revenue - summary.total_uplift)
+      : null;
+  const purposeRows: PurposeMetricRow[] = (
+    (ewData as { purpose: string; weight: number }[]) ?? []
+  ).map((w) => {
+    const kind: PurposeMetricRow["kind"] =
+      w.purpose === "재고소진"
+        ? "stock"
+        : w.purpose === "브랜딩"
+          ? "branding"
+          : w.purpose === "세일즈"
+            ? "sales"
+            : "other";
+    return {
+      purpose: w.purpose,
+      weight: Number(w.weight),
+      kind,
+      uplift: summary?.total_uplift ?? null,
+      contribution: summary?.contribution ?? null,
+      uplift_pct: upliftPct,
+      ach_qty: achSummary?.ach_qty ?? null,
+      qty_reliable: achSummary?.quantity_reliable ?? false,
+      order_count: orderCount,
+    };
+  });
 
   const mains = rows.filter((r) => r.is_main);
   const chartData = rows
@@ -205,6 +243,9 @@ export default async function PromotionDetail({
         options={achOptions}
         optionInfos={optionInfos}
       />
+
+      {/* 목적별 핵심 지표 (S5.4) */}
+      <PurposeBlock rows={purposeRows} />
 
       <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-5">
         {/* 측정 테이블 */}


### PR DESCRIPTION
## 개요

S5 하위 **5.4 — 캠페인 상세 목적 블록**. 마이그레이션 없음. 그 캠페인의 목적별 핵심 지표를 가중·구분해 상세에 표시합니다.

> 5.4만. (5.5~5.6·S6 미포함)

## 변경 사항
- `PurposeBlock.tsx`: 목적별 핵심 지표 카드(가중치 칩 + 구분 지표)
  - 세일즈/기타 → 증분 매출 · 공헌이익 · 증분율
  - 재고소진 → 수량 달성률 + "데이터 부족" 배지(quantity_reliable false)
  - 브랜딩 → 구매 건수(Σorder_count) + 신규 비중 자리(문구만, 미구현)
- `/promotions/[id]`: `effective_purpose_weights` + `Σorder_count` 로드 → 목적별 행 구성. 달성률 블록 아래에 렌더. **다중 목적이면 가중치와 함께 목적별 나열**
- 소비만(재계산 없음): `effective_purpose_weights` · `promotion_summary` · `plan_vs_actual_summary` · promotion_sales

## 검수
- [ ] 다중 목적 캠페인에서 목적별 지표·가중치 구분 표시
- [ ] 재고소진 수량 달성률 + 데이터부족 배지 / 브랜딩 구매건수 + 신규비중 문구
- [ ] Vercel 프리뷰 Ready

S5.4 완료, 검수 후 5.5 대기.

https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ)_