### PR TITLE
CSV 한글 인코딩 수정 (UTF-8 디코드 후 파싱)

### DIFF
--- a/promo-analytics/lib/parse.ts
+++ b/promo-analytics/lib/parse.ts
@@ -43,9 +43,19 @@ function pad(n: number | string): string {
   return String(n).padStart(2, "0");
 }
 
+/** xlsx는 바이너리로, CSV(텍스트)는 UTF-8로 디코드해 읽는다. (한글 CSV 깨짐 방지) */
+function readBook(buf: ArrayBuffer): XLSX.WorkBook {
+  const bytes = new Uint8Array(buf);
+  const isZip = bytes[0] === 0x50 && bytes[1] === 0x4b; // 'PK' = xlsx(zip)
+  if (isZip) return XLSX.read(buf, { cellDates: true });
+  let text = new TextDecoder("utf-8").decode(bytes);
+  if (text.charCodeAt(0) === 0xfeff) text = text.slice(1); // BOM 제거
+  return XLSX.read(text, { type: "string", cellDates: true });
+}
+
 /** 워크북의 첫 시트를 2차원 배열로 */
 function firstSheetRows(buf: ArrayBuffer): unknown[][] {
-  const wb = XLSX.read(buf, { cellDates: true });
+  const wb = readBook(buf);
   const ws = wb.Sheets[wb.SheetNames[0]];
   // defval: "" — 빈 셀을 ""로 채워 희소 배열(구멍) 방지. 헤더에 병합/공백 칸이 있어도
   // header.map(norm)[i]가 undefined가 되지 않아 findCol 등이 크래시하지 않는다.
@@ -54,7 +64,7 @@ function firstSheetRows(buf: ArrayBuffer): unknown[][] {
 
 /** 워크북 객체 (여러 시트를 이름으로 지정해 파싱할 때 한 번만 읽어 재사용) */
 export function readWorkbook(buf: ArrayBuffer): XLSX.WorkBook {
-  return XLSX.read(buf, { cellDates: true });
+  return readBook(buf);
 }
 
 /** 워크북의 시트 이름 목록 */

--- a/promo-analytics/lib/parsePlanGuide.ts
+++ b/promo-analytics/lib/parsePlanGuide.ts
@@ -87,8 +87,19 @@ function packFromName(name: string): number {
   return lead ? Math.max(1, Number(lead[1]) || 1) : 1;
 }
 
+// xlsx는 바이너리로, CSV(텍스트)는 UTF-8로 디코드해 읽는다.
+// XLSX.read(ArrayBuffer)는 CSV를 UTF-8로 디코드하지 않아 한글 헤더가 깨지므로 분기.
+function readWorkbook(buf: ArrayBuffer): XLSX.WorkBook {
+  const bytes = new Uint8Array(buf);
+  const isZip = bytes[0] === 0x50 && bytes[1] === 0x4b; // 'PK' = xlsx(zip)
+  if (isZip) return XLSX.read(buf, { cellDates: true });
+  let text = new TextDecoder("utf-8").decode(bytes);
+  if (text.charCodeAt(0) === 0xfeff) text = text.slice(1); // BOM 제거
+  return XLSX.read(text, { type: "string", cellDates: true });
+}
+
 export function parsePlanGuide(buf: ArrayBuffer): PlanGuideCampaign[] {
-  const wb = XLSX.read(buf, { cellDates: true });
+  const wb = readWorkbook(buf);
   const ws = wb.Sheets[wb.SheetNames[0]];
   const rows = XLSX.utils.sheet_to_json(ws, {
     header: 1,


### PR DESCRIPTION
## 개요

⑤ 플랜 가이드에서 **표준 템플릿 csv를 올려도 "헤더를 찾을 수 없습니다"** 발생 → **CSV 한글 인코딩** 문제 수정.

## 원인
`XLSX.read(ArrayBuffer)`가 CSV를 UTF-8로 디코드하지 않아 한글 헤더(`코드`·`상품명`…)가 깨져 컬럼 매칭에 실패. (.xlsx로 저장하면 바이너리라 괜찮지만, 받은 .csv를 그대로 올리면 깨짐.)

## 변경 사항
- 파일이 `PK`(zip = xlsx) 시그니처면 바이너리로, 아니면 **UTF-8 텍스트로 디코드(BOM 제거) 후 `XLSX.read(text, {type:"string"})`**
- `lib/parsePlanGuide.ts` + `lib/parse.ts`(②일별/③캠페인 CSV도 대비) 동일 처리

## 검수
- [ ] 받은 표준 템플릿 csv ⑤ 업로드 → 미리보기 정상(캠페인 1, 옵션 다수)
- [ ] Vercel 프리뷰 Ready

> 참고: 올려주신 파일은 7+ 케어 스틱 행들의 `품목코드`도 전부 `DR10063`으로 채워져 있어요(아마 입력 실수). 임포트는 되지만 품목 매칭이 어긋날 수 있으니 실제 품목코드(DR10067/10068 등)로 바꾸시는 걸 권합니다.

https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ)_