### PR TITLE
S5.5: 시뮬레이터 목적 슬라이스

### DIFF
--- a/promo-analytics/app/(dash)/predict/Simulator.tsx
+++ b/promo-analytics/app/(dash)/predict/Simulator.tsx
@@ -14,7 +14,7 @@ import {
 import { won, wonShort, pct } from "@/lib/format";
 import { predict, type CaseFeature, type PredictionSpec } from "@/lib/predict";
 
-type Options = { benefitTypes: string[]; seasonalities: string[] };
+type Options = { benefitTypes: string[]; seasonalities: string[]; purposes: string[] };
 
 const BRAND = "#e76f51";
 
@@ -30,6 +30,7 @@ type Scenario = {
 export default function Simulator({ cases, options }: { cases: CaseFeature[]; options: Options }) {
   const [promoType, setPromoType] = useState(options.benefitTypes[0] ?? "할인");
   const [seasonTag, setSeasonTag] = useState("");
+  const [purpose, setPurpose] = useState("");
   const [discount, setDiscount] = useState(40);
   const [days, setDays] = useState(4);
   const [pinned, setPinned] = useState<Scenario[]>([]);
@@ -37,12 +38,13 @@ export default function Simulator({ cases, options }: { cases: CaseFeature[]; op
   const spec: PredictionSpec = {
     promo_type: promoType || null,
     season_tag: seasonTag || null,
+    purpose: purpose || null,
     discount_rate: discount / 100,
     duration_days: days,
   };
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const pred = useMemo(() => predict(spec, cases), [promoType, seasonTag, discount, days, cases]);
+  const pred = useMemo(() => predict(spec, cases), [promoType, seasonTag, purpose, discount, days, cases]);
 
   // 할인율별 예상 증분/공헌이익 곡선
   const curve = useMemo(() => {
@@ -57,7 +59,7 @@ export default function Simulator({ cases, options }: { cases: CaseFeature[]; op
     }
     return out;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [promoType, seasonTag, days, cases]);
+  }, [promoType, seasonTag, purpose, days, cases]);
 
   // 스윗스팟: 최고 효과(증분 최대) / 최고 효율(공헌이익 최대)
   const bestEffect = useMemo(
@@ -76,7 +78,7 @@ export default function Simulator({ cases, options }: { cases: CaseFeature[]; op
       [
         ...prev,
         {
-          label: `${promoType || "?"} ${discount}%·${days}일${seasonTag ? `·${seasonTag}` : ""}`,
+          label: `${promoType || "?"} ${discount}%·${days}일${seasonTag ? `·${seasonTag}` : ""}${purpose ? `·${purpose}` : ""}`,
           uplift: pred.expected_uplift,
           promoDaily: pred.expected_promo_daily,
           baselineDaily: pred.expected_baseline_daily,
@@ -113,6 +115,12 @@ export default function Simulator({ cases, options }: { cases: CaseFeature[]; op
           </Field>
           <Field label="시즈널리티">
             <Chips options={options.seasonalities} value={seasonTag} onChange={setSeasonTag} clearable />
+          </Field>
+          <Field label="목적">
+            <Chips options={options.purposes} value={purpose} onChange={setPurpose} clearable />
+            <p className="mt-1 text-[11px] text-neutral-400">
+              목적을 고르면 같은 목적 캠페인 사례를 우선 가중해 예측합니다.
+            </p>
           </Field>
 
           <div className="mt-5">

--- a/promo-analytics/lib/cases.ts
+++ b/promo-analytics/lib/cases.ts
@@ -13,17 +13,22 @@ export async function loadCases(
 
   return Promise.all(
     (promos as Promotion[]).map(async (p) => {
-      const [{ data: sData }, { data: mData }, { data: psData }] = await Promise.all([
-        supabase.rpc("promotion_summary", { p_id: p.id }),
-        supabase.rpc("promotion_measurement", { p_id: p.id }),
-        supabase
-          .from("promotion_sales")
-          .select("quantity, order_count")
-          .eq("promotion_id", p.id),
-      ]);
+      const [{ data: sData }, { data: mData }, { data: psData }, { data: ewData }] =
+        await Promise.all([
+          supabase.rpc("promotion_summary", { p_id: p.id }),
+          supabase.rpc("promotion_measurement", { p_id: p.id }),
+          supabase
+            .from("promotion_sales")
+            .select("quantity, order_count")
+            .eq("promotion_id", p.id),
+          supabase.rpc("effective_purpose_weights", { p_id: p.id }),
+        ]);
       const s = (sData?.[0] as PromotionSummary) ?? null;
       const meas = (mData as MeasurementRow[]) ?? [];
       const ps = (psData as { quantity: number; order_count: number }[]) ?? [];
+      const purposes = ((ewData as { purpose: string; weight: number }[]) ?? []).map(
+        (w) => ({ purpose: w.purpose, weight: Number(w.weight) }),
+      );
       const duration = daysBetween(p.start_date, p.end_date);
       const promoDays = meas[0]?.promo_days ?? duration;
       const baseline_daily = meas.reduce((a, x) => a + x.baseline_daily_revenue, 0);
@@ -49,6 +54,7 @@ export async function loadCases(
         actual_daily,
         qty_per_day: promoDays > 0 ? totalQty / promoDays : 0,
         orders_per_day: promoDays > 0 ? totalOrders / promoDays : 0,
+        purposes,
       };
     }),
   );

--- a/promo-analytics/lib/predict.ts
+++ b/promo-analytics/lib/predict.ts
@@ -19,6 +19,7 @@ export type CaseFeature = {
   actual_daily: number; // 행사 기간 일평균
   qty_per_day: number; // 일평균 판매수량
   orders_per_day: number; // 일평균 구매건수
+  purposes: { purpose: string; weight: number }[]; // 유효 목적 가중 (S5)
 };
 
 export type PredictionSpec = {
@@ -26,6 +27,7 @@ export type PredictionSpec = {
   season_tag?: string | null;
   discount_rate?: number | null; // 0~1
   duration_days: number;
+  purpose?: string | null; // 목적 선택 (S5) — 같은 목적 사례 우선 가중
 };
 
 export type Comparable = CaseFeature & { score: number };
@@ -87,9 +89,17 @@ export function similarity(spec: PredictionSpec, c: CaseFeature): number {
   return weight > 0 ? score / weight : 0;
 }
 
+// 목적 선택 시 같은 목적 사례를 우선 가중 (제외가 아닌 우선순위 — 콜드스타트 대비).
+// effective_weight 1.0 → ×1.0, 0 → ×0.4.
+function purposeFactor(spec: PredictionSpec, c: CaseFeature): number {
+  if (!spec.purpose) return 1;
+  const pw = c.purposes?.find((p) => p.purpose === spec.purpose)?.weight ?? 0;
+  return 0.4 + 0.6 * Math.min(1, Math.max(0, pw));
+}
+
 export function predict(spec: PredictionSpec, cases: CaseFeature[]): Prediction {
   const scored: Comparable[] = cases
-    .map((c) => ({ ...c, score: similarity(spec, c) }))
+    .map((c) => ({ ...c, score: similarity(spec, c) * purposeFactor(spec, c) }))
     .filter((c) => c.score > 0.15 && c.uplift_per_day !== 0)
     .sort((a, b) => b.score - a.score);
 
@@ -158,9 +168,9 @@ export function predict(spec: PredictionSpec, cases: CaseFeature[]): Prediction 
     confidence,
     confidence_score: cScore,
     comparables: top,
-    rationale: `유사 사례 ${top.length}건(평균 유사도 ${(avgScore * 100).toFixed(
-      0,
-    )}%)의 일평균 증분을 가중 평균해 ${spec.duration_days}일로 환산했습니다.`,
+    rationale:
+      `유사 사례 ${top.length}건(평균 유사도 ${(avgScore * 100).toFixed(0)}%)의 일평균 증분을 가중 평균해 ${spec.duration_days}일로 환산했습니다.` +
+      (spec.purpose ? ` ‘${spec.purpose}’ 목적 사례를 우선 가중했습니다.` : ""),
   };
 }
 


### PR DESCRIPTION
## 개요

S5 하위 **5.5 — 시뮬레이터(`/predict`) 목적 슬라이스**. 마이그레이션 없음. 입력에 목적 선택을 추가해 같은 목적 사례를 우선 가중해 예측합니다.

> 5.5만. (5.6·S6 미포함)

## 변경 사항
- `lib/predict.ts`: `CaseFeature.purposes[]`, `PredictionSpec.purpose` 추가. `predict()`에 **`purposeFactor`(effective_weight 1.0→×1.0, 0→×0.4)** 를 유사도에 곱해 동일 목적 사례를 우선 가중(하드 제외가 아닌 우선순위 → 콜드스타트 대비). rationale에 목적 가중 명시
- `lib/cases.ts`: `effective_purpose_weights` 로드 → `CaseFeature.purposes`
- `/predict` Simulator: **목적 선택 칩** 추가, `spec.purpose` 반영, 할인율 곡선·시나리오 라벨에 목적 반영

## 검수
- [ ] 목적 전환 시 예측·근거 사례가 그 목적 쪽으로 이동
- [ ] 사례 적으면 신뢰도 "낮음" 명시(콜드스타트 폴백 유지)
- [ ] Vercel 프리뷰 Ready

> 달성률 reliability 가중(S6)은 미적용.

S5.5 완료, 검수 후 5.6 대기.

https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ)_