### PR TITLE
가이드 파서 견고화 (다양한 양식 + 실적만 안전 추출)

### DIFF
--- a/promo-analytics/app/(dash)/upload/page.tsx
+++ b/promo-analytics/app/(dash)/upload/page.tsx
@@ -1205,14 +1205,15 @@ function GuideImportCard() {
 
       {campaigns && campaigns.length > 0 && (
         <div className="mt-4 overflow-x-auto">
-          <table className="w-full min-w-[560px] text-left text-sm">
+          <table className="w-full min-w-[680px] text-left text-sm">
             <thead className="text-xs text-neutral-400">
               <tr>
                 <th className="py-1.5 pr-3">코드</th>
                 <th className="py-1.5 pr-3">기간</th>
                 <th className="py-1.5 pr-3 text-right">상품수</th>
                 <th className="py-1.5 pr-3 text-right">Σ판매수량</th>
-                <th className="py-1.5 text-right">Σ매출</th>
+                <th className="py-1.5 pr-3 text-right">Σ매출</th>
+                <th className="py-1.5">읽은 지표</th>
               </tr>
             </thead>
             <tbody>
@@ -1227,7 +1228,10 @@ function GuideImportCard() {
                   <td className="py-1.5 pr-3 text-right tabular-nums">
                     {c.total_qty.toLocaleString()}
                   </td>
-                  <td className="py-1.5 text-right tabular-nums">{won(c.total_revenue)}</td>
+                  <td className="py-1.5 pr-3 text-right tabular-nums">{won(c.total_revenue)}</td>
+                  <td className="py-1.5 whitespace-nowrap text-[11px] text-neutral-400">
+                    {c.qty_label} · {c.rev_label}
+                  </td>
                 </tr>
               ))}
             </tbody>

--- a/promo-analytics/lib/parseGuide.ts
+++ b/promo-analytics/lib/parseGuide.ts
@@ -1,20 +1,23 @@
 import * as XLSX from "xlsx";
 
 // 자사몰 '프로모션 가이드' 워크북 파서 (전용 임포터).
-// 한 시트에 캠페인 블록(CF_P 코드·기간·상품표)이 박스로 쌓여 있어, 평평한 매출 export와 다르다.
-// 라벨 앵커(코드/프로모션일시/상품표 헤더)로 블록을 식별하고, 컬럼은 헤더 라벨로 런타임 탐지한다.
+// 한 시트에 캠페인 블록(CF_P 코드 + 상품표)이 박스로 쌓여 있고, 연도/캠페인마다 표 양식이 다르다.
+// 실적(판매수량/실판매량·매출/실매출)만 안전하게 읽고, 계획(목표)·구성(번들/재고)·상시(월/평균
+// 판매량)는 명시적으로 제외한다. 라벨로 런타임 컬럼 탐지.
 
 export type GuideProduct = {
-  name: string; // 등록상품명
-  quantity: number; // 판매수량
-  revenue: number; // 매출
+  name: string;
+  quantity: number;
+  revenue: number;
 };
 
 export type GuideCampaign = {
-  code: string; // CF_P_YYMMDD
-  name: string; // 블록 제목(있으면)
+  code: string; // CF_P_… (가능하면 6자리)
+  name: string;
   start_date: string | null;
   end_date: string | null;
+  qty_label: string; // 실제로 읽은 수량 컬럼 라벨 (검증용)
+  rev_label: string; // 실제로 읽은 매출 컬럼 라벨
   products: GuideProduct[];
   total_qty: number;
   total_revenue: number;
@@ -23,19 +26,21 @@ export type GuideCampaign = {
 function norm(s: unknown): string {
   return String(s ?? "").replace(/\s+/g, "").toLowerCase();
 }
-
 function toNum(v: unknown): number {
   if (v == null || v === "" || v === "-") return 0;
   if (typeof v === "number") return v;
   const n = Number(String(v).replace(/[,\s₩%]/g, ""));
   return Number.isFinite(n) ? n : 0;
 }
-
 function pad2(n: number | string): string {
   return String(n).padStart(2, "0");
 }
 
-// CF_P_YYMMDD → YYYY-MM-DD (6자리 코드만; 4자리는 날짜 미상)
+// 코드에서 연도 추출 (CF_P_YYMMDD 또는 CF_P_YYMM)
+function yearFromCode(code: string): number | null {
+  const m = code.match(/CF_P_(\d{2})/i);
+  return m ? 2000 + Number(m[1]) : null;
+}
 function dateFromCode(code: string): string | null {
   const m = code.match(/CF_P_(\d{6})/i);
   if (!m) return null;
@@ -47,12 +52,57 @@ function dateFromCode(code: string): string | null {
   return `${year}-${pad2(mm)}-${pad2(dd)}`;
 }
 
-const SUMMARY_LABEL = /^\[?(이익률|구매수|총매출|총광고비|광고비|판관비|상품원가|배송비|이익|roas|객단가|수수료|합계|순위|상품명|등록상품명|소계|총계)\]?$/i;
+// "2024.08.05 (MON) ~ 08.09" / "02.15 14:00 ~ 02.20 23:59" / "05.27 ~ 05.31"
+function parsePeriod(
+  text: string,
+  fallbackYear: number | null,
+): { start: string | null; end: string | null } {
+  const re =
+    /(?:(\d{4})[.\-/])?(\d{1,2})[.\-/](\d{1,2})(?:\s+\d{1,2}:\d{2})?\s*~\s*(?:(\d{4})[.\-/])?(\d{1,2})[.\-/](\d{1,2})/;
+  const m = text.match(re);
+  if (!m) return { start: null, end: null };
+  const y1 = m[1] ? Number(m[1]) : fallbackYear;
+  const y2 = m[4] ? Number(m[4]) : y1;
+  if (!y1) return { start: null, end: null };
+  return {
+    start: `${y1}-${pad2(m[2])}-${pad2(m[3])}`,
+    end: y2 ? `${y2}-${pad2(m[5])}-${pad2(m[6])}` : null,
+  };
+}
+
+const SUMMARY_LABEL =
+  /^\[?(이익률|구매수|총매출|총광고비|광고비|판관비|상품원가|배송비|이익|roas|객단가|수수료|합계|소계|총계|순위|상품명|등록상품명|분류|구분|상품리스트)\]?$/i;
+
+// 수량 컬럼: 실판매량 > 판매수량 > 판매량. 목표·번들·재고·구성·월/평균/주/일 단위는 제외.
+function pickQtyCol(cells: string[]): { idx: number; label: string } {
+  const bad = /(목표|번들|재고|구성|월|평균|주단위|일단위|예상|계획)/;
+  const priorities = [/실판매량/, /판매수량/, /판매량/];
+  for (const pat of priorities) {
+    const idx = cells.findIndex((c) => pat.test(norm(c)) && !bad.test(norm(c)));
+    if (idx >= 0) return { idx, label: cells[idx].trim() };
+  }
+  return { idx: -1, label: "" };
+}
+// 매출 컬럼: 실매출 > 매출(단, 총매출/목표매출/원가/광고 제외)
+function pickRevCol(cells: string[]): { idx: number; label: string } {
+  const bad = /(총매출|목표|원가|광고|단품합|원가합)/;
+  let idx = cells.findIndex((c) => norm(c) === "실매출");
+  if (idx < 0)
+    idx = cells.findIndex((c) => /실매출/.test(norm(c)) && !bad.test(norm(c)));
+  if (idx < 0)
+    idx = cells.findIndex(
+      (c) => (norm(c) === "매출" || /매출액/.test(norm(c))) && !bad.test(norm(c)),
+    );
+  return idx >= 0 ? { idx, label: cells[idx].trim() } : { idx: -1, label: "" };
+}
+function pickNameCol(cells: string[]): number {
+  return cells.findIndex((c) => norm(c).includes("상품명"));
+}
 
 export function parseCampaignGuide(buf: ArrayBuffer): GuideCampaign[] {
   const wb = XLSX.read(buf, { cellDates: true });
 
-  // CF_P 코드가 가장 많이 등장하는 시트를 캠페인 블록 시트로 선택
+  // CF_P 코드가 가장 많은 시트 선택
   let bestSheet = "";
   let bestCount = -1;
   const grids: Record<string, unknown[][]> = {};
@@ -71,96 +121,106 @@ export function parseCampaignGuide(buf: ArrayBuffer): GuideCampaign[] {
       bestSheet = sn;
     }
   }
-
   const rows = grids[bestSheet] ?? [];
-  const campaigns: GuideCampaign[] = [];
-  let cur: GuideCampaign | null = null;
-  let colName = -1;
-  let colQty = -1;
-  let colRev = -1;
 
-  const flush = () => {
+  type Block = GuideCampaign & { _key: string };
+  const blocks: Block[] = [];
+  let cur: Block | null = null;
+  let colName = -1,
+    colQty = -1,
+    colRev = -1;
+
+  const finish = () => {
     if (cur && cur.products.length > 0) {
       cur.total_qty = cur.products.reduce((s, p) => s + p.quantity, 0);
       cur.total_revenue = cur.products.reduce((s, p) => s + p.revenue, 0);
-      campaigns.push(cur);
+      blocks.push(cur);
     }
     cur = null;
     colName = colQty = colRev = -1;
   };
 
   for (let i = 0; i < rows.length; i++) {
-    const row = rows[i];
-    const cells = Array.from(row, (c) => String(c ?? "").trim());
+    const cells = Array.from(rows[i], (c) => String(c ?? "").trim());
 
-    // 새 블록: 6자리 코드(CF_P_YYMMDD) 셀 등장
-    const codeCell = cells.find((c) => /^CF_P_\d{6}$/i.test(c));
-    if (codeCell) {
-      flush();
-      const title =
-        cells.find((c) => /CF_P_\d{4,6}/i.test(c) && c.length > 12) ?? codeCell;
-      cur = {
-        code: codeCell.toUpperCase(),
-        name: title,
-        start_date: dateFromCode(codeCell),
-        end_date: null,
-        products: [],
-        total_qty: 0,
-        total_revenue: 0,
-      };
+    // 블록 시작/갱신: CF_P 코드 셀 (4~6자리)
+    const codeCell = cells.find((c) => /^CF_P_\d{4,6}\b/i.test(c) || /^CF_P_\d{4,6}$/i.test(c));
+    const codeMatch = codeCell?.match(/CF_P_\d{4,6}/i)?.[0]?.toUpperCase();
+    if (codeMatch) {
+      const key4 = codeMatch.replace(/^CF_P_/i, "").slice(0, 4); // YYMM 프리픽스
+      const sameCampaign = cur && cur._key === key4;
+      if (sameCampaign && cur) {
+        // 같은 캠페인의 더 구체적인 코드(6자리)면 코드·날짜 보강
+        if (codeMatch.length > cur.code.length) {
+          cur.code = codeMatch;
+          const d = dateFromCode(codeMatch);
+          if (d) cur.start_date = d;
+        }
+      } else {
+        finish();
+        cur = {
+          _key: key4,
+          code: codeMatch,
+          name: codeCell ?? codeMatch,
+          start_date: dateFromCode(codeMatch),
+          end_date: null,
+          qty_label: "",
+          rev_label: "",
+          products: [],
+          total_qty: 0,
+          total_revenue: 0,
+        };
+      }
     }
     if (!cur) continue;
 
-    // 기간:MM/DD~MM/DD → 코드의 연도를 사용해 보정
-    const periodCell = cells.find(
-      (c) => c.includes("기간:") || /\d{1,2}\/\d{1,2}\s*~\s*\d{1,2}\/\d{1,2}/.test(c),
-    );
-    if (periodCell && cur.start_date) {
-      const m = periodCell.match(/(\d{1,2})\/(\d{1,2})\s*~\s*(\d{1,2})\/(\d{1,2})/);
-      if (m) {
-        const year = cur.start_date.slice(0, 4);
-        cur.start_date = `${year}-${pad2(m[1])}-${pad2(m[2])}`;
-        cur.end_date = `${year}-${pad2(m[3])}-${pad2(m[4])}`;
+    // 기간 (프로모션일시 행 등 어디서든)
+    if (!cur.end_date) {
+      const joined = cells.join(" ");
+      if (/~/.test(joined) && /\d{1,2}[.\-/]\d{1,2}/.test(joined)) {
+        const { start, end } = parsePeriod(joined, yearFromCode(cur.code));
+        if (start) {
+          cur.start_date = start;
+          cur.end_date = end;
+        }
       }
     }
 
-    // 상품표 헤더 탐지 (상품명 + 판매수량 + 매출 이 한 행에)
+    // 상품표 헤더 (상품명 + 실적 수량 + 실적 매출)
     if (colQty < 0) {
-      const nameIdx = cells.findIndex((c) => {
-        const n = norm(c);
-        return n.includes("상품명");
-      });
-      const qtyIdx = cells.findIndex((c) => norm(c).includes("판매수량"));
-      const revIdx = cells.findIndex((c) => norm(c) === "매출" || norm(c).includes("매출액"));
-      if (nameIdx >= 0 && qtyIdx >= 0 && revIdx >= 0) {
+      const nameIdx = pickNameCol(cells);
+      const qty = pickQtyCol(cells);
+      const rev = pickRevCol(cells);
+      if (nameIdx >= 0 && qty.idx >= 0 && rev.idx >= 0) {
         colName = nameIdx;
-        colQty = qtyIdx;
-        colRev = revIdx;
+        colQty = qty.idx;
+        colRev = rev.idx;
+        cur.qty_label = qty.label;
+        cur.rev_label = rev.label;
         continue;
       }
     } else {
-      // 상품 데이터 행
       const name = (cells[colName] ?? "").trim();
-      const qty = toNum(row[colQty]);
-      const rev = toNum(row[colRev]);
+      const qty = toNum(rows[i][colQty]);
+      const rev = toNum(rows[i][colRev]);
       if (name && !SUMMARY_LABEL.test(name) && (qty > 0 || rev > 0)) {
         cur.products.push({ name, quantity: qty, revenue: rev });
       }
     }
   }
-  flush();
+  finish();
 
-  // 같은 코드 블록이 여러 번 나오면 병합(상품 합산)
+  // 같은 코드 병합
   const byCode = new Map<string, GuideCampaign>();
-  for (const c of campaigns) {
+  for (const b of blocks) {
+    const { _key, ...c } = b;
+    void _key;
     const prev = byCode.get(c.code);
-    if (!prev) {
-      byCode.set(c.code, c);
-    } else {
+    if (!prev) byCode.set(c.code, c);
+    else {
       prev.products.push(...c.products);
       prev.total_qty += c.total_qty;
       prev.total_revenue += c.total_revenue;
-      if (!prev.start_date && c.start_date) prev.start_date = c.start_date;
       if (!prev.end_date && c.end_date) prev.end_date = c.end_date;
     }
   }

--- a/promo-analytics/lib/parseGuide.ts
+++ b/promo-analytics/lib/parseGuide.ts
@@ -57,8 +57,9 @@ function dateFromDigits(d: string): string | null {
 }
 
 function parsePeriod(text: string, fallbackYear: number | null) {
+  // 첫 날짜와 '~' 사이의 요일 표기·시간 등(예: " (MON) ", " 14:00 ")을 모두 허용
   const re =
-    /(?:(\d{4})[.\-/])?(\d{1,2})[.\-/](\d{1,2})(?:\s+\d{1,2}:\d{2})?\s*~\s*(?:(\d{4})[.\-/])?(\d{1,2})[.\-/](\d{1,2})/;
+    /(?:(\d{4})[.\-/])?(\d{1,2})[.\-/](\d{1,2})[^~]*~\s*(?:(\d{4})[.\-/])?(\d{1,2})[.\-/](\d{1,2})/;
   const m = text.match(re);
   if (!m) return { start: null as string | null, end: null as string | null };
   const y1 = m[1] ? Number(m[1]) : fallbackYear;
@@ -136,7 +137,19 @@ export function parseCampaignGuide(buf: ArrayBuffer): GuideCampaign[] {
       const codeCellRaw = cells.find((c) => /^CF_P_\d{4,8}/i.test(c));
       const parsed = codeCellRaw ? codeFromCell(codeCellRaw) : null;
       if (parsed) {
-        if (!cur || cur.code !== parsed.code) {
+        const curDigits = cur ? cur.code.replace(/^CF_P_/i, "") : null;
+        // 같은 캠페인: 한쪽 코드가 다른 쪽의 프리픽스 (예: 2308 ↔ 230817)
+        const same =
+          curDigits != null &&
+          (parsed.digits.startsWith(curDigits) || curDigits.startsWith(parsed.digits));
+        if (cur && same) {
+          // 더 구체적인(긴) 코드면 코드·날짜 보강 (블록 분할/중복 방지)
+          if (parsed.digits.length > curDigits!.length) {
+            cur.code = parsed.code;
+            const d = dateFromDigits(parsed.digits);
+            if (d) cur.start_date = d;
+          }
+        } else if (!cur || cur.code !== parsed.code) {
           flush();
           cur = {
             code: parsed.code,

--- a/promo-analytics/lib/parseGuide.ts
+++ b/promo-analytics/lib/parseGuide.ts
@@ -1,23 +1,21 @@
 import * as XLSX from "xlsx";
 
 // 자사몰 '프로모션 가이드' 워크북 파서 (전용 임포터).
-// 한 시트에 캠페인 블록(CF_P 코드 + 상품표)이 박스로 쌓여 있고, 연도/캠페인마다 표 양식이 다르다.
-// 실적(판매수량/실판매량·매출/실매출)만 안전하게 읽고, 계획(목표)·구성(번들/재고)·상시(월/평균
-// 판매량)는 명시적으로 제외한다. 라벨로 런타임 컬럼 탐지.
+// 여러 시트에 캠페인 블록(CF_P 코드 + 상품표)이 박스로 쌓여 있고, 연도/캠페인마다 표 양식이 다르다.
+// - 모든 시트를 스캔한다(블록이 시트별로 흩어져 있음).
+// - 코드는 셀 시작이 'CF_P_' + 4~8자리(제목에 붙은 'CF_P_240301_제목'도 인식).
+// - 실적(실판매량/판매수량/판매량 · 실매출/매출)만 읽고, 계획(목표)·구성(번들/재고)·
+//   상시(월/평균 판매량)는 제외한다.
 
-export type GuideProduct = {
-  name: string;
-  quantity: number;
-  revenue: number;
-};
+export type GuideProduct = { name: string; quantity: number; revenue: number };
 
 export type GuideCampaign = {
-  code: string; // CF_P_… (가능하면 6자리)
+  code: string;
   name: string;
   start_date: string | null;
   end_date: string | null;
-  qty_label: string; // 실제로 읽은 수량 컬럼 라벨 (검증용)
-  rev_label: string; // 실제로 읽은 매출 컬럼 라벨
+  qty_label: string;
+  rev_label: string;
   products: GuideProduct[];
   total_qty: number;
   total_revenue: number;
@@ -36,31 +34,33 @@ function pad2(n: number | string): string {
   return String(n).padStart(2, "0");
 }
 
-// 코드에서 연도 추출 (CF_P_YYMMDD 또는 CF_P_YYMM)
-function yearFromCode(code: string): number | null {
-  const m = code.match(/CF_P_(\d{2})/i);
-  return m ? 2000 + Number(m[1]) : null;
-}
-function dateFromCode(code: string): string | null {
-  const m = code.match(/CF_P_(\d{6})/i);
+// CF_P_ 뒤 숫자에서 코드/연도/날짜 도출. 8자리=YYYYMMDD, 6자리=YYMMDD, 4자리=YYMM(일 미상)
+function codeFromCell(cell: string): { code: string; digits: string } | null {
+  const m = cell.match(/^CF_P_(\d{4,8})/i);
   if (!m) return null;
-  const d = m[1];
-  const year = 2000 + Number(d.slice(0, 2));
-  const mm = Number(d.slice(2, 4));
-  const dd = Number(d.slice(4, 6));
+  return { code: `CF_P_${m[1]}`, digits: m[1] };
+}
+function yearFromDigits(d: string): number | null {
+  if (d.length === 8) return Number(d.slice(0, 4));
+  if (d.length >= 2) return 2000 + Number(d.slice(0, 2));
+  return null;
+}
+function dateFromDigits(d: string): string | null {
+  let y: number, mm: number, dd: number;
+  if (d.length === 8) {
+    y = Number(d.slice(0, 4)); mm = Number(d.slice(4, 6)); dd = Number(d.slice(6, 8));
+  } else if (d.length === 6) {
+    y = 2000 + Number(d.slice(0, 2)); mm = Number(d.slice(2, 4)); dd = Number(d.slice(4, 6));
+  } else return null; // 4자리는 일 미상 → 기간에서 보완
   if (mm < 1 || mm > 12 || dd < 1 || dd > 31) return null;
-  return `${year}-${pad2(mm)}-${pad2(dd)}`;
+  return `${y}-${pad2(mm)}-${pad2(dd)}`;
 }
 
-// "2024.08.05 (MON) ~ 08.09" / "02.15 14:00 ~ 02.20 23:59" / "05.27 ~ 05.31"
-function parsePeriod(
-  text: string,
-  fallbackYear: number | null,
-): { start: string | null; end: string | null } {
+function parsePeriod(text: string, fallbackYear: number | null) {
   const re =
     /(?:(\d{4})[.\-/])?(\d{1,2})[.\-/](\d{1,2})(?:\s+\d{1,2}:\d{2})?\s*~\s*(?:(\d{4})[.\-/])?(\d{1,2})[.\-/](\d{1,2})/;
   const m = text.match(re);
-  if (!m) return { start: null, end: null };
+  if (!m) return { start: null as string | null, end: null as string | null };
   const y1 = m[1] ? Number(m[1]) : fallbackYear;
   const y2 = m[4] ? Number(m[4]) : y1;
   if (!y1) return { start: null, end: null };
@@ -73,156 +73,123 @@ function parsePeriod(
 const SUMMARY_LABEL =
   /^\[?(이익률|구매수|총매출|총광고비|광고비|판관비|상품원가|배송비|이익|roas|객단가|수수료|합계|소계|총계|순위|상품명|등록상품명|분류|구분|상품리스트)\]?$/i;
 
-// 수량 컬럼: 실판매량 > 판매수량 > 판매량. 목표·번들·재고·구성·월/평균/주/일 단위는 제외.
 function pickQtyCol(cells: string[]): { idx: number; label: string } {
   const bad = /(목표|번들|재고|구성|월|평균|주단위|일단위|예상|계획)/;
-  const priorities = [/실판매량/, /판매수량/, /판매량/];
-  for (const pat of priorities) {
+  for (const pat of [/실판매량/, /판매수량/, /판매량/]) {
     const idx = cells.findIndex((c) => pat.test(norm(c)) && !bad.test(norm(c)));
     if (idx >= 0) return { idx, label: cells[idx].trim() };
   }
   return { idx: -1, label: "" };
 }
-// 매출 컬럼: 실매출 > 매출(단, 총매출/목표매출/원가/광고 제외)
 function pickRevCol(cells: string[]): { idx: number; label: string } {
   const bad = /(총매출|목표|원가|광고|단품합|원가합)/;
-  let idx = cells.findIndex((c) => norm(c) === "실매출");
-  if (idx < 0)
-    idx = cells.findIndex((c) => /실매출/.test(norm(c)) && !bad.test(norm(c)));
+  let idx = cells.findIndex((c) => /실매출/.test(norm(c)) && !bad.test(norm(c)));
   if (idx < 0)
     idx = cells.findIndex(
       (c) => (norm(c) === "매출" || /매출액/.test(norm(c))) && !bad.test(norm(c)),
     );
   return idx >= 0 ? { idx, label: cells[idx].trim() } : { idx: -1, label: "" };
 }
-function pickNameCol(cells: string[]): number {
-  return cells.findIndex((c) => norm(c).includes("상품명"));
-}
 
 export function parseCampaignGuide(buf: ArrayBuffer): GuideCampaign[] {
   const wb = XLSX.read(buf, { cellDates: true });
+  const byCode = new Map<string, GuideCampaign>();
 
-  // CF_P 코드가 가장 많은 시트 선택
-  let bestSheet = "";
-  let bestCount = -1;
-  const grids: Record<string, unknown[][]> = {};
+  const mergeIn = (b: GuideCampaign) => {
+    if (b.products.length === 0) return;
+    b.total_qty = b.products.reduce((s, p) => s + p.quantity, 0);
+    b.total_revenue = b.products.reduce((s, p) => s + p.revenue, 0);
+    const prev = byCode.get(b.code);
+    if (!prev) byCode.set(b.code, b);
+    else {
+      prev.products.push(...b.products);
+      prev.total_qty += b.total_qty;
+      prev.total_revenue += b.total_revenue;
+      if (!prev.end_date && b.end_date) prev.end_date = b.end_date;
+      if (!prev.start_date && b.start_date) prev.start_date = b.start_date;
+    }
+  };
+
+  // 모든 시트 스캔
   for (const sn of wb.SheetNames) {
     const rows = XLSX.utils.sheet_to_json(wb.Sheets[sn], {
       header: 1,
       blankrows: false,
       defval: "",
     }) as unknown[][];
-    grids[sn] = rows;
-    let c = 0;
-    for (const r of rows)
-      for (const cell of r) if (/CF_P_\d{4,6}/i.test(String(cell))) c++;
-    if (c > bestCount) {
-      bestCount = c;
-      bestSheet = sn;
-    }
-  }
-  const rows = grids[bestSheet] ?? [];
 
-  type Block = GuideCampaign & { _key: string };
-  const blocks: Block[] = [];
-  let cur: Block | null = null;
-  let colName = -1,
-    colQty = -1,
-    colRev = -1;
+    let cur: GuideCampaign | null = null;
+    let colName = -1,
+      colQty = -1,
+      colRev = -1;
 
-  const finish = () => {
-    if (cur && cur.products.length > 0) {
-      cur.total_qty = cur.products.reduce((s, p) => s + p.quantity, 0);
-      cur.total_revenue = cur.products.reduce((s, p) => s + p.revenue, 0);
-      blocks.push(cur);
-    }
-    cur = null;
-    colName = colQty = colRev = -1;
-  };
+    const flush = () => {
+      if (cur) mergeIn(cur);
+      cur = null;
+      colName = colQty = colRev = -1;
+    };
 
-  for (let i = 0; i < rows.length; i++) {
-    const cells = Array.from(rows[i], (c) => String(c ?? "").trim());
+    for (let i = 0; i < rows.length; i++) {
+      const cells = Array.from(rows[i], (c) => String(c ?? "").trim());
 
-    // 블록 시작/갱신: CF_P 코드 셀 (4~6자리)
-    const codeCell = cells.find((c) => /^CF_P_\d{4,6}\b/i.test(c) || /^CF_P_\d{4,6}$/i.test(c));
-    const codeMatch = codeCell?.match(/CF_P_\d{4,6}/i)?.[0]?.toUpperCase();
-    if (codeMatch) {
-      const key4 = codeMatch.replace(/^CF_P_/i, "").slice(0, 4); // YYMM 프리픽스
-      const sameCampaign = cur && cur._key === key4;
-      if (sameCampaign && cur) {
-        // 같은 캠페인의 더 구체적인 코드(6자리)면 코드·날짜 보강
-        if (codeMatch.length > cur.code.length) {
-          cur.code = codeMatch;
-          const d = dateFromCode(codeMatch);
-          if (d) cur.start_date = d;
+      // 코드 셀(셀 시작이 CF_P_숫자) → 새 블록 또는 같은 코드면 유지
+      const codeCellRaw = cells.find((c) => /^CF_P_\d{4,8}/i.test(c));
+      const parsed = codeCellRaw ? codeFromCell(codeCellRaw) : null;
+      if (parsed) {
+        if (!cur || cur.code !== parsed.code) {
+          flush();
+          cur = {
+            code: parsed.code,
+            name: codeCellRaw!,
+            start_date: dateFromDigits(parsed.digits),
+            end_date: null,
+            qty_label: "",
+            rev_label: "",
+            products: [],
+            total_qty: 0,
+            total_revenue: 0,
+          };
+        }
+      }
+      if (!cur) continue;
+
+      // 기간
+      if (!cur.end_date) {
+        const joined = cells.join(" ");
+        if (/~/.test(joined) && /\d{1,2}[.\-/]\d{1,2}/.test(joined)) {
+          const yearGuess = yearFromDigits(cur.code.replace(/^CF_P_/i, ""));
+          const { start, end } = parsePeriod(joined, yearGuess);
+          if (start) {
+            cur.start_date = start;
+            cur.end_date = end;
+          }
+        }
+      }
+
+      // 상품표 헤더
+      if (colQty < 0) {
+        const nameIdx = cells.findIndex((c) => norm(c).includes("상품명"));
+        const qty = pickQtyCol(cells);
+        const rev = pickRevCol(cells);
+        if (nameIdx >= 0 && qty.idx >= 0 && rev.idx >= 0) {
+          colName = nameIdx;
+          colQty = qty.idx;
+          colRev = rev.idx;
+          cur.qty_label = qty.label;
+          cur.rev_label = rev.label;
+          continue;
         }
       } else {
-        finish();
-        cur = {
-          _key: key4,
-          code: codeMatch,
-          name: codeCell ?? codeMatch,
-          start_date: dateFromCode(codeMatch),
-          end_date: null,
-          qty_label: "",
-          rev_label: "",
-          products: [],
-          total_qty: 0,
-          total_revenue: 0,
-        };
-      }
-    }
-    if (!cur) continue;
-
-    // 기간 (프로모션일시 행 등 어디서든)
-    if (!cur.end_date) {
-      const joined = cells.join(" ");
-      if (/~/.test(joined) && /\d{1,2}[.\-/]\d{1,2}/.test(joined)) {
-        const { start, end } = parsePeriod(joined, yearFromCode(cur.code));
-        if (start) {
-          cur.start_date = start;
-          cur.end_date = end;
+        const name = (cells[colName] ?? "").trim();
+        const qty = toNum(rows[i][colQty]);
+        const rev = toNum(rows[i][colRev]);
+        if (name && !SUMMARY_LABEL.test(name) && (qty > 0 || rev > 0)) {
+          cur.products.push({ name, quantity: qty, revenue: rev });
         }
       }
     }
-
-    // 상품표 헤더 (상품명 + 실적 수량 + 실적 매출)
-    if (colQty < 0) {
-      const nameIdx = pickNameCol(cells);
-      const qty = pickQtyCol(cells);
-      const rev = pickRevCol(cells);
-      if (nameIdx >= 0 && qty.idx >= 0 && rev.idx >= 0) {
-        colName = nameIdx;
-        colQty = qty.idx;
-        colRev = rev.idx;
-        cur.qty_label = qty.label;
-        cur.rev_label = rev.label;
-        continue;
-      }
-    } else {
-      const name = (cells[colName] ?? "").trim();
-      const qty = toNum(rows[i][colQty]);
-      const rev = toNum(rows[i][colRev]);
-      if (name && !SUMMARY_LABEL.test(name) && (qty > 0 || rev > 0)) {
-        cur.products.push({ name, quantity: qty, revenue: rev });
-      }
-    }
+    flush();
   }
-  finish();
 
-  // 같은 코드 병합
-  const byCode = new Map<string, GuideCampaign>();
-  for (const b of blocks) {
-    const { _key, ...c } = b;
-    void _key;
-    const prev = byCode.get(c.code);
-    if (!prev) byCode.set(c.code, c);
-    else {
-      prev.products.push(...c.products);
-      prev.total_qty += c.total_qty;
-      prev.total_revenue += c.total_revenue;
-      if (!prev.end_date && c.end_date) prev.end_date = c.end_date;
-    }
-  }
   return [...byCode.values()].sort((a, b) => a.code.localeCompare(b.code));
 }


### PR DESCRIPTION
## 개요

프로모션 가이드 파서가 실제 파일에서 **0개**를 인식한 문제 수정(후속). 실제 워크북은 연도/캠페인마다 표 양식이 제각각이라(`판매수량` 13 · `판매량` 25 · `실판매량` 등) 첫 파서가 거의 다 놓쳤습니다.

## 변경 사항 (`lib/parseGuide.ts`)
- **블록 시작**: 6자리 한정 → `CF_P` 4~6자리 셀 인식. 같은 캠페인(YYMM 프리픽스)의 4↔6자리를 병합하고 6자리로 날짜 보강
- **수량 컬럼**: `실판매량 > 판매수량 > 판매량` 우선, **목표·번들·재고·구성·월/평균/주·일단위 제외** — 계획(목표)·상시 베이스라인(월/평균 판매량)을 실적으로 오인하지 않도록(데이터 무결성)
- **매출 컬럼**: `실매출 > 매출`, 총매출·목표·원가·광고 제외
- **기간**: `2024.08.05 (MON) ~ 08.09` / `MM.DD HH:MM ~ MM.DD` / `MM.DD ~ MM.DD` 등 `./-/` 구분자·시간 허용, 연도 없으면 코드 연도 사용
- **미리보기에 ‘읽은 지표’(수량·매출 라벨) 표시** — 실적을 읽었는지 사람이 검증. **DB 쓰기 없음 유지**

## 검수
- [ ] ⑤에 프로모션 가이드 올리면 캠페인 다수 인식
- [ ] ‘읽은 지표’가 실적 라벨(판매수량/실판매량·매출/실매출)인지 확인 (목표/평균이면 알려주세요)
- [ ] Vercel 프리뷰 Ready

> 여전히 미리보기 전용입니다. 양식이 너무 이질적이면 계획/실적 혼입 위험이 있어, 결과 확인 후 백필 활성화 여부를 함께 결정합니다.

https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ)_