### PR TITLE
N2: 페이지 스켈레톤 (loading.tsx) — 체감 속도 개선

### DIFF
--- a/promo-analytics/app/(dash)/library/loading.tsx
+++ b/promo-analytics/app/(dash)/library/loading.tsx
@@ -1,0 +1,22 @@
+export default function LibraryLoading() {
+  return (
+    <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
+      <div className="h-5 w-44 animate-pulse rounded-full bg-soft" />
+      <div className="mt-2 h-3 w-72 animate-pulse rounded-full bg-soft" />
+
+      <div className="mt-6 rounded-[28px] bg-canvas p-4 card-soft">
+        <div className="space-y-2">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="grid grid-cols-12 items-center gap-3">
+              <div className="col-span-4 h-3 animate-pulse rounded-full bg-soft" />
+              <div className="col-span-2 h-3 animate-pulse rounded-full bg-soft" />
+              <div className="col-span-2 h-3 animate-pulse rounded-full bg-soft" />
+              <div className="col-span-2 h-3 animate-pulse rounded-full bg-soft" />
+              <div className="col-span-2 h-3 animate-pulse rounded-full bg-soft" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/promo-analytics/app/(dash)/loading.tsx
+++ b/promo-analytics/app/(dash)/loading.tsx
@@ -1,0 +1,47 @@
+// 대시 그룹 공통 스켈레톤 — Next.js App Router loading.tsx 컨벤션.
+// 페이지의 비동기 데이터 fetch 중 자동으로 <Suspense> fallback 으로 표시됨.
+// 신선도(force-dynamic) 유지를 위해 캐싱(revalidate)은 도입하지 않음.
+
+export default function DashLoading() {
+  return (
+    <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
+      <div className="mb-6 flex items-center gap-3">
+        <div className="h-12 w-12 animate-pulse rounded-2xl bg-canvas card-soft" />
+        <div className="space-y-2">
+          <div className="h-3.5 w-24 animate-pulse rounded-full bg-soft" />
+          <div className="h-2.5 w-32 animate-pulse rounded-full bg-soft" />
+        </div>
+      </div>
+
+      <div className="mb-5 rounded-[28px] bg-canvas p-6 card-soft">
+        <div className="h-3 w-20 animate-pulse rounded-full bg-soft" />
+        <div className="mt-3 h-4 w-3/4 animate-pulse rounded-full bg-soft" />
+        <div className="mt-2 h-4 w-1/2 animate-pulse rounded-full bg-soft" />
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="rounded-[24px] bg-canvas p-5 card-soft">
+            <div className="h-2.5 w-16 animate-pulse rounded-full bg-soft" />
+            <div className="mt-3 h-6 w-24 animate-pulse rounded-full bg-soft" />
+            <div className="mt-2 h-2 w-20 animate-pulse rounded-full bg-soft" />
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-3 grid gap-3 sm:mt-4 sm:gap-4 lg:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div
+            key={i}
+            className={`rounded-[28px] bg-canvas p-5 card-soft ${
+              i === 1 ? "lg:col-span-2" : ""
+            }`}
+          >
+            <div className="h-3 w-32 animate-pulse rounded-full bg-soft" />
+            <div className="mt-4 h-32 animate-pulse rounded-2xl bg-soft" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/promo-analytics/app/(dash)/promotions/[id]/loading.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/loading.tsx
@@ -1,0 +1,34 @@
+export default function PromotionDetailLoading() {
+  return (
+    <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
+      <div className="h-3 w-32 animate-pulse rounded-full bg-soft" />
+      <div className="mt-4 h-5 w-60 animate-pulse rounded-full bg-soft" />
+      <div className="mt-2 h-3 w-80 animate-pulse rounded-full bg-soft" />
+
+      <div className="mt-6 grid grid-cols-2 gap-3 md:grid-cols-5">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="rounded-xl bg-canvas p-4 card-soft">
+            <div className="h-2.5 w-16 animate-pulse rounded-full bg-soft" />
+            <div className="mt-3 h-5 w-24 animate-pulse rounded-full bg-soft" />
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-6 rounded-[24px] bg-canvas p-5 card-soft">
+        <div className="h-3 w-32 animate-pulse rounded-full bg-soft" />
+        <div className="mt-3 h-3 w-2/3 animate-pulse rounded-full bg-soft" />
+      </div>
+
+      <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="rounded-[20px] bg-canvas p-4 card-soft">
+            <div className="h-3 w-20 animate-pulse rounded-full bg-soft" />
+            <div className="mt-3 h-7 w-16 animate-pulse rounded-full bg-soft" />
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-4 h-72 animate-pulse rounded-[24px] bg-canvas card-soft" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
N2 — App Router 표준 `loading.tsx` 컨벤션으로 페이지 RSC 데이터 fetch 동안 즉시 스켈레톤 표시. **체감 속도 개선**이 목표 (실제 쿼리는 PR #55 배치 RPC로 이미 단축됨).

핸드오프 §3 권장(3) 중 캐싱(revalidate)은 **신선도 신중히** 권고에 따라 도입하지 않음 — 스켈레톤만.

## 변경
- `app/(dash)/loading.tsx`: 대시 그룹 공통 스켈레톤 (헤더 + AI 인사이트 + KPI 4 + 카드 3)
- `app/(dash)/library/loading.tsx`: 테이블 행 8개 스켈레톤
- `app/(dash)/promotions/[id]/loading.tsx`: 상세 헤더 + Stat 5칸 + 표 영역

뉴모피즘 표면(`bg-canvas card-soft`)에 `bg-soft animate-pulse` 자리표시. `prefers-reduced-motion` 시 globals.css 전역 규칙으로 펄스 정지.

## Test plan
- [ ] Vercel 프리뷰에서 사이드바 메뉴 클릭 시 스켈레톤 즉시 표시 (특히 `/`, `/library`, `/promotions/[id]`)
- [ ] 스켈레톤이 실제 콘텐츠 레이아웃과 어색하지 않음
- [ ] 모바일 390px 표시
- [ ] 빌드 green

https://claude.ai/code/session_015LKzwi94QyhtUws2Zb1hvj

---
_Generated by [Claude Code](https://claude.ai/code/session_015LKzwi94QyhtUws2Zb1hvj)_