### PR TITLE
N4.3: 플랜 ↔ 실적 분리 비교 (cross-campaign achievement)

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/ActualsLink.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/ActualsLink.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export type ActualsCandidate = {
+  id: string;
+  name: string;
+  code: string | null;
+  start_date: string;
+  end_date: string;
+  actual_skus: number;
+};
+
+// 이 캠페인의 플랜이 비교할 '실적 캠페인'을 명시적으로 선택.
+// 가이드(⑤)와 실적(②)이 서로 다른 코드로 업로드된 경우 — 머지 없이 짝지어 비교.
+export default function ActualsLink({
+  promotionId,
+  currentLinkId,
+  candidates,
+}: {
+  promotionId: string;
+  currentLinkId: string | null;
+  candidates: ActualsCandidate[];
+}) {
+  const router = useRouter();
+  const [pick, setPick] = useState<string>(currentLinkId ?? "");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const dirty = (currentLinkId ?? "") !== pick;
+
+  async function save(value: string | null) {
+    setBusy(true);
+    setErr(null);
+    const res = await fetch(
+      `/api/promotions/${promotionId}/plan/actuals-link`,
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ actual_promotion_id: value }),
+      },
+    );
+    setBusy(false);
+    if (!res.ok) {
+      const j = await res.json().catch(() => ({}));
+      setErr(j.error ?? "저장 실패");
+      return;
+    }
+    router.refresh();
+  }
+
+  return (
+    <section className="mt-6 rounded-[24px] bg-canvas p-5 card-soft">
+      <h2 className="text-sm font-semibold text-ink-2">비교 대상 실적 캠페인</h2>
+      <p className="mt-1 text-xs text-ink-4">
+        이 캠페인의 플랜을 어느 캠페인의 실적과 비교할지 선택합니다. 기본값은 자기 자신.
+        가이드(⑤)와 실적(②)이 서로 다른 코드로 업로드된 경우 다른 캠페인을 지정해 짝지어
+        비교하세요. 모든 달성률·진단이 선택한 실적 기준으로 다시 계산됩니다.
+      </p>
+      <div className="mt-3 grid gap-2 sm:grid-cols-[1fr_auto_auto]">
+        <select
+          value={pick}
+          onChange={(e) => setPick(e.target.value)}
+          className="rounded-xl bg-canvas px-3 py-2 text-sm surface-pressed-soft focus:outline-none"
+        >
+          <option value="">자기 캠페인 실적 (기본)</option>
+          {candidates
+            .filter((c) => c.id !== promotionId)
+            .map((c) => (
+              <option key={c.id} value={c.id}>
+                [{c.code ?? "—"}] {c.name} · {c.start_date}~{c.end_date} ·{" "}
+                {c.actual_skus} SKU
+              </option>
+            ))}
+        </select>
+        <button
+          onClick={() => save(pick || null)}
+          disabled={busy || !dirty}
+          className="rounded-full bg-brand-500 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-600 disabled:opacity-50"
+        >
+          저장
+        </button>
+        {currentLinkId && (
+          <button
+            onClick={() => {
+              setPick("");
+              save(null);
+            }}
+            disabled={busy}
+            className="rounded-full bg-canvas px-4 py-2 text-sm font-semibold text-ink-3 card-soft hover:text-ink"
+          >
+            기본으로
+          </button>
+        )}
+      </div>
+      {err && <p className="mt-2 text-xs text-brand-700">{err}</p>}
+    </section>
+  );
+}

--- a/promo-analytics/app/(dash)/promotions/[id]/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/page.tsx
@@ -16,6 +16,7 @@ import Notes from "./Notes";
 import Achievement from "./Achievement";
 import PurposeBlock, { type PurposeMetricRow } from "./PurposeBlock";
 import SkuMatchPanel, { type DiagnosticRow, type SkuMapping } from "./SkuMatchPanel";
+import ActualsLink, { type ActualsCandidate } from "./ActualsLink";
 
 export const dynamic = "force-dynamic";
 
@@ -50,10 +51,12 @@ export default async function PromotionDetail({
   const summary = (sData?.[0] as PromotionSummary) ?? null;
   const notes = (nData as PromotionNote[]) ?? [];
 
-  // 현재 가격 가이드(플랜) 요약 (S2)
+  // 현재 가격 가이드(플랜) 요약 (S2) + 비교 대상 실적 캠페인 링크 (N4.3)
   const { data: planRow } = await supabase
     .from("campaign_plans")
-    .select("id, version, status, expected_revenue_total, expected_contribution_total")
+    .select(
+      "id, version, status, expected_revenue_total, expected_contribution_total, actual_promotion_id",
+    )
     .eq("promotion_id", id)
     .eq("is_current", true)
     .maybeSingle();
@@ -62,7 +65,14 @@ export default async function PromotionDetail({
     status: string;
     expected_revenue_total: number | null;
     expected_contribution_total: number | null;
+    actual_promotion_id: string | null;
   } | null;
+
+  // 비교 대상 후보 (실적 있는 모든 캠페인)
+  const { data: actualsCandidates } = await supabase.rpc(
+    "campaigns_with_actuals",
+  );
+  const candidates = (actualsCandidates as ActualsCandidate[]) ?? [];
 
   // 달성률 (S3): 확정 플랜 vs 실적 + 옵션 매핑용 distinct option_info
   // + SKU 매칭 진단 (N4): 플랜·실적 한 표 (draft 도 포함) + 수동 매핑 목록
@@ -245,6 +255,15 @@ export default async function PromotionDetail({
           </Link>
         </div>
       </div>
+
+      {/* 비교 대상 실적 캠페인 (N4.3) — 플랜이 있을 때만 */}
+      {plan && (
+        <ActualsLink
+          promotionId={id}
+          currentLinkId={plan.actual_promotion_id}
+          candidates={candidates}
+        />
+      )}
 
       {/* 달성률 (S3) */}
       <Achievement

--- a/promo-analytics/app/api/promotions/[id]/plan/actuals-link/route.ts
+++ b/promo-analytics/app/api/promotions/[id]/plan/actuals-link/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export const runtime = "nodejs";
+
+// 현재 캠페인 플랜의 비교 대상 실적 캠페인을 설정/해제.
+// body: { actual_promotion_id: string | null }
+//   null → 자기 캠페인 실적 사용 (기본)
+//   값 있음 → 해당 캠페인의 promotion_sales 를 actuals 로 사용 (cross-campaign)
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const body = (await req.json()) as { actual_promotion_id?: string | null };
+    const supabase = await createClient();
+
+    // 현재 캠페인의 current plan 찾기 (draft / confirmed 모두 허용 — actuals link 는 메타정보)
+    const { data: plan } = await supabase
+      .from("campaign_plans")
+      .select("id")
+      .eq("promotion_id", id)
+      .eq("is_current", true)
+      .order("version", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (!plan) {
+      return NextResponse.json(
+        { error: "이 캠페인에 플랜이 없습니다. 플랜을 먼저 만들어주세요." },
+        { status: 400 },
+      );
+    }
+
+    const link =
+      typeof body.actual_promotion_id === "string" &&
+      body.actual_promotion_id.length > 0
+        ? body.actual_promotion_id
+        : null;
+
+    if (link === id) {
+      return NextResponse.json(
+        { error: "자기 캠페인은 자동 연결되므로 다른 캠페인을 선택하세요." },
+        { status: 400 },
+      );
+    }
+
+    const { error } = await supabase
+      .from("campaign_plans")
+      .update({
+        actual_promotion_id: link,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", plan.id);
+    if (error) throw error;
+
+    return NextResponse.json({ ok: true, actual_promotion_id: link });
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : "비교 대상 설정 실패" },
+      { status: 500 },
+    );
+  }
+}

--- a/promo-analytics/supabase/migrations/0020_plan_actual_link.sql
+++ b/promo-analytics/supabase/migrations/0020_plan_actual_link.sql
@@ -1,0 +1,291 @@
+-- 0020: 플랜 ↔ 실적 분리 비교 (cross-campaign achievement)
+--
+-- 배경: 가이드(⑤)와 실적(②) 시트가 서로 다른 캠페인 코드로 업로드되는 경우가 잦음.
+-- 머지로 두 캠페인을 합치는 대신, 플랜은 플랜대로 실적은 실적대로 별개 유지하고
+-- 플랜이 "비교 대상 실적 캠페인"을 명시적으로 가리키는 구조로 전환.
+--
+-- 모델:
+--   campaign_plans.actual_promotion_id (nullable) — 비교 대상 실적 캠페인
+--   null 이면 자기 캠페인의 실적을 사용 (기존 동작 = 하위 호환)
+--   값이 있으면 해당 캠페인의 promotion_sales 를 actuals 로 사용
+--
+-- 영향 함수: plan_vs_actual, plan_vs_actual_summary, plan_vs_actual_options,
+--          sku_match_diagnostic — 모두 actual_pid 를 redirect 적용해 조회
+
+alter table promo.campaign_plans
+  add column if not exists actual_promotion_id uuid references promo.promotions(id);
+
+create index if not exists campaign_plans_actual_promo_idx
+  on promo.campaign_plans (actual_promotion_id);
+
+-- ── plan_vs_actual (confirmed plan, actuals redirect) ────────────────────
+create or replace function promo.plan_vs_actual(p_id uuid)
+returns table (
+  product_id uuid,
+  base_name text,
+  expected_qty numeric,
+  expected_revenue numeric,
+  expected_contribution numeric,
+  actual_qty numeric,
+  actual_revenue numeric,
+  actual_contribution numeric,
+  ach_qty numeric,
+  ach_revenue numeric,
+  ach_contribution numeric,
+  status text
+)
+language sql
+stable
+set search_path = ''
+as $$
+  with plan as (
+    select id, (rate_card_snapshot->>'mult')::numeric as mult,
+      coalesce(actual_promotion_id, promotion_id) as actual_pid
+    from promo.campaign_plans
+    where promotion_id = p_id and is_current and status = 'confirmed'
+    limit 1
+  ),
+  plan_raw as (
+    select i.product_id,
+      pr.base_name,
+      promo.normalize_sku_name(pr.base_name) as match_key,
+      o.expected_option_qty * i.sku_qty_per_option as eq,
+      o.expected_option_qty * i.sku_qty_per_option * i.unit_sale_price as er,
+      o.expected_option_qty * i.sku_qty_per_option *
+        (i.unit_sale_price * (select mult from plan) - coalesce(i.frozen_cost,0)) as ec
+    from promo.campaign_plan_options o
+    join promo.campaign_plan_option_items i on i.campaign_plan_option_id = o.id
+    left join promo.products pr on pr.id = i.product_id
+    where o.campaign_plan_id = (select id from plan)
+  ),
+  exp as (
+    select match_key,
+      (array_agg(product_id order by product_id))[1] as product_id,
+      (array_agg(base_name order by base_name))[1] as base_name,
+      sum(eq) as expected_qty,
+      sum(er) as expected_revenue,
+      sum(ec) as expected_contribution
+    from plan_raw group by match_key
+  ),
+  mapped_sales as (
+    select coalesce(m.plan_product_id, ps.product_id) as product_id,
+      pr.base_name,
+      promo.normalize_sku_name(pr.base_name) as match_key,
+      ps.quantity, ps.revenue, ps.cost
+    from promo.promotion_sales ps
+    left join promo.promotion_sku_mappings m
+      on m.promotion_id = ps.promotion_id and m.actual_product_id = ps.product_id
+    left join promo.products pr on pr.id = coalesce(m.plan_product_id, ps.product_id)
+    where ps.promotion_id = (select actual_pid from plan)
+      and ps.product_id is not null
+      and exists (select 1 from plan)
+  ),
+  act as (
+    select match_key,
+      (array_agg(product_id order by product_id))[1] as product_id,
+      (array_agg(base_name order by base_name))[1] as base_name,
+      sum(quantity) as actual_qty,
+      sum(revenue) as actual_revenue,
+      sum(revenue) * (select mult from plan) - sum(coalesce(cost,0)) as actual_contribution
+    from mapped_sales group by match_key
+  ),
+  j as (
+    select
+      coalesce(e.product_id, a.product_id) as product_id,
+      coalesce(e.base_name, a.base_name) as base_name,
+      coalesce(e.expected_qty,0) as expected_qty,
+      coalesce(e.expected_revenue,0) as expected_revenue,
+      coalesce(e.expected_contribution,0) as expected_contribution,
+      coalesce(a.actual_qty,0) as actual_qty,
+      coalesce(a.actual_revenue,0) as actual_revenue,
+      coalesce(a.actual_contribution,0) as actual_contribution,
+      (e.match_key is not null and (coalesce(e.expected_qty,0) > 0 or coalesce(e.expected_revenue,0) > 0)) as has_exp,
+      (a.match_key is not null and (coalesce(a.actual_qty,0) <> 0 or coalesce(a.actual_revenue,0) <> 0)) as has_act
+    from exp e
+    full outer join act a on a.match_key = e.match_key
+  )
+  select
+    product_id, base_name, expected_qty, expected_revenue, expected_contribution,
+    actual_qty, actual_revenue, actual_contribution,
+    case when expected_qty > 0 then actual_qty/expected_qty else null end as ach_qty,
+    case when expected_revenue > 0 then actual_revenue/expected_revenue else null end as ach_revenue,
+    case when expected_contribution > 0 then actual_contribution/expected_contribution else null end as ach_contribution,
+    case
+      when has_exp and has_act then 'matched'
+      when has_exp and not has_act then 'unsold'
+      else 'unplanned'
+    end as status
+  from j
+  where has_exp or has_act;
+$$;
+
+-- ── plan_vs_actual_options (옵션 단위, actuals redirect) ────────────────
+create or replace function promo.plan_vs_actual_options(p_id uuid)
+returns table (
+  option_id uuid,
+  option_label text,
+  expected_option_qty numeric,
+  expected_revenue numeric,
+  expected_contribution numeric,
+  match_patterns text[],
+  matched boolean,
+  actual_revenue numeric,
+  actual_qty numeric,
+  ach_revenue numeric
+)
+language sql
+stable
+set search_path = ''
+as $$
+  with plan as (
+    select id, coalesce(actual_promotion_id, promotion_id) as actual_pid
+    from promo.campaign_plans
+    where promotion_id = p_id and is_current and status = 'confirmed' limit 1
+  )
+  select
+    o.id, o.option_label, o.expected_option_qty, o.expected_revenue, o.expected_contribution,
+    o.match_patterns,
+    coalesce(act.matched, false) as matched,
+    coalesce(act.actual_revenue, 0) as actual_revenue,
+    coalesce(act.actual_qty, 0) as actual_qty,
+    case when coalesce(o.expected_revenue,0) > 0 then coalesce(act.actual_revenue,0)/o.expected_revenue else null end as ach_revenue
+  from promo.campaign_plan_options o
+  left join lateral (
+    select sum(ps.revenue) as actual_revenue, sum(ps.quantity) as actual_qty, count(*) > 0 as matched
+    from promo.promotion_sales ps
+    where ps.promotion_id = (select actual_pid from plan)
+      and coalesce(array_length(o.match_patterns,1),0) > 0
+      and exists (
+        select 1 from unnest(o.match_patterns) pat
+        where length(btrim(pat)) > 0
+          and position(
+            lower(regexp_replace(pat, '\s', '', 'g'))
+            in lower(regexp_replace(coalesce(ps.option_info,''), '\s', '', 'g'))
+          ) > 0
+      )
+  ) act on true
+  where o.campaign_plan_id = (select id from plan)
+  order by o.sort;
+$$;
+
+-- ── sku_match_diagnostic (draft 포함, actuals redirect) ────────────────
+create or replace function promo.sku_match_diagnostic(p_id uuid)
+returns table (
+  side text,
+  product_id uuid,
+  base_name text,
+  dr_code text,
+  expected_qty numeric,
+  expected_revenue numeric,
+  actual_qty numeric,
+  actual_revenue numeric,
+  is_mapped boolean
+)
+language sql
+stable
+set search_path = ''
+as $$
+  with current_plan as (
+    select id, coalesce(actual_promotion_id, promotion_id) as actual_pid
+    from promo.campaign_plans
+    where promotion_id = p_id and is_current
+    order by version desc limit 1
+  ),
+  -- 플랜 없으면 자기 캠페인 실적만 표시
+  plan_raw as (
+    select cpoi.product_id,
+      pr.base_name, pr.dr_code,
+      promo.normalize_sku_name(pr.base_name) as match_key,
+      cpo.expected_option_qty * cpoi.sku_qty_per_option as q,
+      cpo.expected_option_qty * cpoi.sku_qty_per_option * cpoi.unit_sale_price as r
+    from promo.campaign_plan_options cpo
+    join promo.campaign_plan_option_items cpoi on cpoi.campaign_plan_option_id = cpo.id
+    left join promo.products pr on pr.id = cpoi.product_id
+    where cpo.campaign_plan_id = (select id from current_plan)
+  ),
+  plan_skus as (
+    select match_key,
+      (array_agg(product_id order by product_id))[1] as product_id,
+      (array_agg(base_name order by base_name))[1] as base_name,
+      (array_agg(dr_code order by dr_code) filter (where dr_code is not null))[1] as dr_code,
+      sum(q) as expected_qty,
+      sum(r) as expected_revenue
+    from plan_raw group by match_key
+  ),
+  mapped_sales as (
+    select coalesce(m.plan_product_id, ps.product_id) as product_id,
+      (m.plan_product_id is not null) as is_mapped,
+      pr.base_name, pr.dr_code,
+      promo.normalize_sku_name(pr.base_name) as match_key,
+      ps.quantity, ps.revenue
+    from promo.promotion_sales ps
+    left join promo.promotion_sku_mappings m
+      on m.promotion_id = ps.promotion_id and m.actual_product_id = ps.product_id
+    left join promo.products pr on pr.id = coalesce(m.plan_product_id, ps.product_id)
+    where ps.promotion_id = coalesce((select actual_pid from current_plan), p_id)
+      and ps.product_id is not null
+  ),
+  actual_skus as (
+    select match_key,
+      (array_agg(product_id order by product_id))[1] as product_id,
+      (array_agg(base_name order by base_name))[1] as base_name,
+      (array_agg(dr_code order by dr_code) filter (where dr_code is not null))[1] as dr_code,
+      bool_or(is_mapped) as is_mapped,
+      sum(quantity) as actual_qty,
+      sum(revenue) as actual_revenue
+    from mapped_sales group by match_key
+  ),
+  combined as (
+    select coalesce(p.product_id, a.product_id) as product_id,
+      coalesce(p.base_name, a.base_name) as base_name,
+      coalesce(p.dr_code, a.dr_code) as dr_code,
+      coalesce(p.expected_qty, 0) as expected_qty,
+      coalesce(p.expected_revenue, 0) as expected_revenue,
+      coalesce(a.actual_qty, 0) as actual_qty,
+      coalesce(a.actual_revenue, 0) as actual_revenue,
+      coalesce(a.is_mapped, false) as is_mapped,
+      case when p.match_key is not null and a.match_key is not null then 'both'
+        when p.match_key is not null then 'plan'
+        else 'actual'
+      end as side
+    from plan_skus p
+    full outer join actual_skus a on a.match_key = p.match_key
+  )
+  select c.side, c.product_id, c.base_name, c.dr_code,
+    c.expected_qty, c.expected_revenue, c.actual_qty, c.actual_revenue, c.is_mapped
+  from combined c
+  order by
+    case c.side when 'both' then 0 when 'plan' then 1 else 2 end,
+    coalesce(c.expected_revenue, 0) desc,
+    coalesce(c.actual_revenue, 0) desc;
+$$;
+
+-- ── 실적 캠페인 후보 목록 (실적이 있는 모든 캠페인) ─────────────────────
+create or replace function promo.campaigns_with_actuals()
+returns table (
+  id uuid,
+  name text,
+  code text,
+  start_date date,
+  end_date date,
+  actual_skus int,
+  actual_revenue numeric
+)
+language sql
+stable
+set search_path = ''
+as $$
+  select p.id, p.name, p.code, p.start_date, p.end_date,
+    count(distinct ps.product_id)::int as actual_skus,
+    coalesce(sum(ps.revenue), 0) as actual_revenue
+  from promo.promotions p
+  join promo.promotion_sales ps on ps.promotion_id = p.id
+  where ps.product_id is not null
+  group by p.id, p.name, p.code, p.start_date, p.end_date
+  having count(*) > 0
+  order by p.start_date desc;
+$$;
+
+grant execute on all functions in schema promo to authenticated;
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
병합 실패 케이스(양쪽 모두 플랜 존재)와 사용자 의도 변경 반영:
머지 대신 플랜은 플랜대로, 실적은 실적대로 별개 유지하고 플랜이
'비교 대상 실적 캠페인'을 명시적으로 가리키는 구조.

마이그레이션 0020
- campaign_plans.actual_promotion_id 컬럼 추가 (nullable, FK)
  - null → 자기 캠페인 실적 (기존 동작 = 하위 호환)
  - 값 → 해당 캠페인의 promotion_sales 를 actuals 로 사용
- plan_vs_actual / plan_vs_actual_options / sku_match_diagnostic 모두 actual_pid redirect 적용
- campaigns_with_actuals(): 실적 있는 캠페인 후보 함수

API: PATCH /api/promotions/[id]/plan/actuals-link
UI: 캠페인 상세 상단 '비교 대상 실적 캠페인' 선택 드롭다운