### PR TITLE
docs: 핸드오프(2026-06-08) + 다음 작업(속도 최적화)

### DIFF
--- a/promo-analytics/HANDOFF_2026-06-08.md
+++ b/promo-analytics/HANDOFF_2026-06-08.md
@@ -1,0 +1,55 @@
+# HANDOFF 연속 (2026-06-08) — 진행상황 & 다음 작업(속도 최적화)
+
+> 새 세션은 **이 파일 + `HANDOFF.md`(2026-06-04, 전체 아키텍처/데이터모델) + `AGENTS.md` + 루트 `SPEC.md`** 를 읽고 시작.
+> 이 파일은 06-04 이후의 변경분과 **다음 작업(속도 최적화)** 만 다룬다.
+
+## 0. 한 줄 요약
+S1~S6 + N1 + 가이드→플랜 임포터까지 구현·운영 반영 완료.
+**다음 작업 = 속도 최적화**(메뉴 이동·로딩 느림). 주원인 = **N+1 DB 쿼리**.
+
+## 1. 환경 / 워크플로 (중요 — 06-04 핸드오프 보강)
+- **Next.js(변형판)**: `AGENTS.md` — 표준과 다를 수 있음. Next API(라우팅/캐싱/`loading.tsx`) 손대기 전 `node_modules/next/dist/docs/` 확인. **로컬에 node_modules 없음 → tsc/빌드 로컬 불가 → Vercel 빌드로만 검증**.
+- **Supabase**: 스키마 `promo`, 프로젝트 `mlbtnnchbpctgjjawkue`. 브라우저 클라이언트 `db.schema:"promo"`. RLS=authenticated 전체 허용(0001 패턴).
+- **마이그레이션**: MCP `apply_migration` 적용 + `supabase/migrations/00NN_*.sql` 커밋. 최신=**0014**. 적용 후 `notify pgrst,'reload schema'`.
+- **배포**: Vercel, 운영 <https://df-promo-dsbd.vercel.app> (Google OAuth, @drfelis.com). main 머지 시 자동 배포(1~2분).
+- **개발 절차**: `claude/<주제>` 브랜치 → 커밋 → 푸시 → **draft PR** → Vercel 프리뷰 `Ready`(webhook) → ready 전환 + **squash 머지**. 머지된 브랜치 재사용 금지(새 브랜치). 리베이스 충돌 시 `git rebase origin/main` + force-push.
+- PR 본문/커밋 끝에 세션 링크 첨부(자동). 모델 식별자는 코드/PR에 넣지 말 것.
+
+## 2. 06-04 이후 추가 구현 (모두 머지됨)
+- **S5 목적 슬라이스**: `purposes`,`promotion_purpose_weights`,`effective_purpose_weights`,`purpose_fit`,`campaign_fits`(0010~0012) → 대시보드/히스토리/상세/시뮬레이터/추천.
+- **S6 달성 신뢰도 가중**: `lib/cases.ts`에 `reliability`(=f(|1−ach_revenue|, 확정플랜)), `lib/predict.ts`의 `predict`/`recommendByGoal(s)` 가중·confidence에 반영.
+- **N1 데이터 백필**: `/upload`를 **소스 교체(삭제 후 삽입, 누적 금지, 같은 기간 총매출 불변식 ±5% 초과 시 중단)**로. 일별/캠페인 모두. 매출 부풀림 방지.
+- **업로드 안정화**: 희소 헤더 크래시 방어(`Array.from`/`defval`), **CSV UTF-8 디코드**(`readBook`/`readWorkbook` — PK면 바이너리, 아니면 UTF-8 string).
+- **연동 이력**: `upload_log`(0013) + `/upload` 하단 표. `logUpload()` 헬퍼(kind: daily/promotion/price_master/plan_guide).
+- **가이드→플랜 임포터(⑤)**: 표준 평평 CSV/xlsx(1행=옵션) → **campaign_plans(예상/가설)**. `lib/parsePlanGuide.ts`, `campaign_plan_options.econ` jsonb(0014, 폼값 그대로). 템플릿 `public/templates/campaign_plan_guide_template.csv`.
+
+### 가이드→플랜 합의 규칙
+set가=`쿠폰혜택가∥프로모션가`. **메인=상시가 할인율≥15%**(최종가 기준, 입력값 우선·비면 계산). **개입수**(번들SKU)·**예상수량**(옵션 판매) 별개 컬럼. 소비자가/상시가/원가=번들 합계(×개입수 금지), item unit=set/개입수. 목표매출·공헌이익·물류비·수수료·광고비=**폼값 그대로 저장**. 코드로 캠페인 매칭/생성·draft 교체·**확정 보존**. 미해결: combo 행 목표매출 Σ중복 가능.
+
+## 3. ★다음 작업 — 속도 최적화 (이번 세션 미완, 여기서 시작)
+### 진단(확정): N+1 DB 쿼리 + 전 페이지 force-dynamic(캐싱 없음)
+- **`lib/cases.ts` `loadCases`**(★최악, `/predict`·`/prescribe`): 캠페인마다 `Promise.all` 4 RPC(`promotion_summary`,`promotion_measurement`,`promotion_sales` select,`effective_purpose_weights`) + 배치 `campaign_achievements`. ≈ **4N 왕복**.
+- **`app/(dash)/library/page.tsx`**: 캠페인마다 `promotion_summary`(N) + 배치 achievements/fits.
+- **`app/(dash)/page.tsx`**(대시보드): 캠페인마다 `promotion_summary`+`promotion_measurement`(2N).
+- 상세 `promotions/[id]/page.tsx`는 단건이라 영향 작음.
+
+### 권장 해결 (위험 낮은 순)
+1. **배치 RPC 신설**(0015+). `campaign_fits()`(0012)가 이미 `cross join lateral promo.purpose_fit(pr.id)`로 전 캠페인 배치 → **동일 패턴** 사용:
+   - `promo.all_promotion_summaries()` → 전 캠페인 summary 1쿼리
+   - `promo.all_campaign_features()` → `cases.ts`가 쓰는 전부(summary + measurement 파생 `baseline_daily/actual_daily/qty_per_day/orders_per_day/promo_days/duration`). purposes는 `campaign_fits`/별도, achievements는 `campaign_achievements`로 조인.
+   - **기존 `promotion_summary`/`promotion_measurement` 정의를 읽어 동일 계산으로 복제**(단일 출처). 검증: 배치=단건 동일.
+2. `cases.ts`/`library`/대시보드를 **배치 1회 호출 + 메모리 조인**으로 리팩터(루프 제거).
+3. (선택, Next 주의) `loading.tsx` 스켈레톤. 캐싱(`revalidate`)은 신선도 고려해 신중히.
+
+### 주의
+계산은 기존 SQL 단일 출처. 배치 함수 수치=기존과 동일해야. 적용 후 schema reload. 빌드 green 후 머지.
+
+## 4. 파일 맵
+- `lib/cases.ts`(N+1 대상) · `lib/predict.ts`(predict/recommend, reliability·purpose) · `lib/plan.ts`(computeOptionTotals/rateCardMult)
+- `lib/parse.ts`(②③①④ + `readBook` CSV UTF-8) · `lib/parsePlanGuide.ts`(⑤)
+- `app/(dash)/upload/page.tsx`(5카드+logUpload+연동이력) · `app/(dash)/page.tsx` · `library/page.tsx` · `predict/Simulator.tsx` · `prescribe/Recommend.tsx` · `promotions/[id]/{page,edit,plan}`
+- `app/api/promotions/[id]/plan/route.ts`(PATCH=computeOptionTotals 재계산)
+- 배치 함수: `campaign_achievements()`,`campaign_fits()`,`overall_baseline_metrics()`. 단건: `promotion_summary`,`promotion_measurement`,`purpose_fit`,`effective_purpose_weights`,`plan_vs_actual*`.
+
+## 5. 데이터 메모
+확정 플랜 0건이었음(데이터 적재는 사용자 ②/③/⑤ 작업). ⑤ 샘플 `CF_P_260608_Better Habits`의 7+ 케어 스틱 행 `품목코드`가 전부 `DR10063`(입력 실수) — 매칭 주의.


### PR DESCRIPTION
## 개요
새 세션이 바로 이어받을 수 있도록 진행상황·아키텍처·다음 작업을 정리한 핸드오프 문서.

- `promo-analytics/HANDOFF_2026-06-08.md` 추가 (기존 `HANDOFF.md` 2026-06-04 보강)
- 06-04 이후 구현(S5/S6/N1/업로드 안정화/가이드→플랜 임포터) 요약
- **다음 작업 = 속도 최적화**(N+1 DB 쿼리 진단 + 배치 RPC 권장안) 명시

문서만 추가(코드 변경 없음).

https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0115B3iPFiVzeRWfARcSZSuZ)_