### PR TITLE
S5.6: 추천 목적 충족도 시각화

### DIFF
--- a/promo-analytics/app/(dash)/prescribe/Recommend.tsx
+++ b/promo-analytics/app/(dash)/prescribe/Recommend.tsx
@@ -185,35 +185,46 @@ export default function Recommend({ options }: { options: Options }) {
                         <span className="rounded-full bg-neutral-100 px-2 py-0.5 text-xs text-neutral-500">신뢰도 {r.confidence}</span>
                       </div>
 
-                      {/* 목적별 예측 */}
-                      <div className="mt-2 grid gap-1.5 text-xs text-neutral-500 sm:grid-cols-2">
+                      {/* 목적별 충족도 (목표 대비) — S5.6 */}
+                      <div className="mt-3 space-y-2">
                         {(r.per_goal ?? [{
                           goal: "revenue" as Goal,
                           metric_per_day: r.metric_per_day,
                           predicted_metric: r.predicted_metric,
                           target: 0,
                           meets_target: r.meets_target,
-                        }]).map((pg) => (
-                          <div key={pg.goal} className="flex items-center gap-1.5">
-                            <span className="rounded-full bg-neutral-100 px-2 py-0.5 text-[11px] font-medium text-neutral-600">
-                              {GOAL_LABEL[pg.goal]}
-                            </span>
-                            <span>
-                              예상 <strong className="text-neutral-800">{fmtMetric(unitFor(pg.goal), pg.predicted_metric)}</strong>
-                              {pg.target > 0 && (
-                                <>
-                                  {" / "}
-                                  목표 {fmtMetric(unitFor(pg.goal), pg.target)}
-                                  {pg.meets_target ? (
-                                    <span className="ml-1 text-green-600">✓</span>
-                                  ) : (
-                                    <span className="ml-1 text-amber-600">▾</span>
-                                  )}
-                                </>
+                        }]).map((pg) => {
+                          const unit = unitFor(pg.goal);
+                          const fulfill = pg.target > 0 ? pg.predicted_metric / pg.target : null;
+                          return (
+                            <div key={pg.goal}>
+                              <div className="mb-0.5 flex items-center justify-between gap-2 text-xs">
+                                <span className="flex min-w-0 items-center gap-1.5">
+                                  <span className="rounded-full bg-neutral-100 px-2 py-0.5 text-[11px] font-medium text-neutral-600">
+                                    {GOAL_LABEL[pg.goal]}
+                                  </span>
+                                  <span className="truncate text-neutral-500">
+                                    예상 <strong className="text-neutral-800">{fmtMetric(unit, pg.predicted_metric)}</strong>
+                                    {pg.target > 0 && <> / 목표 {fmtMetric(unit, pg.target)}</>}
+                                  </span>
+                                </span>
+                                {fulfill != null && (
+                                  <span className={`shrink-0 font-semibold ${pg.meets_target ? "text-green-600" : "text-amber-600"}`}>
+                                    {Math.round(fulfill * 100)}%
+                                  </span>
+                                )}
+                              </div>
+                              {fulfill != null && (
+                                <div className="h-2 overflow-hidden rounded-full bg-neutral-100">
+                                  <div
+                                    className={`h-full rounded-full ${pg.meets_target ? "bg-green-500" : "bg-amber-400"}`}
+                                    style={{ width: `${Math.min(100, fulfill * 100)}%` }}
+                                  />
+                                </div>
                               )}
-                            </span>
-                          </div>
-                        ))}
+                            </div>
+                          );
+                        })}
                       </div>
 
                       <div className="mt-2 flex flex-wrap gap-x-5 gap-y-1 text-xs text-neutral-500">


### PR DESCRIPTION
## 개요

S5 하위 **5.6 — 추천(`/prescribe`) 목적 충족도 시각화** (S5 마지막). 마이그레이션 없음. 추천 결과 카드의 목적별 예측을 **목표 대비 충족도 바**로 강화합니다.

> 5.6만. S5.6 = S5(목적 슬라이스) 종료.

## 변경 사항
- `/prescribe` Recommend: `per_goal`별 **충족도 바**(predicted/target, 100% 캡, 달성=초록 / 미달=앰버 + % 표기). 목표 미입력 목적은 예상치만 표기. 기존 다중 목표 추천(`recommendByGoals`) 그대로 소비(재계산 없음)
- 이전 텍스트(✓/▾) 표기를 바 + 퍼센트로 대체 → **추천안 간 목적 충족도 시각 비교** 가능

## 검수
- [ ] 다중 목적 입력 시 추천안마다 목적별 충족도 바 표시·비교
- [ ] 달성/미달 색상·퍼센트 정확
- [ ] Vercel 프리뷰 Ready

S5.6 완료 = S5 종료. 검수 후 S6 대기.

https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ)_