### PR TITLE
N1+: 업로드 크래시 방어 + 연동 이력

### DIFF
--- a/promo-analytics/app/(dash)/upload/page.tsx
+++ b/promo-analytics/app/(dash)/upload/page.tsx
@@ -1,10 +1,35 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { won, pct } from "@/lib/format";
 import type { ParsedPriceConfig } from "@/lib/parse";
+
+// 업로드 이력 기록 — 연동 파일명·시간·종류·행수를 남긴다(업데이트 참고용).
+// 실패해도 업로드 자체를 막지 않는다(best-effort).
+async function logUpload(
+  supabase: ReturnType<typeof createClient>,
+  entry: {
+    kind: "daily" | "promotion" | "price_master";
+    source_file: string;
+    detail?: string;
+    row_count?: number;
+    total_revenue?: number | null;
+    action?: "insert" | "replace";
+  },
+) {
+  try {
+    const { data } = await supabase.auth.getUser();
+    await supabase
+      .from("upload_log")
+      .insert({ ...entry, uploaded_by: data.user?.email ?? null });
+    if (typeof window !== "undefined")
+      window.dispatchEvent(new Event("upload-done"));
+  } catch {
+    /* 이력 기록 실패는 무시 */
+  }
+}
 
 type Kind = "master" | "daily" | "promotion";
 
@@ -46,6 +71,116 @@ export default function UploadPage() {
         ))}
         <PriceMasterCard />
       </div>
+      <UploadHistory />
+    </div>
+  );
+}
+
+type LogRow = {
+  id: string;
+  kind: string;
+  source_file: string;
+  detail: string | null;
+  row_count: number | null;
+  total_revenue: number | null;
+  action: string | null;
+  uploaded_by: string | null;
+  created_at: string;
+};
+
+const KIND_LABEL: Record<string, string> = {
+  daily: "일별 매출",
+  promotion: "캠페인",
+  price_master: "가격 마스터",
+};
+
+function UploadHistory() {
+  const [rows, setRows] = useState<LogRow[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    const supabase = createClient();
+    const { data } = await supabase
+      .from("upload_log")
+      .select("*")
+      .order("created_at", { ascending: false })
+      .limit(30);
+    setRows((data as LogRow[]) ?? []);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    load();
+    const h = () => load();
+    window.addEventListener("upload-done", h);
+    return () => window.removeEventListener("upload-done", h);
+  }, [load]);
+
+  return (
+    <div className="mt-6 rounded-[24px] bg-white card-soft p-5">
+      <div className="flex items-center justify-between">
+        <h2 className="font-medium">연동 이력</h2>
+        <button
+          onClick={load}
+          className="rounded-lg border border-neutral-200 px-3 py-1 text-xs text-neutral-600 hover:bg-neutral-50"
+        >
+          새로고침
+        </button>
+      </div>
+      <p className="mt-1 text-sm text-neutral-500">
+        최근 업로드한 파일·시간·행수입니다. 다음 업데이트 때 어떤 소스가 반영됐는지 참고하세요.
+      </p>
+      {loading ? (
+        <p className="mt-4 text-sm text-neutral-400">불러오는 중…</p>
+      ) : rows.length === 0 ? (
+        <p className="mt-4 text-sm text-neutral-400">아직 업로드 이력이 없습니다.</p>
+      ) : (
+        <div className="mt-3 overflow-x-auto">
+          <table className="w-full min-w-[640px] text-left text-sm">
+            <thead className="text-xs text-neutral-400">
+              <tr>
+                <th className="py-1.5 pr-3">시간</th>
+                <th className="py-1.5 pr-3">종류</th>
+                <th className="py-1.5 pr-3">파일명</th>
+                <th className="py-1.5 pr-3">요약</th>
+                <th className="py-1.5 pr-3 text-right">행수</th>
+                <th className="py-1.5">방식</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr key={r.id} className="border-t border-neutral-100 align-top">
+                  <td className="py-1.5 pr-3 whitespace-nowrap text-neutral-500">
+                    {new Date(r.created_at).toLocaleString("ko-KR", {
+                      month: "2-digit",
+                      day: "2-digit",
+                      hour: "2-digit",
+                      minute: "2-digit",
+                    })}
+                  </td>
+                  <td className="py-1.5 pr-3 whitespace-nowrap">
+                    <span className="rounded-full bg-neutral-100 px-2 py-0.5 text-xs text-neutral-600">
+                      {KIND_LABEL[r.kind] ?? r.kind}
+                    </span>
+                  </td>
+                  <td className="py-1.5 pr-3 font-medium text-neutral-800">{r.source_file}</td>
+                  <td className="py-1.5 pr-3 text-neutral-500">{r.detail ?? "—"}</td>
+                  <td className="py-1.5 pr-3 text-right tabular-nums text-neutral-700">
+                    {r.row_count != null ? r.row_count.toLocaleString() : "—"}
+                  </td>
+                  <td className="py-1.5">
+                    {r.action === "replace" ? (
+                      <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[11px] text-amber-700">교체(백필)</span>
+                    ) : (
+                      <span className="rounded bg-neutral-100 px-1.5 py-0.5 text-[11px] text-neutral-500">신규</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 }
@@ -79,6 +214,13 @@ function UploadCard({ def }: { def: CardDef }) {
           .from("products")
           .upsert(rows, { onConflict: "base_name" });
         if (error) throw error;
+        await logUpload(supabase, {
+          kind: "price_master",
+          source_file: file.name,
+          detail: `품목 마스터 ${rows.length}건`,
+          row_count: rows.length,
+          action: "replace",
+        });
         setP({ phase: "ok", message: `${rows.length}개 품목 반영 완료` });
         return;
       }
@@ -198,6 +340,14 @@ function UploadCard({ def }: { def: CardDef }) {
         }
 
         const dates = rows.map((r) => r.sale_date).sort();
+        await logUpload(supabase, {
+          kind: "daily",
+          source_file: file.name,
+          detail: `${dates[0]} ~ ${dates[dates.length - 1]} · 상품 ${productMap.size}종`,
+          row_count: done,
+          total_revenue: newRevenue,
+          action: oldCount && oldCount > 0 ? "replace" : "insert",
+        });
         setP({
           phase: "ok",
           message: `${done}행 적재 · 상품 ${productMap.size}종 · 기간 ${dates[0]} ~ ${dates[dates.length - 1]}`,
@@ -315,6 +465,14 @@ function UploadCard({ def }: { def: CardDef }) {
           done += batch.length;
         }
 
+        await logUpload(supabase, {
+          kind: "promotion",
+          source_file: file.name,
+          detail: `${name} · 실적 교체`,
+          row_count: done,
+          total_revenue: newRevenue,
+          action: "replace",
+        });
         setP({ phase: "ok", message: `${name} 실적 백필 완료 · ${done}행. 상세로 이동합니다…` });
         router.push(`/promotions/${existing.id}`);
         return;
@@ -366,6 +524,14 @@ function UploadCard({ def }: { def: CardDef }) {
         done += batch.length;
       }
 
+      await logUpload(supabase, {
+        kind: "promotion",
+        source_file: file.name,
+        detail: `${name} · ${parsed.start_date}~${parsed.end_date} · 신규`,
+        row_count: done,
+        total_revenue: newRevenue,
+        action: "insert",
+      });
       setP({ phase: "ok", message: `${name} 생성 완료 · ${done}행. 상세로 이동합니다…` });
       router.push(`/promotions/${promo.id}/edit`);
     } catch (e) {
@@ -737,6 +903,13 @@ function PriceMasterCard() {
         done += batch.length;
       }
 
+      await logUpload(supabase, {
+        kind: "price_master",
+        source_file: fileName,
+        detail: `품목 ${itemPayload.length}건 · 구성 ${records.length}건${unmatched > 0 ? ` · 매칭실패 ${unmatched}` : ""}`,
+        row_count: records.length,
+        action: "replace",
+      });
       setPreview((prev) =>
         prev ? { ...prev, matchedConfigCount: records.length, unmatched } : prev,
       );

--- a/promo-analytics/lib/parse.ts
+++ b/promo-analytics/lib/parse.ts
@@ -71,7 +71,9 @@ function sheetRows(wb: XLSX.WorkBook, sheetName: string): unknown[][] {
 
 /** 헤더 셀을 공백 제거·소문자만 적용해 반환 (VAT+/VAT− 구분처럼 부호를 보존해야 할 때) */
 function rawHeader(header: unknown[]): string[] {
-  return header.map((h) => String(h ?? "").replace(/\s+/g, "").toLowerCase());
+  // Array.from — 희소 배열(병합/공백 셀로 생긴 구멍) 방지. findColRaw/findPackPriceCol의
+  // .findIndex가 구멍을 undefined로 방문해 .includes에서 크래시하던 문제 차단.
+  return Array.from(header, (h) => String(h ?? "").replace(/\s+/g, "").toLowerCase());
 }
 
 /** 원시 헤더(부호 보존) 기준으로 조건에 맞는 첫 컬럼 인덱스 */
@@ -128,7 +130,11 @@ export type DailyRow = {
 export function parseDailySales(buf: ArrayBuffer): DailyRow[] {
   const rows = firstSheetRows(buf);
   const h = findHeaderRow(rows, ["일자", "기초상품명", "결제금액", "판매수량"]);
-  if (h < 0) throw new Error("일별 매출 추이 헤더를 찾을 수 없습니다 (일자/기초상품명/결제금액/판매수량).");
+  if (h < 0)
+    throw new Error(
+      "일별 매출 추이 헤더를 찾을 수 없습니다 (일자·기초상품명·결제금액·판매수량 컬럼 필요). " +
+        "‘가이드/기획’ 문서가 아니라 일자별 매출 export인지 확인하세요.",
+    );
   const header = rows[h];
   const cDate = findCol(header, ["일자"]);
   const cName = findCol(header, ["기초상품명", "상품명"]);
@@ -176,7 +182,11 @@ export type ParsedPromotion = {
 export function parsePromotionSheet(buf: ArrayBuffer): ParsedPromotion {
   const rows = firstSheetRows(buf);
   const h = findHeaderRow(rows, ["일자", "기초상품명", "결제금액", "원가", "수수료"]);
-  if (h < 0) throw new Error("프로모션 시트 헤더를 찾을 수 없습니다.");
+  if (h < 0)
+    throw new Error(
+      "캠페인 매출 시트 헤더를 찾을 수 없습니다 (일자·기초상품명·결제금액·원가·수수료 컬럼 필요). " +
+        "‘프로모션 가이드/기획’ 문서는 형식이 달라 이 칸으로 올릴 수 없습니다 — 캠페인 매출 export를 올려주세요.",
+    );
   const header = rows[h];
   const cPeriod = findCol(header, ["일자"]);
   const cName = findCol(header, ["기초상품명", "상품명"]);

--- a/promo-analytics/supabase/migrations/0013_upload_log.sql
+++ b/promo-analytics/supabase/migrations/0013_upload_log.sql
@@ -1,0 +1,21 @@
+-- 0013: 업로드 이력 — 연동된 파일명·시간·종류·행수 기록 (업데이트 참고용)
+create table if not exists promo.upload_log (
+  id uuid primary key default gen_random_uuid(),
+  kind text not null,            -- 'daily' | 'promotion' | 'price_master'
+  source_file text not null,
+  detail text,                   -- 기간/캠페인명/시트 등 요약
+  row_count integer,
+  total_revenue numeric,
+  action text,                   -- 'insert' | 'replace'(백필 교체)
+  uploaded_by text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists upload_log_created_idx on promo.upload_log (created_at desc);
+
+alter table promo.upload_log enable row level security;
+drop policy if exists upload_log_authenticated_all on promo.upload_log;
+create policy upload_log_authenticated_all on promo.upload_log
+  for all to authenticated using (true) with check (true);
+
+grant all on promo.upload_log to authenticated;


### PR DESCRIPTION
## 개요

업로드 크래시 추가 방어 + **연동 이력(파일명·시간)** 기능. 모바일에서 가격가이드(④) 업로드가 `undefined is not an object (e.includes)`로 죽던 문제와, "어떤 파일이 언제 반영됐는지" 추적 요청을 함께 해결합니다.

## 변경 사항
### 마이그레이션 `0013_upload_log` (additive · 적용 완료)
`promo.upload_log` — 연동 파일명·시간·종류·행수·총매출·방식(신규/교체) 기록. RLS는 기존 패턴(authenticated all) 동일.

### 크래시 방어 (`lib/parse.ts`)
- `rawHeader`를 **`Array.from`으로 dense화** → `findColRaw`/`findPackPriceCol`의 `.findIndex`가 희소 헤더(병합/공백 셀)의 구멍을 `undefined`로 방문해 `.includes`에서 죽던 문제 차단 (#45의 `defval`에 이은 확정 방어)
- ③/④ 헤더 미발견 시 **기대 컬럼 + "가이드/기획 문서는 형식이 다름"** 안내로 개선

### 연동 이력 (`/upload`)
- 각 적재 성공 시 `upload_log` 기록(일별/캠페인/가격마스터, 신규/교체 구분)
- 하단에 **"연동 이력" 표**: 시간·종류·파일명·요약·행수·방식. `upload-done` 이벤트로 업로드 직후 자동 갱신

## 파일 형식 관련(중요)
- **가격가이드** 파일 → **④ 가격 마스터** 카드가 맞음(`품목코드/기초 상품명/소비자가/원가(VAT+)/상시가/2·3·4·5묶음` 호환). 이 PR로 크래시 없이 적재됩니다.
- **프로모션 가이드(기획)** 파일 → 캠페인 블록이 박스로 쌓인 *기획 문서*라, ③(평평한 매출 export: 일자·기초상품명·결제금액·원가·수수료)와 형식이 다릅니다. ③로는 올릴 수 없고, 이제 친절한 안내가 표시됩니다.

## 검수
- [ ] 가격가이드 워크북 ④ 적재 시 크래시 없음
- [ ] 적재 후 "연동 이력"에 파일명·시간 표시
- [ ] 잘못된 카드에 가이드 문서 넣으면 안내 메시지
- [ ] Vercel 프리뷰 Ready

https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ)_