### PR TITLE
N6 R1: 성능 수술 — 롤업 서빙 테이블 + O(N²) 제거 + 연동 센터 + 파일명 투명화

### DIFF
--- a/promo-analytics/app/(dash)/library/page.tsx
+++ b/promo-analytics/app/(dash)/library/page.tsx
@@ -9,39 +9,38 @@ import LibraryTable, { type LibraryRow } from "./LibraryTable";
 
 export const dynamic = "force-dynamic";
 
-type BatchSummary = PromotionSummary & { promotion_id: string };
+// 0022 롤업 번들 — 사전 계산된 서빙 테이블에서 1회 왕복으로 읽는다
+type RollupEntry = {
+  promotion_id: string;
+  features: (PromotionSummary & { promotion_id: string }) | null;
+  achievement: CampaignAchievement | null;
+  fits: CampaignFit[];
+};
+type LibraryBundle = { promotions: Promotion[]; rollups: RollupEntry[] };
 
 export default async function LibraryPage() {
   const supabase = await createClient();
-  const [{ data: promos }, { data: sumData }, { data: achData }, { data: fitData }] =
-    await Promise.all([
-      supabase
-        .from("promotions")
-        .select("*")
-        .order("start_date", { ascending: false }),
-      supabase.rpc("all_promotion_summaries"),
-      supabase.rpc("campaign_achievements"),
-      supabase.rpc("campaign_fits"),
-    ]);
-  const sumMap = new Map<string, PromotionSummary>(
-    ((sumData as BatchSummary[]) ?? []).map((s) => [s.promotion_id, s]),
-  );
-  const achMap = new Map<string, CampaignAchievement>(
-    ((achData as CampaignAchievement[]) ?? []).map((a) => [a.promotion_id, a]),
-  );
-  // 캠페인별 목적 적합도 묶기
+  const { data: bundle } = await supabase.rpc("library_bundle");
+  const { promotions: promos = [], rollups = [] } =
+    ((bundle as LibraryBundle | null) ?? {}) as Partial<LibraryBundle>;
+
+  const sumMap = new Map<string, PromotionSummary>();
+  const achMap = new Map<string, CampaignAchievement>();
   const fitMap = new Map<
     string,
     { purpose: string; score: number | null; reliable: boolean }[]
   >();
-  for (const f of (fitData as CampaignFit[]) ?? []) {
-    const arr = fitMap.get(f.promotion_id) ?? [];
-    arr.push({
-      purpose: f.purpose,
-      score: f.fit_score_0_100 != null ? Number(f.fit_score_0_100) : null,
-      reliable: f.data_reliable,
-    });
-    fitMap.set(f.promotion_id, arr);
+  for (const r of rollups) {
+    if (r.features) sumMap.set(r.promotion_id, r.features);
+    if (r.achievement) achMap.set(r.promotion_id, r.achievement);
+    fitMap.set(
+      r.promotion_id,
+      (r.fits ?? []).map((f) => ({
+        purpose: f.purpose,
+        score: f.fit_score_0_100 != null ? Number(f.fit_score_0_100) : null,
+        reliable: f.data_reliable,
+      })),
+    );
   }
 
   const rows: LibraryRow[] = (promos ?? []).map((p: Promotion) => {

--- a/promo-analytics/app/(dash)/page.tsx
+++ b/promo-analytics/app/(dash)/page.tsx
@@ -46,29 +46,38 @@ type CampaignFeatureRow = PromotionSummary & {
   duration_days: number;
 };
 
+// 0022 롤업 번들 — 사전 계산된 서빙 테이블에서 1회 왕복으로 읽는다
+type DashboardBundle = {
+  promotions: Promotion[];
+  rollups: {
+    promotion_id: string;
+    features: CampaignFeatureRow | null;
+    achievement: CampaignAchievement | null;
+  }[];
+  overall: OverallMetrics | null;
+  purpose_metrics: PurposeMetric[];
+};
+
 export default async function Dashboard() {
   const supabase = await createClient();
-  const [
-    { data: promos },
-    { data: overallData },
-    { data: achData },
-    { data: pmData },
-    { data: featData },
-  ] = await Promise.all([
-    supabase.from("promotions").select("*").order("start_date", { ascending: false }),
-    supabase.rpc("overall_baseline_metrics"),
-    supabase.rpc("campaign_achievements"),
-    supabase.rpc("purpose_metrics"),
-    supabase.rpc("all_campaign_features"),
-  ]);
+  const { data: bundleData } = await supabase.rpc("dashboard_bundle");
+  const bundle = ((bundleData as DashboardBundle | null) ??
+    {}) as Partial<DashboardBundle>;
+  const promos = bundle.promotions ?? [];
+  const achData = (bundle.rollups ?? [])
+    .map((r) => r.achievement)
+    .filter((a): a is CampaignAchievement => a != null);
+  const pmData = bundle.purpose_metrics ?? [];
   const featMap = new Map<string, CampaignFeatureRow>(
-    ((featData as CampaignFeatureRow[]) ?? []).map((f) => [f.promotion_id, f]),
+    (bundle.rollups ?? [])
+      .filter((r) => r.features != null)
+      .map((r) => [r.promotion_id, r.features as CampaignFeatureRow]),
   );
 
-  const overall = (overallData?.[0] as OverallMetrics | undefined) ?? null;
+  const overall = bundle.overall ?? null;
 
   // 목적 슬라이스 (S5.2): 목적별 가중 기여매출/공헌 + 평균 적합도
-  const pm = (pmData as PurposeMetric[]) ?? [];
+  const pm = pmData;
   const purposeUplift = pm.map((p) => ({
     purpose: p.purpose,
     value: Number(p.weighted_uplift) || 0,
@@ -84,7 +93,7 @@ export default async function Dashboard() {
   }));
 
   // 달성률 (S4): 확정 플랜 보유 캠페인만, 매출(expected_revenue_total) 가중평균
-  const ach = (achData as CampaignAchievement[]) ?? [];
+  const ach = achData;
   const withPlan = ach.filter((a) => a.has_confirmed_plan);
   const wAchRevenue = weightedAvg(
     withPlan.map((a) => ({ v: a.ach_revenue, w: a.expected_revenue_total })),
@@ -98,7 +107,7 @@ export default async function Dashboard() {
     contribution: a.ach_contribution,
   }));
 
-  const rows: Row[] = (promos ?? []).map((p: Promotion) => {
+  const rows: Row[] = promos.map((p: Promotion) => {
     const f = featMap.get(p.id);
     if (!f) {
       return { ...p, summary: null, baseline_daily: 0, promo_daily: 0, promo_days: 1 };

--- a/promo-analytics/app/(dash)/promotions/[id]/edit/EditForm.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/edit/EditForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import type { Promotion } from "@/lib/types";
 import { wonShort } from "@/lib/format";
 
@@ -103,10 +104,14 @@ export default function EditForm({
       }),
     });
     setSaving(false);
-    if (res.ok) router.push(`/promotions/${promo.id}`);
-    else {
+    if (res.ok) {
+      toast.success("저장됐습니다");
+      router.push(`/promotions/${promo.id}`);
+    } else {
       const d = await res.json().catch(() => ({}));
-      alert(d.error ?? "저장 실패 (마이그레이션이 적용됐는지 확인하세요)");
+      toast.error(d.error ?? "저장 실패 (마이그레이션이 적용됐는지 확인하세요)", {
+        action: { label: "다시 시도", onClick: () => save() },
+      });
     }
   }
 
@@ -121,7 +126,9 @@ export default function EditForm({
       router.refresh();
     } else {
       const d = await res.json().catch(() => ({}));
-      alert(d.error ?? "삭제 실패");
+      toast.error(d.error ?? "삭제 실패", {
+        action: { label: "다시 시도", onClick: () => remove() },
+      });
     }
   }
 

--- a/promo-analytics/app/(dash)/promotions/[id]/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/page.tsx
@@ -20,6 +20,43 @@ import ActualsLink, { type ActualsCandidate } from "./ActualsLink";
 
 export const dynamic = "force-dynamic";
 
+// 0022 롤업 번들 — 13개 쿼리(4블록 순차)를 1회 왕복으로 통합
+type DetailBundle = {
+  promo: Promotion | null;
+  rollup: {
+    features: PromotionSummary | null;
+    measurement: MeasurementRow[];
+    pva_summary: PlanVsActualSummary | null;
+    pva_rows: PlanVsActualRow[];
+    pva_options: PlanVsActualOption[];
+    diagnostic: DiagnosticRow[];
+  } | null;
+  notes: PromotionNote[];
+  plan: {
+    version: number;
+    status: string;
+    expected_revenue_total: number | null;
+    expected_contribution_total: number | null;
+    actual_promotion_id: string | null;
+  } | null;
+  candidates: ActualsCandidate[];
+  option_infos: string[];
+  order_count: number;
+  mappings: SkuMapping[];
+  weights: { purpose: string; weight: number }[];
+  sources: UploadSource[];
+};
+
+type UploadSource = {
+  id: string;
+  kind: string;
+  source_file: string;
+  detail: string | null;
+  row_count: number | null;
+  action: string | null;
+  created_at: string;
+};
+
 export default async function PromotionDetail({
   params,
 }: {
@@ -28,105 +65,41 @@ export default async function PromotionDetail({
   const { id } = await params;
   const supabase = await createClient();
 
-  const { data: promo } = await supabase
-    .from("promotions")
-    .select("*")
-    .eq("id", id)
-    .single<Promotion>();
+  const { data: bundleData } = await supabase.rpc("promotion_detail_bundle", {
+    p_id: id,
+  });
+  const bundle = (bundleData as DetailBundle | null) ?? null;
+  const promo = bundle?.promo ?? null;
   if (!promo) notFound();
 
-  const [{ data: mData }, { data: sData }, { data: nData }] = await Promise.all([
-    supabase.rpc("promotion_measurement", { p_id: id }),
-    supabase.rpc("promotion_summary", { p_id: id }),
-    supabase
-      .from("promotion_notes")
-      .select("*")
-      .eq("promotion_id", id)
-      .order("created_at", { ascending: false }),
-  ]);
-
-  const rows = ((mData as MeasurementRow[]) ?? []).sort(
+  const rows = (bundle?.rollup?.measurement ?? []).sort(
     (a, b) => b.uplift_revenue - a.uplift_revenue,
   );
-  const summary = (sData?.[0] as PromotionSummary) ?? null;
-  const notes = (nData as PromotionNote[]) ?? [];
+  const summary = bundle?.rollup?.features ?? null;
+  const notes = bundle?.notes ?? [];
+  const plan = bundle?.plan ?? null;
+  const candidates = bundle?.candidates ?? [];
 
-  // 현재 가격 가이드(플랜) 요약 (S2) + 비교 대상 실적 캠페인 링크 (N4.3)
-  const { data: planRow } = await supabase
-    .from("campaign_plans")
-    .select(
-      "id, version, status, expected_revenue_total, expected_contribution_total, actual_promotion_id",
-    )
-    .eq("promotion_id", id)
-    .eq("is_current", true)
-    .maybeSingle();
-  const plan = planRow as {
-    version: number;
-    status: string;
-    expected_revenue_total: number | null;
-    expected_contribution_total: number | null;
-    actual_promotion_id: string | null;
-  } | null;
-
-  // 비교 대상 후보 (실적 있는 모든 캠페인)
-  const { data: actualsCandidates } = await supabase.rpc(
-    "campaigns_with_actuals",
-  );
-  const candidates = (actualsCandidates as ActualsCandidate[]) ?? [];
-
-  // 달성률 (S3): 확정 플랜 vs 실적 + 옵션 매핑용 distinct option_info
-  // + SKU 매칭 진단 (N4): 플랜·실적 한 표 (draft 도 포함) + 수동 매핑 목록
-  const [
-    { data: pvaSummary },
-    { data: pvaRows },
-    { data: pvaOptions },
-    { data: optInfoRows },
-    { data: diagRows },
-    { data: skuMaps },
-  ] = await Promise.all([
-    supabase.rpc("plan_vs_actual_summary", { p_id: id }),
-    supabase.rpc("plan_vs_actual", { p_id: id }),
-    supabase.rpc("plan_vs_actual_options", { p_id: id }),
-    supabase
-      .from("promotion_sales")
-      .select("option_info")
-      .eq("promotion_id", id)
-      .not("option_info", "is", null),
-    supabase.rpc("sku_match_diagnostic", { p_id: id }),
-    supabase
-      .from("promotion_sku_mappings")
-      .select("plan_product_id, actual_product_id")
-      .eq("promotion_id", id),
-  ]);
-  const achSummary = (pvaSummary?.[0] as PlanVsActualSummary) ?? null;
-  const achRows = (pvaRows as PlanVsActualRow[]) ?? [];
-  const achOptions = (pvaOptions as PlanVsActualOption[]) ?? [];
+  const achSummary = bundle?.rollup?.pva_summary ?? null;
+  const achRows = bundle?.rollup?.pva_rows ?? [];
+  const achOptions = bundle?.rollup?.pva_options ?? [];
   const optionInfos = [
     ...new Set(
-      ((optInfoRows as { option_info: string | null }[]) ?? [])
-        .map((r) => (r.option_info ?? "").trim())
-        .filter((s) => s.length > 0),
+      (bundle?.option_infos ?? []).map((s) => s.trim()).filter((s) => s.length > 0),
     ),
   ].sort();
-  const diagnosticRows = (diagRows as DiagnosticRow[]) ?? [];
-  const skuMappings = (skuMaps as SkuMapping[]) ?? [];
+  const diagnosticRows = bundle?.rollup?.diagnostic ?? [];
+  const skuMappings = bundle?.mappings ?? [];
+  const sources = bundle?.sources ?? [];
 
   // 목적별 핵심 지표 (S5.4): 유효 가중치 × 측정·달성률·구매건수
-  const [{ data: ewData }, { data: ocData }] = await Promise.all([
-    supabase.rpc("effective_purpose_weights", { p_id: id }),
-    supabase.from("promotion_sales").select("order_count").eq("promotion_id", id),
-  ]);
-  const orderCount = ((ocData as { order_count: number | null }[]) ?? []).reduce(
-    (s, r) => s + (Number(r.order_count) || 0),
-    0,
-  );
+  const ewData = bundle?.weights ?? [];
+  const orderCount = Number(bundle?.order_count) || 0;
   const upliftPct =
     summary && summary.actual_revenue - summary.total_uplift > 0
       ? summary.total_uplift / (summary.actual_revenue - summary.total_uplift)
       : null;
-  const purposeRows: PurposeMetricRow[] = (
-    (ewData as { purpose: string; weight: number }[]) ?? []
-  ).map((w) => {
+  const purposeRows: PurposeMetricRow[] = ewData.map((w) => {
     const kind: PurposeMetricRow["kind"] =
       w.purpose === "재고소진"
         ? "stock"
@@ -256,13 +229,52 @@ export default async function PromotionDetail({
         </div>
       </div>
 
-      {/* 비교 대상 실적 캠페인 (N4.3) — 플랜이 있을 때만 */}
-      {plan && (
-        <ActualsLink
-          promotionId={id}
-          currentLinkId={plan.actual_promotion_id}
-          candidates={candidates}
-        />
+      {/* 연동 센터 (N6 R1.4) — 비교 대상·SKU 매칭·병합을 한 곳에서 */}
+      {(plan || diagnosticRows.length > 0 || skuMappings.length > 0) && (
+        <section className="mt-6 rounded-[24px] bg-white card-soft p-5">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <h2 className="text-sm font-semibold text-neutral-700">
+                플랜 ↔ 실적 연동 센터
+              </h2>
+              {plan && !plan.actual_promotion_id && (
+                <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+                  비교 대상 미지정
+                </span>
+              )}
+              {diagnosticRows.some((r) => r.side !== "both" && !r.is_mapped) && (
+                <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+                  미매칭 SKU{" "}
+                  {diagnosticRows.filter((r) => r.side !== "both" && !r.is_mapped).length}
+                </span>
+              )}
+            </div>
+            <Link
+              href={`/promotions/${id}/edit`}
+              className="text-xs text-neutral-400 hover:text-brand-600 hover:underline"
+            >
+              중복 캠페인이 있나요? 병합 도구 →
+            </Link>
+          </div>
+          <p className="mt-1 text-xs text-neutral-400">
+            플랜이 비교할 실적 캠페인과 SKU 매칭을 여기서 한 번에 끝내세요. 연동이 끝나면
+            아래 달성률이 자동으로 채워집니다.
+          </p>
+          {plan && (
+            <ActualsLink
+              promotionId={id}
+              currentLinkId={plan.actual_promotion_id}
+              candidates={candidates}
+            />
+          )}
+          {(diagnosticRows.length > 0 || skuMappings.length > 0) && (
+            <SkuMatchPanel
+              promotionId={id}
+              rows={diagnosticRows}
+              mappings={skuMappings}
+            />
+          )}
+        </section>
       )}
 
       {/* 달성률 (S3) */}
@@ -273,15 +285,6 @@ export default async function PromotionDetail({
         options={achOptions}
         optionInfos={optionInfos}
       />
-
-      {/* SKU 매칭 진단 (N4) — 플랜·실적 양쪽 SKU 한 표 + 수동 연동 */}
-      {(diagnosticRows.length > 0 || skuMappings.length > 0) && (
-        <SkuMatchPanel
-          promotionId={id}
-          rows={diagnosticRows}
-          mappings={skuMappings}
-        />
-      )}
 
       {/* 목적별 핵심 지표 (S5.4) */}
       <PurposeBlock rows={purposeRows} />
@@ -410,6 +413,30 @@ export default async function PromotionDetail({
               </p>
             )}
           </div>
+
+          {/* 데이터 출처 (N6 R1.3) — 이 캠페인을 만들거나 갱신한 업로드 파일 */}
+          {sources.length > 0 && (
+            <div className="mt-4 rounded-[24px] bg-white card-soft p-4">
+              <div className="text-xs text-neutral-500">데이터 출처 (업로드 파일)</div>
+              <ul className="mt-1.5 space-y-1.5 text-sm">
+                {sources.slice(0, 5).map((s) => (
+                  <li key={s.id} className="flex items-baseline justify-between gap-2">
+                    <span className="min-w-0 truncate text-neutral-700" title={s.source_file}>
+                      {s.source_file}
+                    </span>
+                    <span className="shrink-0 text-[11px] text-neutral-400">
+                      {s.kind === "plan_guide" ? "플랜" : s.kind === "promotion" ? "실적" : s.kind}
+                      {" · "}
+                      {new Date(s.created_at).toLocaleDateString("ko-KR", {
+                        month: "2-digit",
+                        day: "2-digit",
+                      })}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
         </section>
       </div>
 

--- a/promo-analytics/app/(dash)/upload/page.tsx
+++ b/promo-analytics/app/(dash)/upload/page.tsx
@@ -17,6 +17,7 @@ async function logUpload(
     row_count?: number;
     total_revenue?: number | null;
     action?: "insert" | "replace";
+    codes?: string[]; // 영향받은 캠페인 코드 — 캠페인 상세 '데이터 출처' 역추적용 (R1.3)
   },
 ) {
   try {
@@ -28,6 +29,13 @@ async function logUpload(
       window.dispatchEvent(new Event("upload-done"));
   } catch {
     /* 이력 기록 실패는 무시 */
+  }
+  try {
+    // 롤업 프리웜 (R1.1): 업로드 직후 재계산해 다음 페이지 조회를 즉시 로딩으로.
+    // 실패해도 무시 — 트리거 dirty 플래그 + 읽기 시점 ensure가 안전망.
+    await supabase.rpc("refresh_rollups");
+  } catch {
+    /* 프리웜 실패는 무시 */
   }
 }
 
@@ -474,6 +482,7 @@ function UploadCard({ def }: { def: CardDef }) {
           row_count: done,
           total_revenue: newRevenue,
           action: "replace",
+          codes: code ? [code] : undefined,
         });
         setP({ phase: "ok", message: `${name} 실적 백필 완료 · ${done}행. 상세로 이동합니다…` });
         router.push(`/promotions/${existing.id}`);
@@ -533,6 +542,7 @@ function UploadCard({ def }: { def: CardDef }) {
         row_count: done,
         total_revenue: newRevenue,
         action: "insert",
+        codes: code ? [code] : undefined,
       });
       setP({ phase: "ok", message: `${name} 생성 완료 · ${done}행. 상세로 이동합니다…` });
       router.push(`/promotions/${promo.id}/edit`);
@@ -1137,6 +1147,7 @@ function PriceMasterCard() {
 function PlanGuideImportCard() {
   const router = useRouter();
   const [p, setP] = useState<Progress>({ phase: "idle", message: "" });
+  const [fileName, setFileName] = useState<string | null>(null);
   const [camps, setCamps] = useState<
     import("@/lib/parsePlanGuide").PlanGuideCampaign[] | null
   >(null);
@@ -1144,6 +1155,7 @@ function PlanGuideImportCard() {
   async function handleFile(file: File) {
     try {
       setCamps(null);
+      setFileName(file.name); // 원본 파일명 보존 — 이력에 그대로 남긴다 (R1.3)
       setP({ phase: "reading", message: `${file.name} 읽는 중…` });
       const buf = await file.arrayBuffer();
       setP({ phase: "parsing", message: "플랜 가이드 파싱 중…" });
@@ -1323,10 +1335,11 @@ function PlanGuideImportCard() {
 
       await logUpload(supabase, {
         kind: "plan_guide",
-        source_file: "캠페인 플랜 가이드",
-        detail: `생성 ${created} · 교체 ${replaced} · 확정보존 ${skipped}${failed ? ` · 실패 ${failed}` : ""}`,
+        source_file: fileName ?? "캠페인 플랜 가이드",
+        detail: `생성 ${created} · 교체 ${replaced} · 확정보존 ${skipped}${failed ? ` · 실패 ${failed}` : ""} · ${camps.map((c) => c.code).join(", ")}`,
         row_count: allOptions.length,
         action: "replace",
+        codes: camps.map((c) => c.code).filter(Boolean),
       });
       setP({
         phase: "ok",

--- a/promo-analytics/app/layout.tsx
+++ b/promo-analytics/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Toaster } from "sonner";
 import "@fontsource-variable/asta-sans";
 import "./globals.css";
 
@@ -12,7 +13,10 @@ export default function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="ko" className="h-full antialiased">
-      <body className="min-h-full">{children}</body>
+      <body className="min-h-full">
+        {children}
+        <Toaster position="top-center" richColors closeButton />
+      </body>
     </html>
   );
 }

--- a/promo-analytics/package-lock.json
+++ b/promo-analytics/package-lock.json
@@ -15,6 +15,7 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "recharts": "^3.8.1",
+        "sonner": "^2.0.7",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
@@ -6464,6 +6465,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/promo-analytics/package.json
+++ b/promo-analytics/package.json
@@ -16,6 +16,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "recharts": "^3.8.1",
+    "sonner": "^2.0.7",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {

--- a/promo-analytics/supabase/migrations/0022_rollups.sql
+++ b/promo-analytics/supabase/migrations/0022_rollups.sql
@@ -1,0 +1,275 @@
+-- 0022: 롤업 서빙 테이블 — "요청 시점 집계 금지" (N6 R1.1)
+--
+-- 문제: 모든 페이지가 매 요청마다 전 캠페인의 측정(업리프트·헤일로·기여이익)을
+--       SQL로 풀 재계산 (0015 배치 RPC도 계산 자체는 매번 수행). 데이터가 작아도
+--       함수 체인이 깊어 페이지 로드가 수 초.
+-- 해결: 계산 결과를 campaign_rollups / global_rollups 에 저장하고 페이지는
+--       이것만 읽는다. 입력 테이블이 바뀌면 statement 트리거가 dirty 플래그를
+--       세우고, 다음 읽기(또는 업로드 직후 명시적 refresh)가 1회 재계산한다.
+--       계산 로직은 기존 함수(단일 출처)를 그대로 호출 — 수치 동일 보장.
+
+-- ── 서빙 테이블 ─────────────────────────────────────────────────────────
+create table if not exists promo.campaign_rollups (
+  promotion_id uuid primary key references promo.promotions(id) on delete cascade,
+  features     jsonb,                       -- all_campaign_features 행 (summary 포함)
+  achievement  jsonb,                       -- campaign_achievements 행
+  fits         jsonb not null default '[]', -- campaign_fits 행 배열
+  measurement  jsonb not null default '[]', -- promotion_measurement 행 배열 (상세용)
+  pva_summary  jsonb,                       -- plan_vs_actual_summary 행
+  pva_rows     jsonb not null default '[]', -- plan_vs_actual 행 배열
+  pva_options  jsonb not null default '[]', -- plan_vs_actual_options 행 배열
+  diagnostic   jsonb not null default '[]', -- sku_match_diagnostic 행 배열
+  refreshed_at timestamptz not null default now()
+);
+
+create table if not exists promo.global_rollups (
+  key          text primary key,            -- 'overall' | 'purpose_metrics'
+  payload      jsonb,
+  refreshed_at timestamptz not null default now()
+);
+
+-- 단일 행 dirty 플래그
+create table if not exists promo.rollup_state (
+  id           boolean primary key default true check (id),
+  dirty        boolean not null default true,
+  refreshed_at timestamptz
+);
+insert into promo.rollup_state (id, dirty) values (true, true)
+on conflict (id) do nothing;
+
+alter table promo.campaign_rollups enable row level security;
+alter table promo.global_rollups   enable row level security;
+alter table promo.rollup_state     enable row level security;
+do $$
+declare t text;
+begin
+  foreach t in array array['campaign_rollups','global_rollups','rollup_state'] loop
+    execute format('drop policy if exists %I on promo.%I;', t || '_authenticated_all', t);
+    execute format(
+      'create policy %I on promo.%I for all to authenticated using (true) with check (true);',
+      t || '_authenticated_all', t);
+  end loop;
+end $$;
+
+-- ── 업로드 역추적: upload_log 에 영향받은 캠페인 코드 기록 (N6 R1.3) ────
+alter table promo.upload_log add column if not exists codes text[];
+
+-- ── dirty 마킹 트리거 — 측정 입력 테이블 전체 ──────────────────────────
+create or replace function promo.mark_rollups_dirty()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  update promo.rollup_state set dirty = true where not dirty;
+  return null;
+end;
+$$;
+
+do $$
+declare t text;
+begin
+  foreach t in array array[
+    'products','daily_sales','promotions','promotion_main_products',
+    'promotion_sales','promotion_purpose_weights','promotion_sku_mappings',
+    'campaign_plans','campaign_plan_options','campaign_plan_option_items',
+    'product_price_configs'
+  ] loop
+    execute format('drop trigger if exists %I on promo.%I;', t || '_mark_dirty', t);
+    execute format(
+      'create trigger %I after insert or update or delete on promo.%I
+       for each statement execute function promo.mark_rollups_dirty();',
+      t || '_mark_dirty', t);
+  end loop;
+end $$;
+
+-- ── 전체 재계산 ─────────────────────────────────────────────────────────
+create or replace function promo.refresh_rollups(p_force boolean default false)
+returns void
+language plpgsql
+set search_path = ''
+as $$
+declare
+  is_dirty boolean;
+begin
+  -- 동시 호출 직렬화. 락 대기 후 dirty 재확인 — 앞선 호출이 이미 갱신했으면 스킵.
+  perform pg_advisory_xact_lock(hashtext('promo.refresh_rollups'));
+  select dirty into is_dirty from promo.rollup_state where id;
+  if not p_force and not coalesce(is_dirty, true) then
+    return;
+  end if;
+
+  delete from promo.campaign_rollups;
+  with feats as (select * from promo.all_campaign_features()),
+       achs  as (select * from promo.campaign_achievements()),
+       fits  as (
+         select f.promotion_id, jsonb_agg(to_jsonb(f.*)) as j
+         from promo.campaign_fits() f group by f.promotion_id
+       ),
+       meas  as (
+         select pr.id as pid,
+                coalesce(jsonb_agg(to_jsonb(m.*)) filter (where m.product_id is not null),
+                         '[]'::jsonb) as j
+         from promo.promotions pr
+         left join lateral promo.promotion_measurement(pr.id) m on true
+         group by pr.id
+       ),
+       pvas  as (
+         select pr.id as pid,
+           (select to_jsonb(s.*) from promo.plan_vs_actual_summary(pr.id) s limit 1) as s_j,
+           (select coalesce(jsonb_agg(to_jsonb(r.*)), '[]'::jsonb)
+              from promo.plan_vs_actual(pr.id) r) as r_j,
+           (select coalesce(jsonb_agg(to_jsonb(o.*)), '[]'::jsonb)
+              from promo.plan_vs_actual_options(pr.id) o) as o_j,
+           (select coalesce(jsonb_agg(to_jsonb(d.*)), '[]'::jsonb)
+              from promo.sku_match_diagnostic(pr.id) d) as d_j
+         from promo.promotions pr
+       )
+  insert into promo.campaign_rollups
+    (promotion_id, features, achievement, fits, measurement,
+     pva_summary, pva_rows, pva_options, diagnostic, refreshed_at)
+  select pr.id,
+         to_jsonb(f.*),
+         to_jsonb(a.*),
+         coalesce(ft.j, '[]'::jsonb),
+         coalesce(m.j,  '[]'::jsonb),
+         p.s_j,
+         coalesce(p.r_j, '[]'::jsonb),
+         coalesce(p.o_j, '[]'::jsonb),
+         coalesce(p.d_j, '[]'::jsonb),
+         now()
+  from promo.promotions pr
+  left join feats f on f.promotion_id = pr.id
+  left join achs  a on a.promotion_id = pr.id
+  left join fits  ft on ft.promotion_id = pr.id
+  left join meas  m on m.pid = pr.id
+  left join pvas  p on p.pid = pr.id;
+
+  insert into promo.global_rollups (key, payload, refreshed_at)
+  values
+    ('overall',
+     (select to_jsonb(o.*) from promo.overall_baseline_metrics() o limit 1), now()),
+    ('purpose_metrics',
+     (select coalesce(jsonb_agg(to_jsonb(pm.*)), '[]'::jsonb) from promo.purpose_metrics() pm), now())
+  on conflict (key) do update
+    set payload = excluded.payload, refreshed_at = excluded.refreshed_at;
+
+  update promo.rollup_state set dirty = false, refreshed_at = now() where id;
+end;
+$$;
+
+create or replace function promo.ensure_rollups_fresh()
+returns void
+language plpgsql
+set search_path = ''
+as $$
+begin
+  if exists (select 1 from promo.rollup_state where id and dirty) then
+    perform promo.refresh_rollups();
+  end if;
+end;
+$$;
+
+-- ── 페이지 번들 RPC — 페이지당 1회 왕복 ────────────────────────────────
+create or replace function promo.library_bundle()
+returns jsonb
+language plpgsql
+set search_path = ''
+as $$
+declare result jsonb;
+begin
+  perform promo.ensure_rollups_fresh();
+  select jsonb_build_object(
+    'promotions',
+      (select coalesce(jsonb_agg(to_jsonb(p.*) order by p.start_date desc), '[]'::jsonb)
+       from promo.promotions p),
+    'rollups',
+      (select coalesce(jsonb_agg(jsonb_build_object(
+         'promotion_id', r.promotion_id,
+         'features', r.features,
+         'achievement', r.achievement,
+         'fits', r.fits)), '[]'::jsonb)
+       from promo.campaign_rollups r)
+  ) into result;
+  return result;
+end;
+$$;
+
+create or replace function promo.dashboard_bundle()
+returns jsonb
+language plpgsql
+set search_path = ''
+as $$
+declare result jsonb;
+begin
+  perform promo.ensure_rollups_fresh();
+  select jsonb_build_object(
+    'promotions',
+      (select coalesce(jsonb_agg(to_jsonb(p.*) order by p.start_date desc), '[]'::jsonb)
+       from promo.promotions p),
+    'rollups',
+      (select coalesce(jsonb_agg(jsonb_build_object(
+         'promotion_id', r.promotion_id,
+         'features', r.features,
+         'achievement', r.achievement)), '[]'::jsonb)
+       from promo.campaign_rollups r),
+    'overall',
+      (select g.payload from promo.global_rollups g where g.key = 'overall'),
+    'purpose_metrics',
+      coalesce((select g.payload from promo.global_rollups g where g.key = 'purpose_metrics'),
+               '[]'::jsonb)
+  ) into result;
+  return result;
+end;
+$$;
+
+create or replace function promo.promotion_detail_bundle(p_id uuid)
+returns jsonb
+language plpgsql
+set search_path = ''
+as $$
+declare result jsonb;
+begin
+  perform promo.ensure_rollups_fresh();
+  select jsonb_build_object(
+    'promo',  (select to_jsonb(p.*) from promo.promotions p where p.id = p_id),
+    'rollup', (select to_jsonb(r.*) from promo.campaign_rollups r where r.promotion_id = p_id),
+    'notes',
+      (select coalesce(jsonb_agg(to_jsonb(n.*) order by n.created_at desc), '[]'::jsonb)
+       from promo.promotion_notes n where n.promotion_id = p_id),
+    'plan',
+      (select to_jsonb(cp.*) from promo.campaign_plans cp
+       where cp.promotion_id = p_id and cp.is_current limit 1),
+    'candidates',
+      (select coalesce(jsonb_agg(to_jsonb(c.*)), '[]'::jsonb)
+       from promo.campaigns_with_actuals() c),
+    'option_infos',
+      (select coalesce(jsonb_agg(distinct ps.option_info), '[]'::jsonb)
+       from promo.promotion_sales ps
+       where ps.promotion_id = p_id and ps.option_info is not null
+         and length(trim(ps.option_info)) > 0),
+    'order_count',
+      (select coalesce(sum(ps.order_count), 0)
+       from promo.promotion_sales ps where ps.promotion_id = p_id),
+    'mappings',
+      (select coalesce(jsonb_agg(jsonb_build_object(
+         'plan_product_id', m.plan_product_id,
+         'actual_product_id', m.actual_product_id)), '[]'::jsonb)
+       from promo.promotion_sku_mappings m where m.promotion_id = p_id),
+    'weights',
+      (select coalesce(jsonb_agg(to_jsonb(w.*)), '[]'::jsonb)
+       from promo.effective_purpose_weights(p_id) w),
+    'sources',
+      coalesce((select jsonb_agg(to_jsonb(u.*) order by u.created_at desc)
+        from promo.upload_log u, promo.promotions p2
+        where p2.id = p_id and p2.code is not null
+          and u.codes is not null and p2.code = any(u.codes)), '[]'::jsonb)
+  ) into result;
+  return result;
+end;
+$$;
+
+grant execute on all functions in schema promo to authenticated;
+
+notify pgrst, 'reload schema';

--- a/promo-analytics/supabase/migrations/0023_batch_purpose_fits.sql
+++ b/promo-analytics/supabase/migrations/0023_batch_purpose_fits.sql
@@ -1,0 +1,149 @@
+-- 0023: purpose_fit / campaign_fits / purpose_metrics O(N²) 제거 (N6 R1.1)
+--
+-- 문제: purpose_fit(p_id) 가 한 캠페인의 점수 정규화를 위해 '전체 캠페인'의
+--       promotion_summary + plan_vs_actual_summary 를 매번 재계산 (base CTE).
+--       campaign_fits() = N × purpose_fit = N² 차 summary 호출 → 단독 22초.
+--       purpose_metrics() 도 내부에서 purpose_fit × N → 23초.
+--       (히스토리 분석·대시보드가 느렸던 근본 원인)
+-- 해결: base 를 한 번만 계산하는 all_purpose_fits() 배치 함수를 단일 출처로 만들고
+--       purpose_fit(단건)·campaign_fits()·purpose_metrics() 는 여기에 위임.
+--       수식·정규화(동류 min-max) 는 0010/0011/0012 와 동일 — 수치 변화 없음.
+
+create or replace function promo.all_purpose_fits()
+returns table (
+  promotion_id uuid,
+  purpose text,
+  fit_metric_raw numeric,
+  fit_score_0_100 numeric,
+  data_reliable boolean
+)
+language sql
+stable
+set search_path = ''
+as $$
+  with base as (
+    select pr.id as promotion_id,
+      case when (s.actual_revenue - s.total_uplift) > 0
+        then s.total_uplift / (s.actual_revenue - s.total_uplift) else null end as uplift_pct,
+      pvs.ach_qty,
+      pvs.quantity_reliable as qty_reliable,
+      coalesce(oc.order_cnt, 0) as order_cnt
+    from promo.promotions pr
+    left join lateral promo.promotion_summary(pr.id) s on true
+    left join lateral promo.plan_vs_actual_summary(pr.id) pvs on true
+    left join lateral (
+      select coalesce(sum(ps.order_count), 0) as order_cnt
+      from promo.promotion_sales ps where ps.promotion_id = pr.id
+    ) oc on true
+  ),
+  cp as (
+    select pr.id as promotion_id, w.purpose
+    from promo.promotions pr
+    cross join lateral promo.effective_purpose_weights(pr.id) w
+    where w.weight > 0
+  ),
+  metric as (
+    select cp.promotion_id, cp.purpose,
+      case
+        when cp.purpose = '재고소진' then b.ach_qty
+        when cp.purpose = '브랜딩'   then b.order_cnt
+        else b.uplift_pct
+      end as raw,
+      case
+        when cp.purpose = '재고소진' then coalesce(b.qty_reliable, false)
+        when cp.purpose = '브랜딩'   then (b.order_cnt > 0)
+        else true
+      end as reliable
+    from cp join base b on b.promotion_id = cp.promotion_id
+  ),
+  bounds as (
+    select purpose, min(raw) as mn, max(raw) as mx
+    from metric where raw is not null
+    group by purpose
+  )
+  select m.promotion_id, m.purpose, m.raw,
+    case
+      when bd.mx > bd.mn then round((m.raw - bd.mn) / (bd.mx - bd.mn) * 100, 1)
+      when m.raw is not null then 100
+      else null
+    end as fit_score_0_100,
+    m.reliable
+  from metric m
+  left join bounds bd on bd.purpose = m.purpose;
+$$;
+
+-- 단건은 배치에 위임 (단일 출처 역전 — 이제 배치가 원본)
+create or replace function promo.purpose_fit(p_id uuid)
+returns table (
+  purpose text,
+  fit_metric_raw numeric,
+  fit_score_0_100 numeric,
+  data_reliable boolean
+)
+language sql
+stable
+set search_path = ''
+as $$
+  select f.purpose, f.fit_metric_raw, f.fit_score_0_100, f.data_reliable
+  from promo.all_purpose_fits() f
+  where f.promotion_id = p_id
+  order by f.purpose;
+$$;
+
+create or replace function promo.campaign_fits()
+returns table (
+  promotion_id uuid,
+  purpose text,
+  fit_score_0_100 numeric,
+  data_reliable boolean
+)
+language sql
+stable
+set search_path = ''
+as $$
+  select f.promotion_id, f.purpose, f.fit_score_0_100, f.data_reliable
+  from promo.all_purpose_fits() f;
+$$;
+
+-- purpose_metrics: summary 도 배치(all_promotion_summaries)로, fit 도 배치로 — 1패스
+create or replace function promo.purpose_metrics()
+returns table (
+  purpose text,
+  weighted_uplift numeric,
+  weighted_contribution numeric,
+  campaign_count int,
+  avg_fit_score numeric,
+  data_reliable boolean
+)
+language sql
+stable
+set search_path = ''
+as $$
+  with cw as (
+    select w.purpose, w.promotion_id, w.weight,
+           coalesce(s.total_uplift, 0)  as uplift,
+           coalesce(s.contribution, 0)  as contribution
+    from promo.all_effective_purpose_weights() w
+    left join promo.all_promotion_summaries() s on s.promotion_id = w.promotion_id
+    where w.weight > 0
+  ),
+  fit as (
+    select f.promotion_id, f.purpose, f.fit_score_0_100, f.data_reliable
+    from promo.all_purpose_fits() f
+  )
+  select
+    cw.purpose,
+    sum(cw.uplift * cw.weight)        as weighted_uplift,
+    sum(cw.contribution * cw.weight)  as weighted_contribution,
+    count(distinct cw.promotion_id)::int as campaign_count,
+    avg(fit.fit_score_0_100)          as avg_fit_score,
+    bool_and(coalesce(fit.data_reliable, true)) as data_reliable
+  from cw
+  left join fit on fit.promotion_id = cw.promotion_id and fit.purpose = cw.purpose
+  group by cw.purpose
+  order by sum(cw.uplift * cw.weight) desc nulls last;
+$$;
+
+grant execute on all functions in schema promo to authenticated;
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
N6 마스터플랜 R1 페이즈 — "체감 수술". 느림·연동 뎁스·파일명·에러 피드백을 근본 원인 수준에서 수정.

## R1.1 성능 — 측정 결과

| 항목 | 이전 | 이후 |
|---|---|---|
| campaign_fits() (히스토리 느림의 주범, O(N²)) | 21.9s | **1.2s** |
| purpose_metrics() | 22.9s | **2.3s** |
| 페이지 데이터 읽기 (번들 RPC) | 매 요청 풀 재계산 | **5.6ms** |
| 라이브러리 RPC 왕복 | 4 | **1** |
| 대시보드 RPC 왕복 | 5 | **1** |
| 캠페인 상세 쿼리 | 13 (4블록 순차) | **1** |

- **0022**: `campaign_rollups`/`global_rollups` 서빙 테이블. 11개 입력 테이블의 statement 트리거가 dirty 마킹 → 읽기 시점 ensure 또는 업로드 직후 프리웜으로 1회 재계산(6.5s). 계산은 기존 함수 호출 그대로 — 수치 동일 (24캠페인 비교 0건 불일치).
- **0023**: `purpose_fit(p_id)`가 한 캠페인 점수를 위해 전체 캠페인 summary를 재계산하던 O(N²)를 `all_purpose_fits()` 단일 패스로 교체. 신구 결과 20행 완전 동일.

## R1.3 파일명 투명화
- ⑤ 플랜 가이드 업로드가 `source_file: "캠페인 플랜 가이드"` 하드코딩 → **실제 파일명** 기록 (워싱의 실체).
- `upload_log.codes[]` 신설 — 캠페인 상세에 "데이터 출처" 카드 (이 캠페인을 만든 업로드 파일 역추적).

## R1.4 연동 센터
- 비교 대상 지정 + SKU 매칭 + 병합 진입을 캠페인 상세의 단일 "플랜 ↔ 실적 연동 센터" 섹션으로 통합. 비교 대상 미지정/미매칭 SKU 경고 배지.

## R1.5 피드백
- sonner 토스트 도입, EditForm `alert()` → 토스트 + "다시 시도" 액션.

## 비고
- 마이그레이션 2건은 운영 DB에 적용·검증 완료.
- 변이 직후 첫 조회는 재계산(~6.5s)을 1회 흡수 — R2에서 캠페인 단위 증분 refresh로 축소 예정.
- R1.2의 TanStack Query 도입은 R2 컴포넌트 재구축과 함께 진행 (현재는 번들 RPC로 충분히 빠름).

https://claude.ai/code/session_01JDEWhEszHRLfEdSo18ej1w

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDEWhEszHRLfEdSo18ej1w)_