### PR TITLE
S6.1: 달성 신뢰도 → 예측 가중

### DIFF
--- a/promo-analytics/lib/cases.ts
+++ b/promo-analytics/lib/cases.ts
@@ -1,15 +1,34 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { Promotion, PromotionSummary, MeasurementRow } from "./types";
+import type {
+  Promotion,
+  PromotionSummary,
+  MeasurementRow,
+  CampaignAchievement,
+} from "./types";
 import type { CaseFeature } from "./predict";
 import { daysBetween } from "./format";
+
+// 달성 신뢰도(S6): 확정 플랜 + 계획 정확도(|1−ach_revenue|)를 0~1로.
+// 확정·근접 달성↑, 플랜 없거나 실적 없으면 기본값 0.5.
+function reliabilityFrom(a: CampaignAchievement | null): number {
+  if (!a || !a.has_confirmed_plan || a.ach_revenue == null) return 0.5;
+  const accuracy = Math.max(0, 1 - Math.abs(1 - a.ach_revenue));
+  return 0.5 + 0.5 * accuracy;
+}
 
 /** 모든 프로모션 + 요약/측정을 CaseFeature 배열로 로드 */
 export async function loadCases(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   supabase: SupabaseClient<any, any, any>,
 ): Promise<CaseFeature[]> {
-  const { data: promos } = await supabase.from("promotions").select("*");
+  const [{ data: promos }, { data: achData }] = await Promise.all([
+    supabase.from("promotions").select("*"),
+    supabase.rpc("campaign_achievements"),
+  ]);
   if (!promos) return [];
+  const achMap = new Map<string, CampaignAchievement>(
+    ((achData as CampaignAchievement[]) ?? []).map((a) => [a.promotion_id, a]),
+  );
 
   return Promise.all(
     (promos as Promotion[]).map(async (p) => {
@@ -29,6 +48,7 @@ export async function loadCases(
       const purposes = ((ewData as { purpose: string; weight: number }[]) ?? []).map(
         (w) => ({ purpose: w.purpose, weight: Number(w.weight) }),
       );
+      const a = achMap.get(p.id) ?? null;
       const duration = daysBetween(p.start_date, p.end_date);
       const promoDays = meas[0]?.promo_days ?? duration;
       const baseline_daily = meas.reduce((a, x) => a + x.baseline_daily_revenue, 0);
@@ -55,6 +75,10 @@ export async function loadCases(
         qty_per_day: promoDays > 0 ? totalQty / promoDays : 0,
         orders_per_day: promoDays > 0 ? totalOrders / promoDays : 0,
         purposes,
+        ach_revenue: a?.ach_revenue ?? null,
+        ach_contribution: a?.ach_contribution ?? null,
+        has_confirmed_plan: a?.has_confirmed_plan ?? false,
+        reliability: reliabilityFrom(a),
       };
     }),
   );

--- a/promo-analytics/lib/predict.ts
+++ b/promo-analytics/lib/predict.ts
@@ -20,6 +20,11 @@ export type CaseFeature = {
   qty_per_day: number; // 일평균 판매수량
   orders_per_day: number; // 일평균 구매건수
   purposes: { purpose: string; weight: number }[]; // 유효 목적 가중 (S5)
+  // 달성률 패턴 (S6) — campaign_achievements/plan_vs_actual 단일 출처
+  ach_revenue: number | null; // 계획 대비 실적 매출 비율 (1.0=계획대로)
+  ach_contribution: number | null; // 계획 대비 실적 공헌 비율
+  has_confirmed_plan: boolean;
+  reliability: number; // 0~1 달성 신뢰도 = f(|1−ach_revenue|, 확정 플랜)
 };
 
 export type PredictionSpec = {
@@ -48,13 +53,19 @@ export type Prediction = {
   rationale: string;
 };
 
+// 유사도 × 달성 신뢰도(S6)로 가중. 계획을 잘 맞춘 사례가 예측을 더 끈다.
+function caseWeight(c: Comparable): number {
+  return c.score * (c.reliability ?? 1);
+}
+
 function wavg(items: Comparable[], pick: (c: Comparable) => number | null): number {
   let s = 0, w = 0;
   for (const c of items) {
     const v = pick(c);
     if (v == null) continue;
-    s += v * c.score;
-    w += c.score;
+    const cw = caseWeight(c);
+    s += v * cw;
+    w += cw;
   }
   return w > 0 ? s / w : 0;
 }
@@ -135,9 +146,12 @@ export function predict(spec: PredictionSpec, cases: CaseFeature[]): Prediction 
     };
   }
 
-  // 유사도 가중 평균 일평균 증분
-  const wSum = top.reduce((s, c) => s + c.score, 0);
-  const perDay = top.reduce((s, c) => s + c.uplift_per_day * c.score, 0) / wSum;
+  // 유사도 × 달성 신뢰도(S6) 가중 평균 일평균 증분
+  const ewSum = top.reduce((s, c) => s + caseWeight(c), 0);
+  const perDay =
+    ewSum > 0
+      ? top.reduce((s, c) => s + c.uplift_per_day * caseWeight(c), 0) / ewSum
+      : 0;
   const expected = perDay * spec.duration_days;
 
   // 분산 → 범위
@@ -145,9 +159,16 @@ export function predict(spec: PredictionSpec, cases: CaseFeature[]): Prediction 
   const min = Math.min(...perDays) * spec.duration_days;
   const max = Math.max(...perDays) * spec.duration_days;
 
-  // 신뢰도: 사례 수 + 평균 유사도
+  // 신뢰도: 사례 수 + 평균 유사도 + 평균 달성 신뢰도, 달성 분산 크면 ↓ (S6)
+  const wSum = top.reduce((s, c) => s + c.score, 0);
   const avgScore = wSum / top.length;
-  const cScore = Math.min(1, (top.length / 5) * 0.5 + avgScore * 0.5);
+  const meanRel = top.reduce((s, c) => s + c.reliability, 0) / top.length;
+  const relStdev = Math.sqrt(
+    top.reduce((s, c) => s + (c.reliability - meanRel) ** 2, 0) / top.length,
+  );
+  const cScore =
+    Math.min(1, (top.length / 5) * 0.4 + avgScore * 0.35 + meanRel * 0.25) *
+    (1 - Math.min(0.35, relStdev)); // 달성 분산 패널티
   const confidence: Prediction["confidence"] =
     cScore >= 0.66 ? "높음" : cScore >= 0.4 ? "보통" : "낮음";
 
@@ -170,7 +191,9 @@ export function predict(spec: PredictionSpec, cases: CaseFeature[]): Prediction 
     comparables: top,
     rationale:
       `유사 사례 ${top.length}건(평균 유사도 ${(avgScore * 100).toFixed(0)}%)의 일평균 증분을 가중 평균해 ${spec.duration_days}일로 환산했습니다.` +
-      (spec.purpose ? ` ‘${spec.purpose}’ 목적 사례를 우선 가중했습니다.` : ""),
+      (spec.purpose ? ` ‘${spec.purpose}’ 목적 사례를 우선 가중했습니다.` : "") +
+      ` 계획을 잘 맞춘 캠페인(달성 신뢰도 평균 ${(meanRel * 100).toFixed(0)}%)에 가중치를 더 줬습니다.` +
+      (relStdev > 0.25 ? " 다만 사례 간 달성 편차가 커 신뢰도를 낮췄습니다." : ""),
   };
 }
 


### PR DESCRIPTION
## 개요

S6 하위 **6.1 — 달성률 패턴 → 예측 신뢰도 가중** (S6 핵심). 마이그레이션 없음. 축적된 달성률(계획 대비 실적)을 예측 가중·신뢰도에 반영합니다.

> 6.1만. (6.2 플랜 세트수 힌트 · 6.3 추천 달성 일관성 랭킹은 후속 PR)

## 변경 사항
- `lib/cases.ts`: `CaseFeature`에 `ach_revenue` / `ach_contribution` / `has_confirmed_plan` / `reliability` 추가. `campaign_achievements()` **배치 조인**(캠페인당 호출 없음).
  - `reliability = f(|1 − ach_revenue|, has_confirmed_plan)` → 확정 플랜 & 근접 달성 0.5~1.0, **무플랜/무실적 기본 0.5**
- `lib/predict.ts`:
  - 유사 사례 가중평균에 reliability 곱(`caseWeight = 유사도 × 신뢰도`) → **계획을 잘 맞춘 사례가 예측을 더 끔**
  - `confidence`에 평균 신뢰도 반영 + **달성 분산(stdev) 패널티**(편차 크면 신뢰도↓)
  - rationale에 신뢰도 가중·편차 명시. 목적 가중(S5) 유지
- 측정/달성률 계산 로직 **무변경**(S1~S4 함수 단일 출처). `recommend`/`prescribe`는 추가 필드만 소비(랭킹 반영은 6.3)

## 검수
- [ ] 달성률 높은 사례가 예측을 더 끄는지(가중 전/후 비교)
- [ ] 콜드스타트/달성 분산 클 때 confidence "낮음" 명시
- [ ] Vercel 프리뷰 Ready

S6.1 완료, 검수 후 6.2 대기.

https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ)_