### PR TITLE
S6.2: 플랜 에디터 예상 세트수 힌트

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
@@ -42,6 +42,13 @@ export type ProductEcon = Record<
   string,
   { consumer_price: number | null; regular_price: number | null; cost: number | null }
 >;
+// 예상 세트수 힌트 (S6.2) — 유사 캠페인 확정 플랜 평균, 비구속 표시용
+export type QtyHint = {
+  main: number | null;
+  sub: number | null;
+  mainN: number;
+  subN: number;
+};
 
 type ItemState = EditorItem & { key: string };
 type OptState = {
@@ -74,11 +81,13 @@ export default function PlanEditor({
   plan,
   initialOptions,
   rateCard,
+  qtyHint,
 }: {
   promotionId: string;
   plan: CampaignPlan | null;
   initialOptions: EditorOption[];
   rateCard: RateCard | null;
+  qtyHint?: QtyHint;
 }) {
   const router = useRouter();
   const [options, setOptions] = useState<OptState[]>(() => toState(initialOptions));
@@ -317,6 +326,7 @@ export default function PlanEditor({
             opt={o}
             totals={optionResults[i]}
             mult={mult}
+            qtyHint={qtyHint}
             readOnly={confirmed}
             onPatch={(patch) => patchOption(o.key, patch)}
             onRemove={() => removeOption(o.key)}
@@ -426,6 +436,7 @@ function OptionCard({
   opt,
   totals,
   mult,
+  qtyHint,
   readOnly,
   onPatch,
   onRemove,
@@ -436,6 +447,7 @@ function OptionCard({
   opt: OptState;
   totals: ReturnType<typeof computeOptionTotals>;
   mult: number;
+  qtyHint?: QtyHint;
   readOnly: boolean;
   onPatch: (patch: Partial<OptState>) => void;
   onRemove: () => void;
@@ -453,18 +465,29 @@ function OptionCard({
           onChange={(e) => onPatch({ option_label: e.target.value })}
           placeholder="옵션 라벨 (예: 모래 4묶음 세트)"
         />
-        <label className="flex items-center gap-1 text-xs text-neutral-500">
-          예상 세트수
-          <input
-            type="number"
-            className="w-24 rounded-lg border border-neutral-200 px-2 py-1.5 text-right text-sm disabled:bg-neutral-50"
-            value={opt.expected_option_qty || 0}
-            disabled={readOnly}
-            onChange={(e) =>
-              onPatch({ expected_option_qty: Number(e.target.value) || 0 })
-            }
-          />
-        </label>
+        <div className="flex flex-col gap-0.5">
+          <label className="flex items-center gap-1 text-xs text-neutral-500">
+            예상 세트수
+            <input
+              type="number"
+              className="w-24 rounded-lg border border-neutral-200 px-2 py-1.5 text-right text-sm disabled:bg-neutral-50"
+              value={opt.expected_option_qty || 0}
+              disabled={readOnly}
+              onChange={(e) =>
+                onPatch({ expected_option_qty: Number(e.target.value) || 0 })
+              }
+            />
+          </label>
+          {(() => {
+            const hv = opt.is_main ? qtyHint?.main : qtyHint?.sub;
+            const hn = opt.is_main ? qtyHint?.mainN : qtyHint?.subN;
+            return hv != null && hn ? (
+              <span className="text-[10px] text-neutral-400">
+                유사 캠페인 평균 {num(hv)}세트 ({hn}건, {opt.is_main ? "메인" : "서브"})
+              </span>
+            ) : null;
+          })()}
+        </div>
         <label className="flex items-center gap-1 text-xs text-neutral-500">
           <input
             type="checkbox"

--- a/promo-analytics/app/(dash)/promotions/[id]/plan/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/page.tsx
@@ -7,7 +7,11 @@ import type {
   CampaignPlanOptionItem,
   RateCard,
 } from "@/lib/types";
-import PlanEditor, { type EditorOption, type ProductEcon } from "./PlanEditor";
+import PlanEditor, {
+  type EditorOption,
+  type ProductEcon,
+  type QtyHint,
+} from "./PlanEditor";
 
 export const dynamic = "force-dynamic";
 
@@ -106,6 +110,35 @@ export default async function PlanPage({
     .limit(1)
     .maybeSingle();
 
+  // 예상 세트수 힌트 (S6.2): 다른 캠페인 확정 플랜 옵션의 예상 세트수 평균 (비구속)
+  let qtyHint: QtyHint = { main: null, sub: null, mainN: 0, subN: 0 };
+  const { data: confPlans } = await supabase
+    .from("campaign_plans")
+    .select("id")
+    .eq("status", "confirmed")
+    .neq("promotion_id", id);
+  const confIds = ((confPlans as { id: string }[]) ?? []).map((p) => p.id);
+  if (confIds.length > 0) {
+    const { data: hintOpts } = await supabase
+      .from("campaign_plan_options")
+      .select("expected_option_qty, is_main")
+      .in("campaign_plan_id", confIds);
+    const hintRows =
+      (hintOpts as { expected_option_qty: number | null; is_main: boolean }[]) ?? [];
+    const avgQty = (pred: (r: (typeof hintRows)[number]) => boolean) => {
+      const xs = hintRows
+        .filter(pred)
+        .map((r) => r.expected_option_qty)
+        .filter((x): x is number => x != null && x > 0);
+      return xs.length
+        ? { v: Math.round(xs.reduce((a, b) => a + b, 0) / xs.length), n: xs.length }
+        : { v: null, n: 0 };
+    };
+    const m = avgQty((r) => r.is_main);
+    const s = avgQty((r) => !r.is_main);
+    qtyHint = { main: m.v, sub: s.v, mainN: m.n, subN: s.n };
+  }
+
   return (
     <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
       <div className="mb-1 text-sm text-neutral-400">
@@ -128,6 +161,7 @@ export default async function PlanPage({
         plan={plan}
         initialOptions={options}
         rateCard={(rc as RateCard) ?? null}
+        qtyHint={qtyHint}
       />
     </div>
   );


### PR DESCRIPTION
## 개요

S6 하위 **6.2 — 플랜 에디터 예상 세트수 힌트**. 마이그레이션 없음. **비구속 표시 전용**(자동 채움 없음).

> 6.2만. (6.1 머지 완료 · 6.3 추천 달성 일관성 랭킹은 후속 PR)

## 변경 사항
- `/promotions/[id]/plan` page: 다른 캠페인 **확정 플랜** 옵션의 예상 세트수 평균을 메인/서브로 나눠 집계(`QtyHint`) → PlanEditor 전달
- `PlanEditor` / `OptionCard`: 예상 세트수 입력 아래 **"유사 캠페인 평균 N세트 (N건, 메인/서브)"** 힌트 표시
- **자동 입력·값 설정 없음** — 입력값은 사용자만 변경. 데이터 없으면 미표시(콜드스타트)

## 데이터 노트
- 현재 DB에 확정 플랜 0건 → 힌트는 아직 미표시(정상). 확정 플랜이 쌓이면 자동으로 나타남(SPEC §4 콜드스타트 원칙)

## 검수
- [ ] 플랜 에디터 정상 렌더(에러 없음)
- [ ] 확정 플랜 존재 시 메인/서브 평균 세트수 힌트 표시·자동채움 없음
- [ ] Vercel 프리뷰 Ready

S6.2 완료, 검수 후 6.3 대기.

https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ)_