### PR TITLE
N4.2: 캠페인 병합 도구

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/edit/MergeForm.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/edit/MergeForm.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+type Candidate = {
+  id: string;
+  name: string;
+  code: string | null;
+  start_date: string;
+  end_date: string;
+};
+
+// 캠페인 병합: 이 캠페인(source)을 다른 캠페인(target)으로 흡수.
+// 같은 행사인데 가이드(⑤)·실적(②) 시트가 서로 다른 코드로 업로드돼 별개 캠페인이 생긴 경우 사용.
+export default function MergeForm({
+  sourceId,
+  sourceName,
+  candidates,
+}: {
+  sourceId: string;
+  sourceName: string;
+  candidates: Candidate[];
+}) {
+  const router = useRouter();
+  const [targetId, setTargetId] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const target = candidates.find((c) => c.id === targetId);
+
+  async function merge() {
+    if (!targetId || !target) return;
+    const ok = window.confirm(
+      `현재 캠페인 [${sourceName}]을\n` +
+        `대상 캠페인 [${target.name}]에 병합합니다.\n\n` +
+        `· 실적·메모·메인상품·목적 가중치·SKU 매핑을 모두 대상으로 이전\n` +
+        `· 플랜이 있으면 대상으로 이전 (양쪽 모두 있으면 거부)\n` +
+        `· 기간은 합집합 (시작=min, 종료=max)\n` +
+        `· 현재 캠페인은 삭제됩니다\n\n` +
+        `되돌릴 수 없습니다. 진행할까요?`,
+    );
+    if (!ok) return;
+    setBusy(true);
+    setErr(null);
+    const res = await fetch(`/api/promotions/${sourceId}/merge`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ target_id: targetId }),
+    });
+    setBusy(false);
+    if (!res.ok) {
+      const j = await res.json().catch(() => ({}));
+      setErr(j.error ?? "병합 실패");
+      return;
+    }
+    // 병합 후 대상 캠페인 상세로 이동
+    router.push(`/promotions/${targetId}`);
+    router.refresh();
+  }
+
+  return (
+    <section className="rounded-[28px] bg-canvas p-6 card-soft">
+      <h2 className="text-sm font-semibold text-ink-2">캠페인 병합 (고급)</h2>
+      <p className="mt-1 text-xs text-ink-4">
+        같은 행사인데 가이드(⑤)와 실적(②) 시트가 서로 다른 코드로 업로드돼 별개 캠페인이
+        생긴 경우, 현재 캠페인을 다른 캠페인에 흡수합니다. 모든 데이터(실적·메모·플랜·매핑)는
+        대상으로 이전되고 현재 캠페인은 삭제됩니다.
+      </p>
+
+      <div className="mt-4 grid gap-2 sm:grid-cols-[1fr_auto]">
+        <select
+          value={targetId}
+          onChange={(e) => setTargetId(e.target.value)}
+          className="rounded-xl bg-canvas px-3 py-2 text-sm surface-pressed-soft focus:outline-none"
+        >
+          <option value="">병합 대상 캠페인 선택 …</option>
+          {candidates.map((c) => (
+            <option key={c.id} value={c.id}>
+              [{c.code ?? "—"}] {c.name} · {c.start_date}~{c.end_date}
+            </option>
+          ))}
+        </select>
+        <button
+          onClick={merge}
+          disabled={busy || !targetId}
+          className="rounded-full bg-brand-500 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-600 disabled:opacity-50"
+        >
+          {busy ? "병합 중…" : "병합 실행"}
+        </button>
+      </div>
+      {err && <p className="mt-2 text-xs text-brand-700">{err}</p>}
+    </section>
+  );
+}

--- a/promo-analytics/app/(dash)/promotions/[id]/edit/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/edit/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import type { Promotion } from "@/lib/types";
 import EditForm from "./EditForm";
+import MergeForm from "./MergeForm";
 import { loadOptions } from "@/lib/options";
 
 export const dynamic = "force-dynamic";
@@ -20,6 +21,13 @@ export default async function EditPromotion({
     .eq("id", id)
     .single<Promotion>();
   if (!promo) notFound();
+
+  // 병합 후보 목록 (자기 자신 제외)
+  const { data: otherPromos } = await supabase
+    .from("promotions")
+    .select("id, name, code, start_date, end_date")
+    .neq("id", id)
+    .order("start_date", { ascending: false });
 
   const { data: sales } = await supabase
     .from("promotion_sales")
@@ -66,6 +74,21 @@ export default async function EditPromotion({
         options={options}
         initialWeights={initialWeights}
       />
+      <div className="mt-8">
+        <MergeForm
+          sourceId={id}
+          sourceName={promo.name}
+          candidates={
+            (otherPromos ?? []).map((p) => ({
+              id: p.id as string,
+              name: p.name as string,
+              code: (p.code as string | null) ?? null,
+              start_date: p.start_date as string,
+              end_date: p.end_date as string,
+            }))
+          }
+        />
+      </div>
     </div>
   );
 }

--- a/promo-analytics/app/api/promotions/[id]/merge/route.ts
+++ b/promo-analytics/app/api/promotions/[id]/merge/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export const runtime = "nodejs";
+
+// 이 캠페인(source)을 다른 캠페인(target)에 병합. 모든 데이터를 target 으로 이전 후
+// source 캠페인 삭제. 한쪽에만 플랜이 있어야 함.
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id: sourceId } = await params;
+    const body = (await req.json()) as { target_id?: string };
+    if (!body.target_id) {
+      return NextResponse.json(
+        { error: "병합 대상(target_id)이 필요합니다" },
+        { status: 400 },
+      );
+    }
+    const supabase = await createClient();
+    const { data, error } = await supabase.rpc("merge_campaigns", {
+      source_id: sourceId,
+      target_id: body.target_id,
+    });
+    if (error) throw error;
+    return NextResponse.json(data ?? { ok: true });
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : "병합 실패" },
+      { status: 500 },
+    );
+  }
+}

--- a/promo-analytics/supabase/migrations/0019_merge_campaigns.sql
+++ b/promo-analytics/supabase/migrations/0019_merge_campaigns.sql
@@ -1,0 +1,91 @@
+-- 0019: 캠페인 병합 함수 — 가이드와 실적이 서로 다른 캠페인 코드로 업로드된 케이스 해결
+--
+-- 시나리오: 가이드(⑤)는 'CF_P_260511_벌크UP' 코드로, 실적(②)은 'CF_P_260518' 코드로
+-- 업로드돼 같은 행사인데 두 개의 promotion 행이 생긴 경우. 한쪽의 모든 데이터를
+-- 다른 쪽으로 이전한 뒤 원본 삭제.
+--
+-- 이전 대상: promotion_sales, promotion_notes, promotion_main_products,
+--           promotion_purpose_weights, promotion_sku_mappings, campaign_plans
+-- 메타: 시작일/종료일은 합집합으로 확장. name/code 는 target 유지.
+-- 제약: 양쪽 모두 플랜이 있으면 거부 (사용자가 한쪽 먼저 정리해야 함).
+
+create or replace function promo.merge_campaigns(source_id uuid, target_id uuid)
+returns jsonb
+language plpgsql
+set search_path = ''
+as $$
+declare
+  v_source promo.promotions%rowtype;
+  v_target promo.promotions%rowtype;
+  v_source_plan_count int;
+  v_target_plan_count int;
+  v_sales_moved int;
+  v_notes_moved int;
+begin
+  if source_id = target_id then
+    raise exception '원본과 대상이 같습니다';
+  end if;
+
+  select * into v_source from promo.promotions where id = source_id;
+  if not found then raise exception '원본 캠페인을 찾을 수 없습니다'; end if;
+
+  select * into v_target from promo.promotions where id = target_id;
+  if not found then raise exception '대상 캠페인을 찾을 수 없습니다'; end if;
+
+  select count(*) into v_source_plan_count from promo.campaign_plans where promotion_id = source_id;
+  select count(*) into v_target_plan_count from promo.campaign_plans where promotion_id = target_id;
+  if v_source_plan_count > 0 and v_target_plan_count > 0 then
+    raise exception '양쪽 캠페인 모두 플랜이 있어 자동 병합 불가. 한쪽 플랜을 먼저 정리하세요.';
+  end if;
+
+  -- 단순 이전 (PK 가 자체 id 라 충돌 없음)
+  update promo.promotion_sales set promotion_id = target_id where promotion_id = source_id;
+  get diagnostics v_sales_moved = row_count;
+
+  update promo.promotion_notes set promotion_id = target_id where promotion_id = source_id;
+  get diagnostics v_notes_moved = row_count;
+
+  -- 충돌 가능: 같은 (target_id, key) 있으면 target 유지
+  insert into promo.promotion_main_products (promotion_id, product_id)
+    select target_id, product_id from promo.promotion_main_products
+    where promotion_id = source_id
+    on conflict do nothing;
+  delete from promo.promotion_main_products where promotion_id = source_id;
+
+  insert into promo.promotion_purpose_weights (promotion_id, purpose, weight)
+    select target_id, purpose, weight from promo.promotion_purpose_weights
+    where promotion_id = source_id
+    on conflict (promotion_id, purpose) do nothing;
+  delete from promo.promotion_purpose_weights where promotion_id = source_id;
+
+  insert into promo.promotion_sku_mappings (promotion_id, plan_product_id, actual_product_id)
+    select target_id, plan_product_id, actual_product_id from promo.promotion_sku_mappings
+    where promotion_id = source_id
+    on conflict do nothing;
+  delete from promo.promotion_sku_mappings where promotion_id = source_id;
+
+  -- 플랜 이전 (한쪽에만 있을 때만 도달)
+  update promo.campaign_plans set promotion_id = target_id where promotion_id = source_id;
+
+  -- 메타: 기간 합집합 (start = min, end = max)
+  update promo.promotions
+  set start_date = least(v_source.start_date, v_target.start_date),
+      end_date = greatest(v_source.end_date, v_target.end_date)
+  where id = target_id;
+
+  -- 원본 삭제 (cascade)
+  delete from promo.promotions where id = source_id;
+
+  return jsonb_build_object(
+    'ok', true,
+    'target_id', target_id,
+    'sales_moved', v_sales_moved,
+    'notes_moved', v_notes_moved,
+    'plans_moved', v_source_plan_count
+  );
+end;
+$$;
+
+grant execute on function promo.merge_campaigns(uuid, uuid) to authenticated;
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
N4.1 후속: 가이드와 실적이 서로 다른 캠페인 코드로 업로드돼 별개의 promotion 행이 된 경우 캠페인 단위 흡수가 필요. UI에서 후보 캠페인 골라 1번에 병합.

### 변경
- Migration 0019: `promo.merge_campaigns(source_id, target_id)` 함수 (적용 완료)
  - 6개 테이블 데이터 이전, PK 충돌은 target 유지, 양쪽 모두 플랜이면 거부
  - 기간 합집합, name/code 는 target 유지
  - 원본 캠페인 삭제
- API: `POST /api/promotions/[id]/merge { target_id }`
- UI: 캠페인 편집 페이지 하단 "캠페인 병합 (고급)" 섹션 — 후보 셀렉트 + 확인 다이얼로그

### 사용 시나리오 (사용자 케이스)
1. CF_P_260518 캠페인 편집으로 진입
2. "캠페인 병합" → 대상 = CF_P_260511_벌크UP 선택 → 병합
3. CF_P_260511_벌크UP 상세로 이동, 플랜+실적 모두 한 캠페인에 모임
4. SKU 자동 매칭(N4.1)으로 달성률 자동 표시

## Test plan
- [ ] Vercel 프리뷰 → CF_P_260518 편집 → 병합 폼 표시
- [ ] 대상 후보 리스트에 다른 캠페인들 나타남
- [ ] 병합 실행 → 확인 다이얼로그 → 성공 시 target 상세로 이동
- [ ] 양쪽 모두 플랜 있는 경우 거부 메시지 확인

https://claude.ai/code/session_015LKzwi94QyhtUws2Zb1hvj

---
_Generated by [Claude Code](https://claude.ai/code/session_015LKzwi94QyhtUws2Zb1hvj)_