### PR TITLE
프로모션 가이드 임포터 1단계: 파서 + 미리보기

### DIFF
--- a/promo-analytics/app/(dash)/upload/page.tsx
+++ b/promo-analytics/app/(dash)/upload/page.tsx
@@ -70,6 +70,7 @@ export default function UploadPage() {
           <UploadCard key={c.key} def={c} />
         ))}
         <PriceMasterCard />
+        <GuideImportCard />
       </div>
       <UploadHistory />
     </div>
@@ -1120,6 +1121,121 @@ function PriceMasterCard() {
               />
             </div>
           )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────
+// ⑤ 프로모션 가이드 (일괄) — 미리보기 전용 (S: 전용 임포터 1단계)
+//    캠페인 블록(CF_P 코드·기간·상품표)을 파싱해 무엇이 잡히는지 확인만 한다. DB 기록 없음.
+// ─────────────────────────────────────────────
+function GuideImportCard() {
+  const [p, setP] = useState<Progress>({ phase: "idle", message: "" });
+  const [campaigns, setCampaigns] = useState<
+    import("@/lib/parseGuide").GuideCampaign[] | null
+  >(null);
+
+  async function handleFile(file: File) {
+    try {
+      setCampaigns(null);
+      setP({ phase: "reading", message: `${file.name} 읽는 중…` });
+      const buf = await file.arrayBuffer();
+      setP({ phase: "parsing", message: "가이드 파싱 중…" });
+      const { parseCampaignGuide } = await import("@/lib/parseGuide");
+      const found = parseCampaignGuide(buf);
+      if (found.length === 0)
+        throw new Error(
+          "캠페인 블록(CF_P 코드 + 상품명·판매수량·매출 표)을 찾지 못했습니다. 프로모션 가이드 워크북이 맞는지 확인하세요.",
+        );
+      setCampaigns(found);
+      setP({
+        phase: "ok",
+        message: `${found.length}개 캠페인 · 상품 ${found.reduce((s, c) => s + c.products.length, 0)}행 인식`,
+      });
+    } catch (e) {
+      setP({ phase: "error", message: errMsg(e) });
+    }
+  }
+
+  return (
+    <div className="rounded-[24px] bg-white card-soft p-5">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="font-medium">⑤ 프로모션 가이드 (일괄 · 미리보기)</h2>
+          <p className="mt-1 text-sm text-neutral-500">
+            여러 캠페인이 박스로 쌓인 ‘프로모션 가이드’ 워크북에서 캠페인별 상품·판매수량·매출을
+            인식합니다. <b>지금은 미리보기 전용</b>(DB에 쓰지 않음) — 인식 결과를 확인한 뒤 다음
+            단계에서 백필을 켭니다.
+          </p>
+        </div>
+        <label
+          className={`shrink-0 cursor-pointer rounded-xl border border-neutral-200 px-4 py-2 text-sm font-medium hover:bg-neutral-50 ${
+            p.phase === "reading" || p.phase === "parsing" ? "pointer-events-none opacity-50" : ""
+          }`}
+        >
+          파일 선택
+          <input
+            type="file"
+            accept=".xlsx,.xls"
+            className="hidden"
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) handleFile(f);
+              e.target.value = "";
+            }}
+          />
+        </label>
+      </div>
+
+      {p.phase !== "idle" && p.message && (
+        <div
+          className={`mt-3 rounded-lg px-3 py-2 text-sm ${
+            p.phase === "error"
+              ? "bg-red-50 text-red-700"
+              : p.phase === "ok"
+                ? "bg-green-50 text-green-700"
+                : "bg-neutral-100 text-neutral-600"
+          }`}
+        >
+          {p.message}
+        </div>
+      )}
+
+      {campaigns && campaigns.length > 0 && (
+        <div className="mt-4 overflow-x-auto">
+          <table className="w-full min-w-[560px] text-left text-sm">
+            <thead className="text-xs text-neutral-400">
+              <tr>
+                <th className="py-1.5 pr-3">코드</th>
+                <th className="py-1.5 pr-3">기간</th>
+                <th className="py-1.5 pr-3 text-right">상품수</th>
+                <th className="py-1.5 pr-3 text-right">Σ판매수량</th>
+                <th className="py-1.5 text-right">Σ매출</th>
+              </tr>
+            </thead>
+            <tbody>
+              {campaigns.map((c) => (
+                <tr key={c.code} className="border-t border-neutral-100">
+                  <td className="py-1.5 pr-3 font-medium text-neutral-800">{c.code}</td>
+                  <td className="py-1.5 pr-3 whitespace-nowrap text-neutral-500">
+                    {c.start_date ?? "?"}
+                    {c.end_date ? ` ~ ${c.end_date}` : ""}
+                  </td>
+                  <td className="py-1.5 pr-3 text-right tabular-nums">{c.products.length}</td>
+                  <td className="py-1.5 pr-3 text-right tabular-nums">
+                    {c.total_qty.toLocaleString()}
+                  </td>
+                  <td className="py-1.5 text-right tabular-nums">{won(c.total_revenue)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <p className="mt-2 text-[11px] text-neutral-400">
+            상품명·수량·매출이 캠페인별로 맞게 잡혔는지 확인해 주세요. 이 표를 캡처해 공유하면
+            컬럼 매핑을 검증한 뒤 실제 백필(코드로 캠페인 매칭→실적 교체)을 활성화합니다.
+          </p>
         </div>
       )}
     </div>

--- a/promo-analytics/lib/parseGuide.ts
+++ b/promo-analytics/lib/parseGuide.ts
@@ -1,0 +1,168 @@
+import * as XLSX from "xlsx";
+
+// 자사몰 '프로모션 가이드' 워크북 파서 (전용 임포터).
+// 한 시트에 캠페인 블록(CF_P 코드·기간·상품표)이 박스로 쌓여 있어, 평평한 매출 export와 다르다.
+// 라벨 앵커(코드/프로모션일시/상품표 헤더)로 블록을 식별하고, 컬럼은 헤더 라벨로 런타임 탐지한다.
+
+export type GuideProduct = {
+  name: string; // 등록상품명
+  quantity: number; // 판매수량
+  revenue: number; // 매출
+};
+
+export type GuideCampaign = {
+  code: string; // CF_P_YYMMDD
+  name: string; // 블록 제목(있으면)
+  start_date: string | null;
+  end_date: string | null;
+  products: GuideProduct[];
+  total_qty: number;
+  total_revenue: number;
+};
+
+function norm(s: unknown): string {
+  return String(s ?? "").replace(/\s+/g, "").toLowerCase();
+}
+
+function toNum(v: unknown): number {
+  if (v == null || v === "" || v === "-") return 0;
+  if (typeof v === "number") return v;
+  const n = Number(String(v).replace(/[,\s₩%]/g, ""));
+  return Number.isFinite(n) ? n : 0;
+}
+
+function pad2(n: number | string): string {
+  return String(n).padStart(2, "0");
+}
+
+// CF_P_YYMMDD → YYYY-MM-DD (6자리 코드만; 4자리는 날짜 미상)
+function dateFromCode(code: string): string | null {
+  const m = code.match(/CF_P_(\d{6})/i);
+  if (!m) return null;
+  const d = m[1];
+  const year = 2000 + Number(d.slice(0, 2));
+  const mm = Number(d.slice(2, 4));
+  const dd = Number(d.slice(4, 6));
+  if (mm < 1 || mm > 12 || dd < 1 || dd > 31) return null;
+  return `${year}-${pad2(mm)}-${pad2(dd)}`;
+}
+
+const SUMMARY_LABEL = /^\[?(이익률|구매수|총매출|총광고비|광고비|판관비|상품원가|배송비|이익|roas|객단가|수수료|합계|순위|상품명|등록상품명|소계|총계)\]?$/i;
+
+export function parseCampaignGuide(buf: ArrayBuffer): GuideCampaign[] {
+  const wb = XLSX.read(buf, { cellDates: true });
+
+  // CF_P 코드가 가장 많이 등장하는 시트를 캠페인 블록 시트로 선택
+  let bestSheet = "";
+  let bestCount = -1;
+  const grids: Record<string, unknown[][]> = {};
+  for (const sn of wb.SheetNames) {
+    const rows = XLSX.utils.sheet_to_json(wb.Sheets[sn], {
+      header: 1,
+      blankrows: false,
+      defval: "",
+    }) as unknown[][];
+    grids[sn] = rows;
+    let c = 0;
+    for (const r of rows)
+      for (const cell of r) if (/CF_P_\d{4,6}/i.test(String(cell))) c++;
+    if (c > bestCount) {
+      bestCount = c;
+      bestSheet = sn;
+    }
+  }
+
+  const rows = grids[bestSheet] ?? [];
+  const campaigns: GuideCampaign[] = [];
+  let cur: GuideCampaign | null = null;
+  let colName = -1;
+  let colQty = -1;
+  let colRev = -1;
+
+  const flush = () => {
+    if (cur && cur.products.length > 0) {
+      cur.total_qty = cur.products.reduce((s, p) => s + p.quantity, 0);
+      cur.total_revenue = cur.products.reduce((s, p) => s + p.revenue, 0);
+      campaigns.push(cur);
+    }
+    cur = null;
+    colName = colQty = colRev = -1;
+  };
+
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i];
+    const cells = Array.from(row, (c) => String(c ?? "").trim());
+
+    // 새 블록: 6자리 코드(CF_P_YYMMDD) 셀 등장
+    const codeCell = cells.find((c) => /^CF_P_\d{6}$/i.test(c));
+    if (codeCell) {
+      flush();
+      const title =
+        cells.find((c) => /CF_P_\d{4,6}/i.test(c) && c.length > 12) ?? codeCell;
+      cur = {
+        code: codeCell.toUpperCase(),
+        name: title,
+        start_date: dateFromCode(codeCell),
+        end_date: null,
+        products: [],
+        total_qty: 0,
+        total_revenue: 0,
+      };
+    }
+    if (!cur) continue;
+
+    // 기간:MM/DD~MM/DD → 코드의 연도를 사용해 보정
+    const periodCell = cells.find(
+      (c) => c.includes("기간:") || /\d{1,2}\/\d{1,2}\s*~\s*\d{1,2}\/\d{1,2}/.test(c),
+    );
+    if (periodCell && cur.start_date) {
+      const m = periodCell.match(/(\d{1,2})\/(\d{1,2})\s*~\s*(\d{1,2})\/(\d{1,2})/);
+      if (m) {
+        const year = cur.start_date.slice(0, 4);
+        cur.start_date = `${year}-${pad2(m[1])}-${pad2(m[2])}`;
+        cur.end_date = `${year}-${pad2(m[3])}-${pad2(m[4])}`;
+      }
+    }
+
+    // 상품표 헤더 탐지 (상품명 + 판매수량 + 매출 이 한 행에)
+    if (colQty < 0) {
+      const nameIdx = cells.findIndex((c) => {
+        const n = norm(c);
+        return n.includes("상품명");
+      });
+      const qtyIdx = cells.findIndex((c) => norm(c).includes("판매수량"));
+      const revIdx = cells.findIndex((c) => norm(c) === "매출" || norm(c).includes("매출액"));
+      if (nameIdx >= 0 && qtyIdx >= 0 && revIdx >= 0) {
+        colName = nameIdx;
+        colQty = qtyIdx;
+        colRev = revIdx;
+        continue;
+      }
+    } else {
+      // 상품 데이터 행
+      const name = (cells[colName] ?? "").trim();
+      const qty = toNum(row[colQty]);
+      const rev = toNum(row[colRev]);
+      if (name && !SUMMARY_LABEL.test(name) && (qty > 0 || rev > 0)) {
+        cur.products.push({ name, quantity: qty, revenue: rev });
+      }
+    }
+  }
+  flush();
+
+  // 같은 코드 블록이 여러 번 나오면 병합(상품 합산)
+  const byCode = new Map<string, GuideCampaign>();
+  for (const c of campaigns) {
+    const prev = byCode.get(c.code);
+    if (!prev) {
+      byCode.set(c.code, c);
+    } else {
+      prev.products.push(...c.products);
+      prev.total_qty += c.total_qty;
+      prev.total_revenue += c.total_revenue;
+      if (!prev.start_date && c.start_date) prev.start_date = c.start_date;
+      if (!prev.end_date && c.end_date) prev.end_date = c.end_date;
+    }
+  }
+  return [...byCode.values()].sort((a, b) => a.code.localeCompare(b.code));
+}


### PR DESCRIPTION
## 개요

‘자사몰 프로모션 가이드’ **전용 임포터 1단계** — 파서 + **미리보기 전용 카드**(DB 쓰기 없음). 블라인드로 DB에 쓰는 위험을 피하려고, 먼저 실제 파일에서 캠페인·상품·수량·매출이 제대로 잡히는지 *읽기만으로* 검증합니다.

## 배경
File 1(프로모션 가이드)은 여러 캠페인(CF_P_2308, 2309…)이 박스로 쌓이고 반품안내/상세템플릿까지 섞인 **불규칙 2D 워크북**이라, ③의 평평한 매출 export와 형식이 완전히 다릅니다. 그래서 라벨 앵커로 블록을 식별하는 전용 파서가 필요합니다.

## 변경 사항
- `lib/parseGuide.ts`: 
  - CF_P 코드가 가장 많은 시트 선택
  - 블록 단위 파싱 — `코드`(CF_P_YYMMDD → 연·월·일), `기간:MM/DD~MM/DD`, 상품표 헤더(`상품명/판매수량/매출`는 **라벨로 런타임 컬럼 탐지**), 상품 행
  - 요약 라벨 행(이익률/구매수/총매출 등) 제외, 같은 코드 블록 병합
- `/upload` **⑤ 카드(미리보기 전용)**: 캠페인별 코드·기간·상품수·Σ판매수량·Σ매출 표. **DB 기록 없음.**

## 다음 단계 (별도 PR)
미리보기가 정확함을 확인하면 → 코드로 캠페인 find-or-create → 실적 promotion_sales 교체(백필, 부풀림 방지 동일 패턴) + upload_log 기록 활성화.

## 검수
- [ ] 프로모션 가이드 워크북 ⑤에 올리면 캠페인 목록·수량·매출이 합리적으로 표시
- [ ] 표를 캡처해 공유 → 컬럼 매핑 검증
- [ ] Vercel 프리뷰 Ready

https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ)_