### PR TITLE
N4: 플랜↔실적 SKU 수동 매핑 UI + 진단

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/SkuMatchPanel.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/SkuMatchPanel.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { won, wonShort, num } from "@/lib/format";
+
+// promo.sku_match_diagnostic() 반환 행
+export type DiagnosticRow = {
+  side: "both" | "plan" | "actual";
+  product_id: string;
+  base_name: string;
+  dr_code: string | null;
+  expected_qty: number | null;
+  expected_revenue: number | null;
+  actual_qty: number | null;
+  actual_revenue: number | null;
+  is_mapped: boolean;
+};
+
+export type SkuMapping = {
+  plan_product_id: string;
+  actual_product_id: string;
+};
+
+// 양쪽 SKU 리스트에서 선택해 수동 매핑하는 패널.
+// product_id 가 다른 경로(가이드 임포터 ⑤ vs 실적 시트 ②)로 등록된 같은 SKU 를 연결.
+export default function SkuMatchPanel({
+  promotionId,
+  rows,
+  mappings,
+}: {
+  promotionId: string;
+  rows: DiagnosticRow[];
+  mappings: SkuMapping[];
+}) {
+  const router = useRouter();
+  const [planPick, setPlanPick] = useState<string>("");
+  const [actualPick, setActualPick] = useState<string>("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const matched = rows.filter((r) => r.side === "both");
+  const planOnly = rows.filter((r) => r.side === "plan");
+  const actualOnly = rows.filter((r) => r.side === "actual");
+
+  const mappingPairs = useMemo(() => {
+    const byPlan = new Map<string, string[]>();
+    for (const m of mappings) {
+      const arr = byPlan.get(m.plan_product_id) ?? [];
+      arr.push(m.actual_product_id);
+      byPlan.set(m.plan_product_id, arr);
+    }
+    return byPlan;
+  }, [mappings]);
+
+  async function addMapping() {
+    if (!planPick || !actualPick) return;
+    setBusy(true);
+    setErr(null);
+    const res = await fetch(`/api/promotions/${promotionId}/sku-mappings`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        plan_product_id: planPick,
+        actual_product_id: actualPick,
+      }),
+    });
+    setBusy(false);
+    if (!res.ok) {
+      const j = await res.json().catch(() => ({}));
+      setErr(j.error ?? "매핑 추가 실패");
+      return;
+    }
+    setPlanPick("");
+    setActualPick("");
+    router.refresh();
+  }
+
+  async function removeMapping(plan_product_id: string, actual_product_id: string) {
+    setBusy(true);
+    setErr(null);
+    const res = await fetch(`/api/promotions/${promotionId}/sku-mappings`, {
+      method: "DELETE",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ plan_product_id, actual_product_id }),
+    });
+    setBusy(false);
+    if (!res.ok) {
+      const j = await res.json().catch(() => ({}));
+      setErr(j.error ?? "매핑 삭제 실패");
+      return;
+    }
+    router.refresh();
+  }
+
+  return (
+    <section className="mt-6">
+      <h2 className="mb-2 text-sm font-semibold text-ink-2">SKU 매칭 진단</h2>
+      <p className="mb-3 text-xs text-ink-4">
+        플랜·실적 시트가 같은 SKU를 서로 다른 품목명/품목코드로 등록하면 자동 매칭이 안 됩니다.
+        아래 양쪽 리스트에서 같은 SKU를 골라 수동 연동하세요. 매칭한 실적은 달성률 집계에 합산됩니다.
+      </p>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <Stat label="자동 매칭됨" value={matched.length} tone="ok" />
+        <Stat label="플랜만 (실적 없음)" value={planOnly.length} tone="warn" />
+        <Stat label="실적만 (플랜 없음)" value={actualOnly.length} tone="warn" />
+      </div>
+
+      {/* 수동 매핑 추가 */}
+      {(planOnly.length > 0 || actualOnly.length > 0) && (
+        <div className="mt-4 rounded-[20px] bg-canvas p-4 card-soft">
+          <h3 className="mb-2 text-xs font-semibold text-ink-2">수동 매핑 추가</h3>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_auto_1fr_auto]">
+            <select
+              value={planPick}
+              onChange={(e) => setPlanPick(e.target.value)}
+              className="rounded-xl bg-canvas px-3 py-2 text-sm surface-pressed-soft focus:outline-none"
+            >
+              <option value="">플랜 SKU 선택 …</option>
+              {planOnly.map((r) => (
+                <option key={r.product_id} value={r.product_id}>
+                  [{r.dr_code ?? "—"}] {r.base_name}
+                </option>
+              ))}
+            </select>
+            <span className="self-center text-center text-xs text-ink-4">↔</span>
+            <select
+              value={actualPick}
+              onChange={(e) => setActualPick(e.target.value)}
+              className="rounded-xl bg-canvas px-3 py-2 text-sm surface-pressed-soft focus:outline-none"
+            >
+              <option value="">실적 SKU 선택 …</option>
+              {actualOnly.map((r) => (
+                <option key={r.product_id} value={r.product_id}>
+                  [{r.dr_code ?? "—"}] {r.base_name}
+                </option>
+              ))}
+            </select>
+            <button
+              onClick={addMapping}
+              disabled={busy || !planPick || !actualPick}
+              className="rounded-full bg-brand-500 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-600 disabled:opacity-50"
+            >
+              연동
+            </button>
+          </div>
+          {err && <p className="mt-2 text-xs text-brand-700">{err}</p>}
+        </div>
+      )}
+
+      {/* 현재 매핑 목록 */}
+      {mappings.length > 0 && (
+        <div className="mt-3 rounded-[20px] bg-canvas p-4 card-soft">
+          <h3 className="mb-2 text-xs font-semibold text-ink-2">
+            현재 매핑 ({mappings.length}건)
+          </h3>
+          <ul className="space-y-1.5 text-xs">
+            {mappings.map((m) => {
+              const planName =
+                rows.find((r) => r.product_id === m.plan_product_id)?.base_name ??
+                m.plan_product_id;
+              return (
+                <li
+                  key={`${m.plan_product_id}-${m.actual_product_id}`}
+                  className="flex items-center justify-between gap-2"
+                >
+                  <span className="truncate text-ink-2">
+                    {planName}{" "}
+                    <span className="text-ink-4">
+                      ← actual {m.actual_product_id.slice(0, 8)}…
+                    </span>
+                  </span>
+                  <button
+                    onClick={() => removeMapping(m.plan_product_id, m.actual_product_id)}
+                    disabled={busy}
+                    className="text-xs text-ink-4 hover:text-brand-700"
+                  >
+                    해제
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+
+      {/* SKU 진단 표 */}
+      <div className="mt-3 overflow-x-auto rounded-[20px] bg-canvas card-soft">
+        <table className="w-full min-w-[640px] text-xs">
+          <thead className="text-left text-ink-4">
+            <tr>
+              <th className="px-3 py-2 font-medium">상태</th>
+              <th className="px-3 py-2 font-medium">SKU</th>
+              <th className="px-3 py-2 text-right font-medium">기대수량</th>
+              <th className="px-3 py-2 text-right font-medium">기대매출</th>
+              <th className="px-3 py-2 text-right font-medium">실수량</th>
+              <th className="px-3 py-2 text-right font-medium">실매출</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => {
+              const linked = (mappingPairs.get(r.product_id)?.length ?? 0) > 0;
+              return (
+                <tr
+                  key={r.product_id}
+                  className="border-t border-[var(--color-line)]/60"
+                >
+                  <td className="px-3 py-2">
+                    <SideBadge side={r.side} isMapped={r.is_mapped || linked} />
+                  </td>
+                  <td className="px-3 py-2">
+                    <div className="text-ink">{r.base_name}</div>
+                    {r.dr_code && (
+                      <div className="text-[10px] text-ink-4">{r.dr_code}</div>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 text-right text-ink-3">
+                    {r.expected_qty ? num(r.expected_qty) : "—"}
+                  </td>
+                  <td className="px-3 py-2 text-right text-ink-3">
+                    {r.expected_revenue ? wonShort(r.expected_revenue) : "—"}
+                  </td>
+                  <td className="px-3 py-2 text-right text-ink-3">
+                    {r.actual_qty ? num(r.actual_qty) : "—"}
+                  </td>
+                  <td className="px-3 py-2 text-right text-ink-3">
+                    {r.actual_revenue ? won(r.actual_revenue) : "—"}
+                  </td>
+                </tr>
+              );
+            })}
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={6} className="px-3 py-6 text-center text-ink-4">
+                  플랜·실적 모두 없습니다.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number;
+  tone: "ok" | "warn";
+}) {
+  const color = tone === "ok" ? "text-brand-600" : "text-ink-2";
+  return (
+    <div className="rounded-[20px] bg-canvas p-4 card-soft">
+      <div className="text-[11px] font-semibold uppercase tracking-[1.4px] text-ink-4">
+        {label}
+      </div>
+      <div className={`mt-1 text-2xl font-bold tabular-nums ${color}`}>{value}</div>
+    </div>
+  );
+}
+
+function SideBadge({
+  side,
+  isMapped,
+}: {
+  side: DiagnosticRow["side"];
+  isMapped: boolean;
+}) {
+  if (side === "both") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold text-brand-700 surface-pressed-soft">
+        {isMapped ? "매핑됨" : "자동 매칭"}
+      </span>
+    );
+  }
+  if (side === "plan") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold text-ink-3 surface-pressed-soft">
+        플랜만
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold text-ink-3 surface-pressed-soft">
+      실적만
+    </span>
+  );
+}

--- a/promo-analytics/app/(dash)/promotions/[id]/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/page.tsx
@@ -15,6 +15,7 @@ import UpliftChart from "./UpliftChart";
 import Notes from "./Notes";
 import Achievement from "./Achievement";
 import PurposeBlock, { type PurposeMetricRow } from "./PurposeBlock";
+import SkuMatchPanel, { type DiagnosticRow, type SkuMapping } from "./SkuMatchPanel";
 
 export const dynamic = "force-dynamic";
 
@@ -64,11 +65,14 @@ export default async function PromotionDetail({
   } | null;
 
   // 달성률 (S3): 확정 플랜 vs 실적 + 옵션 매핑용 distinct option_info
+  // + SKU 매칭 진단 (N4): 플랜·실적 한 표 (draft 도 포함) + 수동 매핑 목록
   const [
     { data: pvaSummary },
     { data: pvaRows },
     { data: pvaOptions },
     { data: optInfoRows },
+    { data: diagRows },
+    { data: skuMaps },
   ] = await Promise.all([
     supabase.rpc("plan_vs_actual_summary", { p_id: id }),
     supabase.rpc("plan_vs_actual", { p_id: id }),
@@ -78,6 +82,11 @@ export default async function PromotionDetail({
       .select("option_info")
       .eq("promotion_id", id)
       .not("option_info", "is", null),
+    supabase.rpc("sku_match_diagnostic", { p_id: id }),
+    supabase
+      .from("promotion_sku_mappings")
+      .select("plan_product_id, actual_product_id")
+      .eq("promotion_id", id),
   ]);
   const achSummary = (pvaSummary?.[0] as PlanVsActualSummary) ?? null;
   const achRows = (pvaRows as PlanVsActualRow[]) ?? [];
@@ -89,6 +98,8 @@ export default async function PromotionDetail({
         .filter((s) => s.length > 0),
     ),
   ].sort();
+  const diagnosticRows = (diagRows as DiagnosticRow[]) ?? [];
+  const skuMappings = (skuMaps as SkuMapping[]) ?? [];
 
   // 목적별 핵심 지표 (S5.4): 유효 가중치 × 측정·달성률·구매건수
   const [{ data: ewData }, { data: ocData }] = await Promise.all([
@@ -243,6 +254,15 @@ export default async function PromotionDetail({
         options={achOptions}
         optionInfos={optionInfos}
       />
+
+      {/* SKU 매칭 진단 (N4) — 플랜·실적 양쪽 SKU 한 표 + 수동 연동 */}
+      {(diagnosticRows.length > 0 || skuMappings.length > 0) && (
+        <SkuMatchPanel
+          promotionId={id}
+          rows={diagnosticRows}
+          mappings={skuMappings}
+        />
+      )}
 
       {/* 목적별 핵심 지표 (S5.4) */}
       <PurposeBlock rows={purposeRows} />

--- a/promo-analytics/app/api/promotions/[id]/sku-mappings/route.ts
+++ b/promo-analytics/app/api/promotions/[id]/sku-mappings/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export const runtime = "nodejs";
+
+// 한 캠페인의 SKU 매핑 목록
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const supabase = await createClient();
+    const { data, error } = await supabase
+      .from("promotion_sku_mappings")
+      .select("plan_product_id, actual_product_id, created_at")
+      .eq("promotion_id", id);
+    if (error) throw error;
+    return NextResponse.json({ mappings: data ?? [] });
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : "조회 실패" },
+      { status: 500 },
+    );
+  }
+}
+
+// 새 매핑 추가: { plan_product_id, actual_product_id }
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const body = (await req.json()) as {
+      plan_product_id?: string;
+      actual_product_id?: string;
+    };
+    if (!body.plan_product_id || !body.actual_product_id) {
+      return NextResponse.json(
+        { error: "plan_product_id 와 actual_product_id 가 필요합니다" },
+        { status: 400 },
+      );
+    }
+    if (body.plan_product_id === body.actual_product_id) {
+      return NextResponse.json(
+        { error: "같은 SKU 는 매핑할 필요가 없습니다" },
+        { status: 400 },
+      );
+    }
+    const supabase = await createClient();
+    const { error } = await supabase.from("promotion_sku_mappings").insert({
+      promotion_id: id,
+      plan_product_id: body.plan_product_id,
+      actual_product_id: body.actual_product_id,
+    });
+    if (error) {
+      if (error.code === "23505")
+        return NextResponse.json({ ok: true, duplicate: true });
+      throw error;
+    }
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : "매핑 추가 실패" },
+      { status: 500 },
+    );
+  }
+}
+
+// 매핑 삭제: { plan_product_id, actual_product_id }
+export async function DELETE(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const body = (await req.json()) as {
+      plan_product_id?: string;
+      actual_product_id?: string;
+    };
+    if (!body.plan_product_id || !body.actual_product_id) {
+      return NextResponse.json(
+        { error: "plan_product_id 와 actual_product_id 가 필요합니다" },
+        { status: 400 },
+      );
+    }
+    const supabase = await createClient();
+    const { error } = await supabase
+      .from("promotion_sku_mappings")
+      .delete()
+      .eq("promotion_id", id)
+      .eq("plan_product_id", body.plan_product_id)
+      .eq("actual_product_id", body.actual_product_id);
+    if (error) throw error;
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : "매핑 삭제 실패" },
+      { status: 500 },
+    );
+  }
+}

--- a/promo-analytics/supabase/migrations/0017_sku_mappings.sql
+++ b/promo-analytics/supabase/migrations/0017_sku_mappings.sql
@@ -1,0 +1,194 @@
+-- 0017: SKU 매칭 매핑 + 진단 함수
+--
+-- 배경: 가이드 임포터(⑤)와 캠페인 실적 시트(②)가 각각 별개로 products 행을 만들면서
+-- 같은 SKU가 다른 product_id 로 등록되는 케이스가 발생. plan_vs_actual 의 자동 매칭
+-- (product_id 기준)이 비어서 달성률이 0건으로 표시됨.
+--
+-- 해결:
+--   1) promotion_sku_mappings: 사용자가 "이 플랜 SKU = 이 실적 SKU" 수동 매핑
+--   2) plan_vs_actual: 실적의 product_id 를 매핑으로 redirect 해 집계
+--   3) sku_match_diagnostic: 플랜·실적 양쪽 SKU 를 한 표로 (status 무관)
+
+-- ── 매핑 테이블 ────────────────────────────────────────────
+create table if not exists promo.promotion_sku_mappings (
+  promotion_id      uuid not null references promo.promotions(id) on delete cascade,
+  plan_product_id   uuid not null references promo.products(id),
+  actual_product_id uuid not null references promo.products(id),
+  created_at        timestamptz not null default now(),
+  primary key (promotion_id, plan_product_id, actual_product_id)
+);
+
+create index if not exists promotion_sku_mappings_actual_idx
+  on promo.promotion_sku_mappings (promotion_id, actual_product_id);
+
+alter table promo.promotion_sku_mappings enable row level security;
+drop policy if exists promotion_sku_mappings_auth on promo.promotion_sku_mappings;
+create policy promotion_sku_mappings_auth on promo.promotion_sku_mappings
+  for all to authenticated using (true) with check (true);
+
+-- ── plan_vs_actual: 매핑 적용 (실적 product_id 를 plan_product_id 로 변환) ──
+create or replace function promo.plan_vs_actual(p_id uuid)
+returns table (
+  product_id uuid,
+  base_name text,
+  expected_qty numeric,
+  expected_revenue numeric,
+  expected_contribution numeric,
+  actual_qty numeric,
+  actual_revenue numeric,
+  actual_contribution numeric,
+  ach_qty numeric,
+  ach_revenue numeric,
+  ach_contribution numeric,
+  status text
+)
+language sql
+stable
+set search_path = ''
+as $$
+  with plan as (
+    select id, (rate_card_snapshot->>'mult')::numeric as mult
+    from promo.campaign_plans
+    where promotion_id = p_id and is_current and status = 'confirmed'
+    limit 1
+  ),
+  exp as (
+    select i.product_id,
+           max(i.base_name) as base_name,
+           sum(o.expected_option_qty * i.sku_qty_per_option) as expected_qty,
+           sum(o.expected_option_qty * i.sku_qty_per_option * i.unit_sale_price) as expected_revenue,
+           sum(o.expected_option_qty * i.sku_qty_per_option *
+               (i.unit_sale_price * (select mult from plan) - coalesce(i.frozen_cost,0))) as expected_contribution
+    from promo.campaign_plan_options o
+    join promo.campaign_plan_option_items i on i.campaign_plan_option_id = o.id
+    where o.campaign_plan_id = (select id from plan)
+    group by i.product_id
+  ),
+  -- 매핑 적용: 실적의 product_id 를 plan_product_id 로 변환 (없으면 원래 값 유지)
+  mapped_sales as (
+    select coalesce(m.plan_product_id, ps.product_id) as product_id,
+           ps.base_name, ps.quantity, ps.revenue, ps.cost
+    from promo.promotion_sales ps
+    left join promo.promotion_sku_mappings m
+      on m.promotion_id = ps.promotion_id and m.actual_product_id = ps.product_id
+    where ps.promotion_id = p_id and ps.product_id is not null
+      and exists (select 1 from plan)
+  ),
+  act as (
+    select product_id,
+           max(base_name) as base_name,
+           sum(quantity) as actual_qty,
+           sum(revenue) as actual_revenue,
+           sum(revenue) * (select mult from plan) - sum(coalesce(cost,0)) as actual_contribution
+    from mapped_sales
+    group by product_id
+  ),
+  j as (
+    select
+      coalesce(e.product_id, a.product_id) as product_id,
+      coalesce(e.base_name, a.base_name) as base_name,
+      coalesce(e.expected_qty,0) as expected_qty,
+      coalesce(e.expected_revenue,0) as expected_revenue,
+      coalesce(e.expected_contribution,0) as expected_contribution,
+      coalesce(a.actual_qty,0) as actual_qty,
+      coalesce(a.actual_revenue,0) as actual_revenue,
+      coalesce(a.actual_contribution,0) as actual_contribution,
+      (e.product_id is not null and (coalesce(e.expected_qty,0) > 0 or coalesce(e.expected_revenue,0) > 0)) as has_exp,
+      (a.product_id is not null and (coalesce(a.actual_qty,0) <> 0 or coalesce(a.actual_revenue,0) <> 0)) as has_act
+    from exp e
+    full outer join act a on a.product_id = e.product_id
+  )
+  select
+    product_id, base_name, expected_qty, expected_revenue, expected_contribution,
+    actual_qty, actual_revenue, actual_contribution,
+    case when expected_qty > 0 then actual_qty/expected_qty else null end as ach_qty,
+    case when expected_revenue > 0 then actual_revenue/expected_revenue else null end as ach_revenue,
+    case when expected_contribution > 0 then actual_contribution/expected_contribution else null end as ach_contribution,
+    case
+      when has_exp and has_act then 'matched'
+      when has_exp and not has_act then 'unsold'
+      else 'unplanned'
+    end as status
+  from j
+  where has_exp or has_act;
+$$;
+
+-- ── 진단 함수: 플랜·실적 SKU 한 표 (status 무관, draft 도 포함) ──
+create or replace function promo.sku_match_diagnostic(p_id uuid)
+returns table (
+  side text,                  -- 'both' | 'plan' | 'actual'
+  product_id uuid,
+  base_name text,
+  dr_code text,
+  expected_qty numeric,
+  expected_revenue numeric,
+  actual_qty numeric,
+  actual_revenue numeric,
+  is_mapped boolean           -- 매핑으로 redirect 된 실적 포함 여부
+)
+language sql
+stable
+set search_path = ''
+as $$
+  with current_plan as (
+    select id from promo.campaign_plans
+    where promotion_id = p_id and is_current
+    order by version desc limit 1
+  ),
+  plan_skus as (
+    select cpoi.product_id,
+      max(cpoi.base_name) as base_name,
+      sum(cpo.expected_option_qty * cpoi.sku_qty_per_option) as expected_qty,
+      sum(cpo.expected_option_qty * cpoi.sku_qty_per_option * cpoi.unit_sale_price) as expected_revenue
+    from promo.campaign_plan_options cpo
+    join promo.campaign_plan_option_items cpoi on cpoi.campaign_plan_option_id = cpo.id
+    where cpo.campaign_plan_id = (select id from current_plan)
+    group by cpoi.product_id
+  ),
+  mapped_sales as (
+    select coalesce(m.plan_product_id, ps.product_id) as product_id,
+      m.plan_product_id is not null as is_mapped,
+      ps.base_name, ps.quantity, ps.revenue
+    from promo.promotion_sales ps
+    left join promo.promotion_sku_mappings m
+      on m.promotion_id = ps.promotion_id and m.actual_product_id = ps.product_id
+    where ps.promotion_id = p_id and ps.product_id is not null
+  ),
+  actual_skus as (
+    select product_id,
+      bool_or(is_mapped) as is_mapped,
+      max(base_name) as base_name,
+      sum(quantity) as actual_qty,
+      sum(revenue) as actual_revenue
+    from mapped_sales
+    group by product_id
+  ),
+  combined as (
+    select coalesce(p.product_id, a.product_id) as product_id,
+      coalesce(p.base_name, a.base_name) as base_name,
+      coalesce(p.expected_qty, 0) as expected_qty,
+      coalesce(p.expected_revenue, 0) as expected_revenue,
+      coalesce(a.actual_qty, 0) as actual_qty,
+      coalesce(a.actual_revenue, 0) as actual_revenue,
+      coalesce(a.is_mapped, false) as is_mapped,
+      case when p.product_id is not null and a.product_id is not null then 'both'
+        when p.product_id is not null then 'plan'
+        else 'actual'
+      end as side
+    from plan_skus p
+    full outer join actual_skus a on a.product_id = p.product_id
+  )
+  select c.side, c.product_id, c.base_name, pr.dr_code,
+    c.expected_qty, c.expected_revenue, c.actual_qty, c.actual_revenue, c.is_mapped
+  from combined c
+  left join promo.products pr on pr.id = c.product_id
+  order by
+    case c.side when 'both' then 0 when 'plan' then 1 else 2 end,
+    coalesce(c.expected_revenue, 0) desc,
+    coalesce(c.actual_revenue, 0) desc;
+$$;
+
+grant execute on all functions in schema promo to authenticated;
+grant all on all tables in schema promo to authenticated;
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
플랜 가이드(⑤)와 캠페인 실적 시트(②)가 같은 SKU를 다른 product_id로 등록하는 케이스에 대응. 사용자가 **양쪽 리스트에서 직접 골라** 수동 연동하는 가장 확실한 매칭 방식.

### 진단 결과 (운영 DB)
- 23 캠페인 중 플랜·실적이 모두 있는 케이스 0건
- 자동 SKU 매칭이 0건인 이유: 두 업로드 경로의 base_name·dr_code 가 어긋남
- 따라서 **수동 매핑 UI가 필요**

## 변경
### Migration 0017 (적용 완료)
- `promo.promotion_sku_mappings` 테이블: `(promotion_id, plan_product_id, actual_product_id)` 매핑
- `promo.plan_vs_actual` 보강: 매핑 적용해 실적 `product_id` → 플랜 `product_id` 로 redirect
- `promo.sku_match_diagnostic(p_id)`: 플랜·실적 양쪽 SKU 한 표 (draft 도 포함)

### API
- `GET/POST/DELETE /api/promotions/[id]/sku-mappings`

### UI
- `app/(dash)/promotions/[id]/SkuMatchPanel.tsx`
- 캠페인 상세 → "SKU 매칭 진단" 섹션
  - 자동 매칭/플랜만/실적만 3종 카운트
  - 양쪽 셀렉트 박스에서 골라 "연동" 버튼
  - 현재 매핑 목록 + 해제 버튼
  - 전체 SKU 진단 표 (상태 배지 + 기대/실적 수치)

## Test plan
- [ ] Vercel 프리뷰 → CF_P_260608 또는 CF_P_260511 캠페인 상세 → SKU 매칭 진단 섹션 표시
- [ ] 양쪽 셀렉트에서 SKU 선택 → 연동 → router.refresh() 후 'both/매핑됨' 으로 이동 확인
- [ ] 매핑 해제 → 다시 분리 확인
- [ ] 확정 플랜 캠페인의 달성률 카드/표 매핑 반영 확인

https://claude.ai/code/session_015LKzwi94QyhtUws2Zb1hvj

---
_Generated by [Claude Code](https://claude.ai/code/session_015LKzwi94QyhtUws2Zb1hvj)_