### PR TITLE
N1 fix: 희소 헤더 행 파서 크래시 방지

### DIFF
--- a/promo-analytics/lib/parse.ts
+++ b/promo-analytics/lib/parse.ts
@@ -12,7 +12,7 @@ function norm(s: unknown): string {
 
 /** 헤더 행에서 후보 키워드 중 하나라도 포함하는 첫 컬럼 인덱스 */
 function findCol(header: unknown[], candidates: string[]): number {
-  const normed = header.map(norm);
+  const normed = Array.from(header, norm); // 구멍 없이 dense — undefined 접근 방지
   for (let i = 0; i < normed.length; i++) {
     if (candidates.some((c) => normed[i].includes(norm(c)))) return i;
   }
@@ -47,7 +47,9 @@ function pad(n: number | string): string {
 function firstSheetRows(buf: ArrayBuffer): unknown[][] {
   const wb = XLSX.read(buf, { cellDates: true });
   const ws = wb.Sheets[wb.SheetNames[0]];
-  return XLSX.utils.sheet_to_json(ws, { header: 1, blankrows: false });
+  // defval: "" — 빈 셀을 ""로 채워 희소 배열(구멍) 방지. 헤더에 병합/공백 칸이 있어도
+  // header.map(norm)[i]가 undefined가 되지 않아 findCol 등이 크래시하지 않는다.
+  return XLSX.utils.sheet_to_json(ws, { header: 1, blankrows: false, defval: "" });
 }
 
 /** 워크북 객체 (여러 시트를 이름으로 지정해 파싱할 때 한 번만 읽어 재사용) */
@@ -64,7 +66,7 @@ export function sheetNames(buf: ArrayBuffer): string[] {
 function sheetRows(wb: XLSX.WorkBook, sheetName: string): unknown[][] {
   const ws = wb.Sheets[sheetName];
   if (!ws) throw new Error(`시트를 찾을 수 없습니다: ${sheetName}`);
-  return XLSX.utils.sheet_to_json(ws, { header: 1, blankrows: false });
+  return XLSX.utils.sheet_to_json(ws, { header: 1, blankrows: false, defval: "" });
 }
 
 /** 헤더 셀을 공백 제거·소문자만 적용해 반환 (VAT+/VAT− 구분처럼 부호를 보존해야 할 때) */


### PR DESCRIPTION
## 개요

업로드 중 발생한 크래시 핫픽스. 엑셀 헤더 줄에 **병합/공백 칸**이 있으면 `sheet_to_json`이 희소 배열(구멍)을 만들고, `header.map(norm)[i]`가 `undefined`가 되어 `findCol`에서 **`undefined is not an object (evaluating 't[e].includes')`** 크래시가 발생했습니다(모바일 스크린샷 재현).

## 변경 사항
- `firstSheetRows` / `sheetRows`: `sheet_to_json`에 **`defval: ""`** 추가 → 빈 셀을 `""`로 채워 dense 배열화
- `findCol`: `Array.from(header, norm)`로 구멍 없는 매핑(방어)

## 효과
- 형식이 안 맞는 시트를 골라도 **크래시 대신 기존 한글 오류 메시지**("…헤더를 찾을 수 없습니다") 표시
- 정상 파일 파싱 결과는 동일(빈 셀은 원래 `toNum→0`/`""`로 처리되던 값)

## 검수
- [ ] 헤더에 공백 칸이 있는 엑셀 업로드 시 크래시 없음
- [ ] 잘못된 카드에 파일 넣어도 친절한 오류 메시지
- [ ] Vercel 프리뷰 Ready

https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ)_