### PR TITLE
N6 R2.1: 비주얼 전환 — 모던 플랫 디자인 + KPI 타일 + ⌘K 팔레트

### DIFF
--- a/promo-analytics/app/(dash)/AppShell.tsx
+++ b/promo-analytics/app/(dash)/AppShell.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import CommandPalette from "./CommandPalette";
 
 const NAV = [
   { href: "/", label: "대시보드", icon: "M3.5 12l8.5-8 8.5 8M5.5 10.5V19a1 1 0 001 1h3.5v-5h3v5H18a1 1 0 001-1v-8.5" },
@@ -31,8 +32,8 @@ function NavLinks({ onNavigate }: { onNavigate?: () => void }) {
             onClick={onNavigate}
             className={`flex items-center gap-3 rounded-2xl px-3.5 py-2.5 text-sm font-medium transition ${
               active
-                ? "surface-pressed text-ink"
-                : "text-ink-3 hover:text-ink"
+                ? "bg-brand-50 font-semibold text-brand-700"
+                : "text-ink-3 hover:bg-soft hover:text-ink"
             }`}
           >
             <svg
@@ -55,7 +56,7 @@ function NavLinks({ onNavigate }: { onNavigate?: () => void }) {
 function Brand() {
   return (
     <Link href="/" className="flex items-center gap-2.5">
-      <span className="flex h-9 w-9 items-center justify-center rounded-2xl bg-canvas text-sm font-bold text-brand-600 card-soft">
+      <span className="flex h-9 w-9 items-center justify-center rounded-2xl text-sm font-bold text-brand-600 card-soft">
         P
       </span>
       <span className="leading-tight">
@@ -92,10 +93,25 @@ export default function AppShell({
 
   return (
     <div className="min-h-screen md:flex">
+      <CommandPalette />
       {/* 데스크톱 사이드바 */}
       <aside className="sticky top-0 hidden h-screen w-64 shrink-0 flex-col py-4 md:flex">
         <div className="px-5 py-4">
           <Brand />
+        </div>
+        <div className="px-3 pb-2">
+          <button
+            onClick={() => window.dispatchEvent(new Event("open-cmdk"))}
+            className="flex w-full items-center justify-between rounded-xl border border-line bg-card px-3 py-2 text-xs text-ink-4 transition hover:text-ink-2"
+          >
+            <span className="flex items-center gap-1.5">
+              <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                <path strokeLinecap="round" d="M21 21l-4.3-4.3M17 10.5a6.5 6.5 0 11-13 0 6.5 6.5 0 0113 0z" />
+              </svg>
+              검색
+            </span>
+            <kbd className="rounded border border-line bg-soft px-1.5 py-0.5 text-[10px] font-medium">⌘K</kbd>
+          </button>
         </div>
         <NavLinks />
         <div className="mt-auto">
@@ -109,7 +125,7 @@ export default function AppShell({
         <button
           onClick={() => setOpen(true)}
           aria-label="메뉴 열기"
-          className="flex h-10 w-10 items-center justify-center rounded-2xl bg-canvas text-ink-2 card-soft"
+          className="flex h-10 w-10 items-center justify-center rounded-2xl text-ink-2 card-soft"
         >
           <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.8} stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
@@ -121,7 +137,7 @@ export default function AppShell({
       {open && (
         <div className="fixed inset-0 z-50 md:hidden">
           <div className="absolute inset-0 bg-ink/40 backdrop-blur-sm" onClick={() => setOpen(false)} />
-          <div className="absolute right-0 top-0 flex h-full w-72 flex-col bg-canvas py-4 card-soft-h">
+          <div className="absolute right-0 top-0 flex h-full w-72 flex-col py-4 card-soft-h">
             <div className="flex items-center justify-between px-5 py-4">
               <Brand />
               <button
@@ -143,7 +159,7 @@ export default function AppShell({
       )}
 
       <main className="min-w-0 flex-1 md:py-4 md:pr-4">
-        <div className="min-h-full md:rounded-[32px] md:bg-canvas md:card-soft">{children}</div>
+        <div className="min-h-full">{children}</div>
       </main>
     </div>
   );

--- a/promo-analytics/app/(dash)/CommandPalette.tsx
+++ b/promo-analytics/app/(dash)/CommandPalette.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Command } from "cmdk";
+import { createClient } from "@/lib/supabase/client";
+
+// N6 R2.1: ⌘K / Ctrl+K 커맨드 팔레트 — 페이지 점프 + 캠페인 검색.
+// 캠페인 목록은 팔레트를 처음 열 때 1회 로드(이름·코드·기간만, 가벼움).
+
+const PAGES = [
+  { label: "대시보드", href: "/" },
+  { label: "성과 시뮬레이터", href: "/predict" },
+  { label: "캠페인 추천", href: "/prescribe" },
+  { label: "히스토리 비교/분석", href: "/library" },
+  { label: "데이터 업로드", href: "/upload" },
+  { label: "설정", href: "/settings" },
+];
+
+type Camp = { id: string; name: string; code: string | null; start_date: string };
+
+export default function CommandPalette() {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [camps, setCamps] = useState<Camp[] | null>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setOpen((v) => !v);
+      }
+    };
+    const onOpen = () => setOpen(true);
+    window.addEventListener("keydown", onKey);
+    window.addEventListener("open-cmdk", onOpen);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("open-cmdk", onOpen);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!open || camps !== null) return;
+    const supabase = createClient();
+    supabase
+      .from("promotions")
+      .select("id, name, code, start_date")
+      .order("start_date", { ascending: false })
+      .then(({ data }) => setCamps((data as Camp[]) ?? []));
+  }, [open, camps]);
+
+  const go = useCallback(
+    (href: string) => {
+      setOpen(false);
+      router.push(href);
+    },
+    [router],
+  );
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[60]" role="dialog" aria-label="명령 팔레트">
+      <div
+        className="absolute inset-0 bg-ink/30 backdrop-blur-[2px]"
+        onClick={() => setOpen(false)}
+      />
+      <div className="absolute left-1/2 top-24 w-[min(560px,calc(100vw-2rem))] -translate-x-1/2">
+        <Command
+          label="검색"
+          className="overflow-hidden rounded-2xl card-soft-h"
+          loop
+        >
+          <Command.Input
+            autoFocus
+            placeholder="캠페인·페이지 검색…  (esc 닫기)"
+            className="w-full border-b border-line bg-transparent px-4 py-3.5 text-[15px] outline-none placeholder:text-ink-4"
+            onKeyDown={(e) => {
+              if (e.key === "Escape") setOpen(false);
+            }}
+          />
+          <Command.List className="max-h-[50vh] overflow-y-auto p-2">
+            <Command.Empty className="px-3 py-6 text-center text-sm text-ink-4">
+              결과가 없습니다.
+            </Command.Empty>
+            <Command.Group
+              heading="페이지"
+              className="[&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-[11px] [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wider [&_[cmdk-group-heading]]:text-ink-4"
+            >
+              {PAGES.map((p) => (
+                <Command.Item
+                  key={p.href}
+                  value={`페이지 ${p.label}`}
+                  onSelect={() => go(p.href)}
+                  className="cursor-pointer rounded-xl px-3 py-2.5 text-sm text-ink-2 data-[selected=true]:bg-brand-50 data-[selected=true]:text-brand-700"
+                >
+                  {p.label}
+                </Command.Item>
+              ))}
+            </Command.Group>
+            <Command.Group
+              heading="캠페인"
+              className="[&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-[11px] [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wider [&_[cmdk-group-heading]]:text-ink-4"
+            >
+              {camps === null && (
+                <div className="px-3 py-2 text-sm text-ink-4">불러오는 중…</div>
+              )}
+              {(camps ?? []).map((c) => (
+                <Command.Item
+                  key={c.id}
+                  value={`${c.name} ${c.code ?? ""}`}
+                  onSelect={() => go(`/promotions/${c.id}`)}
+                  className="cursor-pointer rounded-xl px-3 py-2.5 text-sm text-ink-2 data-[selected=true]:bg-brand-50 data-[selected=true]:text-brand-700"
+                >
+                  <span className="truncate">{c.name}</span>
+                  <span className="ml-2 shrink-0 text-[11px] text-ink-4">
+                    {c.start_date.slice(0, 7)}
+                  </span>
+                </Command.Item>
+              ))}
+            </Command.Group>
+          </Command.List>
+        </Command>
+      </div>
+    </div>
+  );
+}

--- a/promo-analytics/app/(dash)/DashCharts.tsx
+++ b/promo-analytics/app/(dash)/DashCharts.tsx
@@ -305,3 +305,36 @@ export function Donut({
     </div>
   );
 }
+
+// KPI 타일용 미니 스파크라인 (N6 R2.1) — 축·툴팁 없는 추세 실루엣
+export function Spark({
+  data,
+  color = BRAND,
+}: {
+  data: { v: number }[];
+  color?: string;
+}) {
+  if (data.length < 2) return null;
+  return (
+    <div className="pointer-events-none h-9 w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <AreaChart data={data} margin={{ top: 2, right: 0, bottom: 0, left: 0 }}>
+          <defs>
+            <linearGradient id={`spark-${color.replace("#", "")}`} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={color} stopOpacity={0.25} />
+              <stop offset="100%" stopColor={color} stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <Area
+            type="monotone"
+            dataKey="v"
+            stroke={color}
+            strokeWidth={1.6}
+            fill={`url(#spark-${color.replace("#", "")})`}
+            isAnimationActive={false}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/promo-analytics/app/(dash)/library/LibraryTable.tsx
+++ b/promo-analytics/app/(dash)/library/LibraryTable.tsx
@@ -169,7 +169,7 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
       {/* 모바일: 카드 리스트 */}
       <ul className="space-y-2 md:hidden">
         {rows.map((r) => (
-          <li key={r.id} className="rounded-[20px] bg-white p-4 card-soft">
+          <li key={r.id} className="rounded-xl p-4 card-soft">
             <div className="flex items-start gap-3">
               <span
                 className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-bold ${
@@ -234,14 +234,14 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
           </li>
         ))}
         {rows.length === 0 && (
-          <li className="rounded-[20px] bg-white px-4 py-10 text-center text-sm text-neutral-400 card-soft">
+          <li className="rounded-xl px-4 py-10 text-center text-sm text-neutral-400 card-soft">
             조건에 맞는 캠페인이 없습니다.
           </li>
         )}
       </ul>
 
       {/* 데스크톱: 테이블 */}
-      <div className="hidden overflow-x-auto rounded-[24px] bg-white card-soft md:block">
+      <div className="hidden overflow-x-auto rounded-2xl card-soft md:block">
         <table className="w-full min-w-[1000px] text-sm">
           <thead className="bg-neutral-50 text-left text-xs text-neutral-500">
             <tr>

--- a/promo-analytics/app/(dash)/library/loading.tsx
+++ b/promo-analytics/app/(dash)/library/loading.tsx
@@ -4,7 +4,7 @@ export default function LibraryLoading() {
       <div className="h-5 w-44 animate-pulse rounded-full bg-soft" />
       <div className="mt-2 h-3 w-72 animate-pulse rounded-full bg-soft" />
 
-      <div className="mt-6 rounded-[28px] bg-canvas p-4 card-soft">
+      <div className="mt-6 rounded-2xl p-4 card-soft">
         <div className="space-y-2">
           {Array.from({ length: 8 }).map((_, i) => (
             <div key={i} className="grid grid-cols-12 items-center gap-3">

--- a/promo-analytics/app/(dash)/loading.tsx
+++ b/promo-analytics/app/(dash)/loading.tsx
@@ -6,14 +6,14 @@ export default function DashLoading() {
   return (
     <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
       <div className="mb-6 flex items-center gap-3">
-        <div className="h-12 w-12 animate-pulse rounded-2xl bg-canvas card-soft" />
+        <div className="h-12 w-12 animate-pulse rounded-2xl card-soft" />
         <div className="space-y-2">
           <div className="h-3.5 w-24 animate-pulse rounded-full bg-soft" />
           <div className="h-2.5 w-32 animate-pulse rounded-full bg-soft" />
         </div>
       </div>
 
-      <div className="mb-5 rounded-[28px] bg-canvas p-6 card-soft">
+      <div className="mb-5 rounded-2xl p-6 card-soft">
         <div className="h-3 w-20 animate-pulse rounded-full bg-soft" />
         <div className="mt-3 h-4 w-3/4 animate-pulse rounded-full bg-soft" />
         <div className="mt-2 h-4 w-1/2 animate-pulse rounded-full bg-soft" />
@@ -21,7 +21,7 @@ export default function DashLoading() {
 
       <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4">
         {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="rounded-[24px] bg-canvas p-5 card-soft">
+          <div key={i} className="rounded-2xl p-5 card-soft">
             <div className="h-2.5 w-16 animate-pulse rounded-full bg-soft" />
             <div className="mt-3 h-6 w-24 animate-pulse rounded-full bg-soft" />
             <div className="mt-2 h-2 w-20 animate-pulse rounded-full bg-soft" />
@@ -33,7 +33,7 @@ export default function DashLoading() {
         {Array.from({ length: 3 }).map((_, i) => (
           <div
             key={i}
-            className={`rounded-[28px] bg-canvas p-5 card-soft ${
+            className={`rounded-2xl p-5 card-soft ${
               i === 1 ? "lg:col-span-2" : ""
             }`}
           >

--- a/promo-analytics/app/(dash)/page.tsx
+++ b/promo-analytics/app/(dash)/page.tsx
@@ -15,6 +15,7 @@ import {
   AchievementTrend,
   PurposeShareBars,
   PurposeFitBars,
+  Spark,
 } from "./DashCharts";
 
 export const dynamic = "force-dynamic";
@@ -145,7 +146,6 @@ export default async function Dashboard() {
   const totalHalo = sum(rows.map((r) => r.summary?.halo_uplift ?? 0));
   const avgDirect = n ? totalDirect / n : 0;
   const avgHalo = n ? totalHalo / n : 0;
-  const avgDuration = n ? sum(rows.map((r) => r.promo_days)) / n : 0;
   const haloShare = totalUplift !== 0 ? totalHalo / totalUplift : null;
 
   // 상시 일평균 vs 행사 일평균 — 데이터 기간 전체에서 일자 단위로 산출 (product 중복 합산 X)
@@ -197,7 +197,7 @@ export default async function Dashboard() {
       {/* 상단 바 */}
       <header className="mb-6 flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-3">
-          <div className="flex h-12 w-12 flex-col items-center justify-center rounded-2xl bg-canvas card-soft">
+          <div className="flex h-12 w-12 flex-col items-center justify-center rounded-2xl card-soft">
             <span className="text-base font-bold leading-none">{now.getDate()}</span>
           </div>
           <div>
@@ -215,7 +215,7 @@ export default async function Dashboard() {
 
       {/* AI 인사이트 */}
       {best?.summary && (
-        <section className="mb-5 rounded-[28px] bg-canvas p-6 card-soft">
+        <section className="mb-5 rounded-2xl p-6 card-soft">
           <div className="flex items-center gap-2 text-[11px] font-bold uppercase tracking-[1.6px] text-brand-600">
             <span className="flex h-1.5 w-1.5 animate-pulse rounded-full bg-brand-500" />
             AI MD 인사이트
@@ -234,17 +234,38 @@ export default async function Dashboard() {
         </section>
       )}
 
-      {/* KPI Bento */}
+      {/* KPI 타일 (N6 R2.1): 수치 + 전기간 대비 델타 + 스파크라인 + 클릭 드릴 */}
       <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4">
         <Kpi
           label="캠페인 기여 총 매출"
           value={wonShort(totalUplift)}
           full={won(totalUplift)}
+          delta={trend}
+          deltaLabel="전월 대비"
+          spark={monthly.map((m) => ({ v: m.uplift }))}
+          href="/library"
           brand
         />
-        <Kpi label="평균 직접 매출" value={wonShort(avgDirect)} sub={`캠페인 ${n}건 평균`} />
-        <Kpi label="평균 간접 매출" value={wonShort(avgHalo)} sub={`캠페인 ${n}건 평균`} />
-        <Kpi label="평균 운영 기간" value={`${avgDuration.toFixed(1)}일`} sub={`캠페인 ${n}건 평균`} />
+        <Kpi
+          label="매출 달성률 (플랜 가중)"
+          value={wAchRevenue != null ? pct(wAchRevenue, 0) : "—"}
+          delta={wAchRevenue != null ? wAchRevenue - 1 : null}
+          deltaLabel="플랜 대비"
+          spark={achTrend.map((a) => ({ v: a.revenue ?? 0 }))}
+          href="/library"
+        />
+        <Kpi
+          label="평소 대비 행사 매출"
+          value={liftRatio != null ? `${liftRatio.toFixed(1)}배` : "—"}
+          sub="상시 일평균 대비"
+          href="/predict"
+        />
+        <Kpi
+          label="간접 매출 비중"
+          value={haloShare != null ? pct(haloShare, 0) : "—"}
+          sub={`평균 직접 ${wonShort(avgDirect)} · 간접 ${wonShort(avgHalo)}`}
+          href="/library"
+        />
       </div>
 
       {/* 달성률 (계획 대비 실적) — S4 */}
@@ -307,7 +328,7 @@ export default async function Dashboard() {
           </p>
           <BaselineVsPromo data={compData} />
         </Card>
-        <div className="flex flex-col justify-center rounded-[28px] bg-canvas p-5 card-soft">
+        <div className="flex flex-col justify-center rounded-2xl p-5 card-soft">
           <div className="text-[11px] font-bold uppercase tracking-[1.6px] text-ink-3">
             평소 대비 행사 매출 (전 매장)
           </div>
@@ -350,7 +371,7 @@ export default async function Dashboard() {
           <MonthlyArea data={monthly} />
         </Card>
 
-        <div className="rounded-[28px] bg-canvas p-5 card-soft">
+        <div className="rounded-2xl p-5 card-soft">
           <h2 className="mb-3 text-sm font-semibold text-ink-2">전체 간접 매출 비중</h2>
           <Donut pct={haloShare} label="기타 제품 동반구매 기여" />
         </div>
@@ -454,31 +475,69 @@ function Kpi({
   sub,
   full,
   brand,
+  delta,
+  deltaLabel,
+  spark,
+  href,
 }: {
   label: string;
   value: string;
   sub?: string;
   full?: string; // 데스크톱에서 풀 표기 (예: ₩3,409,316,915)
   brand?: boolean;
+  delta?: number | null; // 비율 (예: 0.12 = +12%)
+  deltaLabel?: string;
+  spark?: { v: number }[];
+  href?: string;
 }) {
-  return (
+  const body = (
     <div
-      className={`rounded-[24px] p-4 sm:p-5 ${
-        brand ? "bg-brand-500 text-white" : "bg-canvas card-soft"
+      className={`flex h-full flex-col rounded-2xl p-4 transition sm:p-5 ${
+        brand
+          ? "bg-brand-500 text-white"
+          : "card-soft hover:card-soft-h"
       }`}
     >
-      <div className={`text-[11px] font-bold uppercase tracking-[1.4px] ${brand ? "text-brand-100" : "text-ink-3"}`}>{label}</div>
+      <div className="flex items-start justify-between gap-2">
+        <div className={`text-[11px] font-bold uppercase tracking-[1.4px] ${brand ? "text-brand-100" : "text-ink-3"}`}>{label}</div>
+        {delta != null && Number.isFinite(delta) && (
+          <span
+            className={`shrink-0 rounded-full px-2 py-0.5 text-[11px] font-semibold ${
+              brand
+                ? "bg-white/15 text-white"
+                : delta >= 0
+                  ? "bg-emerald-50 text-emerald-700"
+                  : "bg-red-50 text-red-600"
+            }`}
+            title={deltaLabel}
+          >
+            {delta >= 0 ? "▲" : "▼"} {pct(Math.abs(delta), 0)}
+          </span>
+        )}
+      </div>
       <div className="mt-2 break-words text-lg font-bold tracking-tight tabular-nums sm:text-2xl">
         <span className={full ? "sm:hidden" : ""}>{value}</span>
         {full && <span className="hidden sm:inline">{full}</span>}
       </div>
       {sub && <div className={`mt-0.5 text-[11px] ${brand ? "text-brand-100" : "text-ink-4"}`}>{sub}</div>}
+      {spark && spark.length > 1 && (
+        <div className="mt-auto pt-2">
+          <Spark data={spark} color={brand ? "#ffffff" : "#c66a48"} />
+        </div>
+      )}
     </div>
+  );
+  return href ? (
+    <Link href={href} className="block h-full">
+      {body}
+    </Link>
+  ) : (
+    body
   );
 }
 
 function Card({ children, className = "" }: { children: React.ReactNode; className?: string }) {
-  return <div className={`rounded-[28px] bg-canvas p-5 card-soft ${className}`}>{children}</div>;
+  return <div className={`rounded-2xl p-5 card-soft ${className}`}>{children}</div>;
 }
 
 function CardTitle({ children, className = "" }: { children: React.ReactNode; className?: string }) {
@@ -488,7 +547,7 @@ function CardTitle({ children, className = "" }: { children: React.ReactNode; cl
 function EmptyState() {
   return (
     <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
-      <div className="mx-auto mt-6 max-w-lg rounded-[28px] bg-canvas p-8 text-center card-soft">
+      <div className="mx-auto mt-6 max-w-lg rounded-2xl p-8 text-center card-soft">
         <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-2xl bg-brand-500 text-xl text-white">
           ✦
         </div>

--- a/promo-analytics/app/(dash)/predict/Simulator.tsx
+++ b/promo-analytics/app/(dash)/predict/Simulator.tsx
@@ -109,7 +109,7 @@ export default function Simulator({ cases, options }: { cases: CaseFeature[]; op
 
       <div className="grid gap-3 sm:gap-4 lg:grid-cols-5">
         {/* 컨트롤 */}
-        <section className="rounded-[24px] bg-white p-6 card-soft lg:col-span-2">
+        <section className="rounded-2xl p-6 card-soft lg:col-span-2">
           <Field label="혜택 종류">
             <Chips options={options.benefitTypes} value={promoType} onChange={setPromoType} />
           </Field>
@@ -158,7 +158,7 @@ export default function Simulator({ cases, options }: { cases: CaseFeature[]; op
         </section>
 
         {/* 결과 */}
-        <section className="rounded-[24px] bg-white p-6 card-soft lg:col-span-3">
+        <section className="rounded-2xl p-6 card-soft lg:col-span-3">
           <div className="flex items-start justify-between">
             <div>
               <div className="text-xs text-neutral-400">평소 대비 예상 매출</div>
@@ -190,7 +190,7 @@ export default function Simulator({ cases, options }: { cases: CaseFeature[]; op
       </div>
 
       {/* 할인율 곡선 — 스윗스팟 */}
-      <section className="mt-3 rounded-[24px] bg-white p-6 card-soft sm:mt-4">
+      <section className="mt-3 rounded-2xl p-6 card-soft sm:mt-4">
         <div className="flex items-center gap-2">
           <span className="text-xl">🎯</span>
           <h2 className="text-2xl font-bold tracking-tight">스윗스팟 찾기</h2>
@@ -243,7 +243,7 @@ export default function Simulator({ cases, options }: { cases: CaseFeature[]; op
 
       {/* 시나리오 비교 */}
       {pinned.length > 0 && (
-        <section className="mt-3 rounded-[24px] bg-white p-6 card-soft sm:mt-4">
+        <section className="mt-3 rounded-2xl p-6 card-soft sm:mt-4">
           <div className="mb-3 flex items-center justify-between">
             <h2 className="text-sm font-semibold text-neutral-700">시나리오 비교</h2>
             <button onClick={() => setPinned([])} className="text-xs text-neutral-400 hover:text-brand-600">
@@ -269,7 +269,7 @@ export default function Simulator({ cases, options }: { cases: CaseFeature[]; op
 
       {/* 근거 사례 */}
       {pred.comparables.length > 0 && (
-        <section className="mt-3 rounded-[24px] bg-white p-6 card-soft sm:mt-4">
+        <section className="mt-3 rounded-2xl p-6 card-soft sm:mt-4">
           <h2 className="mb-3 text-sm font-semibold text-neutral-700">근거가 된 유사 사례</h2>
           <ul className="space-y-1.5">
             {pred.comparables.map((c) => (

--- a/promo-analytics/app/(dash)/prescribe/Recommend.tsx
+++ b/promo-analytics/app/(dash)/prescribe/Recommend.tsx
@@ -123,7 +123,7 @@ export default function Recommend({ options }: { options: Options }) {
       </div>
 
       {/* 입력 — 선택된 목표마다 목표값 */}
-      <div className="mt-4 rounded-[24px] bg-white p-5 card-soft">
+      <div className="mt-4 rounded-2xl p-5 card-soft">
         <div className="grid gap-4 sm:grid-cols-2">
           {selected.map((g) => {
             const def = GOALS.find((x) => x.key === g)!;
@@ -167,13 +167,13 @@ export default function Recommend({ options }: { options: Options }) {
       {recs && (
         <div className="mt-6">
           {recs.length === 0 ? (
-            <p className="rounded-[24px] border border-dashed border-neutral-300 bg-white px-6 py-10 text-center text-sm text-neutral-400">
+            <p className="rounded-2xl border border-dashed border-neutral-300 bg-white px-6 py-10 text-center text-sm text-neutral-400">
               추천할 사례가 부족합니다. 캠페인 데이터를 더 쌓아주세요.
             </p>
           ) : (
             <div className="space-y-3">
               {recs.map((r, i) => (
-                <div key={i} className={`rounded-[24px] bg-white p-5 card-soft ${i === 0 ? "ring-2 ring-brand-500" : ""}`}>
+                <div key={i} className={`rounded-2xl p-5 card-soft ${i === 0 ? "ring-2 ring-brand-500" : ""}`}>
                   <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0 flex-1">
                       <div className="flex flex-wrap items-center gap-2">

--- a/promo-analytics/app/(dash)/promotions/[id]/Achievement.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/Achievement.tsx
@@ -27,7 +27,7 @@ export default function Achievement({
     return (
       <section className="mt-6">
         <h2 className="mb-2 text-sm font-semibold text-neutral-700">달성률 (계획 대비 실적)</h2>
-        <div className="rounded-[24px] bg-white card-soft p-6 text-sm text-neutral-500">
+        <div className="rounded-2xl card-soft p-6 text-sm text-neutral-500">
           확정된 가격 가이드(플랜)가 없습니다.{" "}
           <Link href={`/promotions/${promotionId}/plan`} className="text-brand-600 hover:underline">
             플랜을 확정
@@ -71,7 +71,7 @@ export default function Achievement({
       </div>
 
       {/* SKU 단위 가이드 vs 실적 */}
-      <div className="mt-4 overflow-x-auto rounded-[24px] bg-white card-soft">
+      <div className="mt-4 overflow-x-auto rounded-2xl card-soft">
         <table className="w-full min-w-[720px] text-sm">
           <thead className="bg-neutral-50 text-left text-xs text-neutral-500">
             <tr>
@@ -142,7 +142,7 @@ export default function Achievement({
 
       {/* 계획 외 판매 */}
       {unplanned.length > 0 && (
-        <details className="mt-4 rounded-[20px] bg-amber-50/60 p-4">
+        <details className="mt-4 rounded-xl bg-amber-50/60 p-4">
           <summary className="cursor-pointer text-sm font-medium text-amber-800">
             계획 외 판매 — {unplanned.length}개 SKU · 매출 {wonShort(summary.unplanned_revenue)} · 공헌{" "}
             {wonShort(summary.unplanned_contribution)}
@@ -195,7 +195,7 @@ function AchCard({
 }) {
   const fmt = isQty ? num : wonShort;
   return (
-    <div className={`rounded-[20px] p-4 ${primary ? "bg-brand-50" : "bg-white card-soft"}`}>
+    <div className={`rounded-xl p-4 ${primary ? "bg-brand-50" : "card-soft"}`}>
       <div className="flex items-center gap-1.5">
         <span className="text-xs text-neutral-500">{label}</span>
         {lowData && (
@@ -258,7 +258,7 @@ function OptionRow({
   }
 
   return (
-    <div className="rounded-[16px] bg-white card-soft p-3">
+    <div className="rounded-[16px] card-soft p-3">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium">{opt.option_label}</span>

--- a/promo-analytics/app/(dash)/promotions/[id]/ActualsLink.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/ActualsLink.tsx
@@ -51,7 +51,7 @@ export default function ActualsLink({
   }
 
   return (
-    <section className="mt-6 rounded-[24px] bg-canvas p-5 card-soft">
+    <section className="mt-6 rounded-2xl p-5 card-soft">
       <h2 className="text-sm font-semibold text-ink-2">비교 대상 실적 캠페인</h2>
       <p className="mt-1 text-xs text-ink-4">
         이 캠페인의 플랜을 어느 캠페인의 실적과 비교할지 선택합니다. 기본값은 자기 자신.
@@ -62,7 +62,7 @@ export default function ActualsLink({
         <select
           value={pick}
           onChange={(e) => setPick(e.target.value)}
-          className="rounded-xl bg-canvas px-3 py-2 text-sm surface-pressed-soft focus:outline-none"
+          className="rounded-xl px-3 py-2 text-sm surface-pressed-soft focus:outline-none"
         >
           <option value="">자기 캠페인 실적 (기본)</option>
           {candidates
@@ -88,7 +88,7 @@ export default function ActualsLink({
               save(null);
             }}
             disabled={busy}
-            className="rounded-full bg-canvas px-4 py-2 text-sm font-semibold text-ink-3 card-soft hover:text-ink"
+            className="rounded-full px-4 py-2 text-sm font-semibold text-ink-3 card-soft hover:text-ink"
           >
             기본으로
           </button>

--- a/promo-analytics/app/(dash)/promotions/[id]/PurposeBlock.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/PurposeBlock.tsx
@@ -20,7 +20,7 @@ export default function PurposeBlock({ rows }: { rows: PurposeMetricRow[] }) {
       <h2 className="mb-2 text-sm font-semibold text-neutral-700">목적별 핵심 지표</h2>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {rows.map((r) => (
-          <div key={r.purpose} className="rounded-[20px] bg-white p-4 card-soft">
+          <div key={r.purpose} className="rounded-xl p-4 card-soft">
             <div className="flex items-center justify-between gap-2">
               <span className="min-w-0 truncate text-sm font-semibold text-neutral-800">
                 {r.purpose}

--- a/promo-analytics/app/(dash)/promotions/[id]/SkuMatchPanel.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/SkuMatchPanel.tsx
@@ -109,13 +109,13 @@ export default function SkuMatchPanel({
 
       {/* 수동 매핑 추가 */}
       {(planOnly.length > 0 || actualOnly.length > 0) && (
-        <div className="mt-4 rounded-[20px] bg-canvas p-4 card-soft">
+        <div className="mt-4 rounded-xl p-4 card-soft">
           <h3 className="mb-2 text-xs font-semibold text-ink-2">수동 매핑 추가</h3>
           <div className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_auto_1fr_auto]">
             <select
               value={planPick}
               onChange={(e) => setPlanPick(e.target.value)}
-              className="rounded-xl bg-canvas px-3 py-2 text-sm surface-pressed-soft focus:outline-none"
+              className="rounded-xl px-3 py-2 text-sm surface-pressed-soft focus:outline-none"
             >
               <option value="">플랜 SKU 선택 …</option>
               {planOnly.map((r) => (
@@ -128,7 +128,7 @@ export default function SkuMatchPanel({
             <select
               value={actualPick}
               onChange={(e) => setActualPick(e.target.value)}
-              className="rounded-xl bg-canvas px-3 py-2 text-sm surface-pressed-soft focus:outline-none"
+              className="rounded-xl px-3 py-2 text-sm surface-pressed-soft focus:outline-none"
             >
               <option value="">실적 SKU 선택 …</option>
               {actualOnly.map((r) => (
@@ -151,7 +151,7 @@ export default function SkuMatchPanel({
 
       {/* 현재 매핑 목록 */}
       {mappings.length > 0 && (
-        <div className="mt-3 rounded-[20px] bg-canvas p-4 card-soft">
+        <div className="mt-3 rounded-xl p-4 card-soft">
           <h3 className="mb-2 text-xs font-semibold text-ink-2">
             현재 매핑 ({mappings.length}건)
           </h3>
@@ -186,7 +186,7 @@ export default function SkuMatchPanel({
       )}
 
       {/* SKU 진단 표 */}
-      <div className="mt-3 overflow-x-auto rounded-[20px] bg-canvas card-soft">
+      <div className="mt-3 overflow-x-auto rounded-xl card-soft">
         <table className="w-full min-w-[640px] text-xs">
           <thead className="text-left text-ink-4">
             <tr>
@@ -255,7 +255,7 @@ function Stat({
 }) {
   const color = tone === "ok" ? "text-brand-600" : "text-ink-2";
   return (
-    <div className="rounded-[20px] bg-canvas p-4 card-soft">
+    <div className="rounded-xl p-4 card-soft">
       <div className="text-[11px] font-semibold uppercase tracking-[1.4px] text-ink-4">
         {label}
       </div>

--- a/promo-analytics/app/(dash)/promotions/[id]/edit/MergeForm.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/edit/MergeForm.tsx
@@ -60,7 +60,7 @@ export default function MergeForm({
   }
 
   return (
-    <section className="rounded-[28px] bg-canvas p-6 card-soft">
+    <section className="rounded-2xl p-6 card-soft">
       <h2 className="text-sm font-semibold text-ink-2">캠페인 병합 (고급)</h2>
       <p className="mt-1 text-xs text-ink-4">
         같은 행사인데 가이드(⑤)와 실적(②) 시트가 서로 다른 코드로 업로드돼 별개 캠페인이
@@ -72,7 +72,7 @@ export default function MergeForm({
         <select
           value={targetId}
           onChange={(e) => setTargetId(e.target.value)}
-          className="rounded-xl bg-canvas px-3 py-2 text-sm surface-pressed-soft focus:outline-none"
+          className="rounded-xl px-3 py-2 text-sm surface-pressed-soft focus:outline-none"
         >
           <option value="">병합 대상 캠페인 선택 …</option>
           {candidates.map((c) => (

--- a/promo-analytics/app/(dash)/promotions/[id]/loading.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/loading.tsx
@@ -7,28 +7,28 @@ export default function PromotionDetailLoading() {
 
       <div className="mt-6 grid grid-cols-2 gap-3 md:grid-cols-5">
         {Array.from({ length: 5 }).map((_, i) => (
-          <div key={i} className="rounded-xl bg-canvas p-4 card-soft">
+          <div key={i} className="rounded-xl p-4 card-soft">
             <div className="h-2.5 w-16 animate-pulse rounded-full bg-soft" />
             <div className="mt-3 h-5 w-24 animate-pulse rounded-full bg-soft" />
           </div>
         ))}
       </div>
 
-      <div className="mt-6 rounded-[24px] bg-canvas p-5 card-soft">
+      <div className="mt-6 rounded-2xl p-5 card-soft">
         <div className="h-3 w-32 animate-pulse rounded-full bg-soft" />
         <div className="mt-3 h-3 w-2/3 animate-pulse rounded-full bg-soft" />
       </div>
 
       <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-3">
         {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} className="rounded-[20px] bg-canvas p-4 card-soft">
+          <div key={i} className="rounded-xl p-4 card-soft">
             <div className="h-3 w-20 animate-pulse rounded-full bg-soft" />
             <div className="mt-3 h-7 w-16 animate-pulse rounded-full bg-soft" />
           </div>
         ))}
       </div>
 
-      <div className="mt-4 h-72 animate-pulse rounded-[24px] bg-canvas card-soft" />
+      <div className="mt-4 h-72 animate-pulse rounded-2xl card-soft" />
     </div>
   );
 }

--- a/promo-analytics/app/(dash)/promotions/[id]/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/page.tsx
@@ -196,7 +196,7 @@ export default async function PromotionDetail({
       </div>
 
       {/* 가격 가이드(플랜) 요약 + CTA */}
-      <div className="mt-6 rounded-[24px] bg-white card-soft p-5">
+      <div className="mt-6 rounded-2xl card-soft p-5">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <h2 className="text-sm font-semibold text-neutral-700">가격 가이드(플랜)</h2>
@@ -231,7 +231,7 @@ export default async function PromotionDetail({
 
       {/* 연동 센터 (N6 R1.4) — 비교 대상·SKU 매칭·병합을 한 곳에서 */}
       {(plan || diagnosticRows.length > 0 || skuMappings.length > 0) && (
-        <section className="mt-6 rounded-[24px] bg-white card-soft p-5">
+        <section className="mt-6 rounded-2xl card-soft p-5">
           <div className="flex flex-wrap items-center justify-between gap-2">
             <div className="flex items-center gap-2">
               <h2 className="text-sm font-semibold text-neutral-700">
@@ -295,7 +295,7 @@ export default async function PromotionDetail({
           <h2 className="mb-2 text-sm font-semibold text-neutral-700">
             상품별 증분 측정
           </h2>
-          <div className="overflow-x-auto rounded-[24px] bg-white card-soft">
+          <div className="overflow-x-auto rounded-2xl card-soft">
             <table className="w-full min-w-[760px] text-sm">
               <thead className="bg-neutral-50 text-left text-xs text-neutral-500">
                 <tr>
@@ -387,11 +387,11 @@ export default async function PromotionDetail({
           <h2 className="mb-2 text-sm font-semibold text-neutral-700">
             증분 Top 10 (검정=메인 · 회색=후광)
           </h2>
-          <div className="rounded-[24px] bg-white card-soft p-4">
+          <div className="rounded-2xl card-soft p-4">
             <UpliftChart data={chartData} />
           </div>
 
-          <div className="mt-4 rounded-[24px] bg-white card-soft p-4">
+          <div className="mt-4 rounded-2xl card-soft p-4">
             <div className="text-xs text-neutral-500">메인 상품</div>
             {mains.length > 0 ? (
               <ul className="mt-1.5 space-y-1 text-sm">
@@ -416,7 +416,7 @@ export default async function PromotionDetail({
 
           {/* 데이터 출처 (N6 R1.3) — 이 캠페인을 만들거나 갱신한 업로드 파일 */}
           {sources.length > 0 && (
-            <div className="mt-4 rounded-[24px] bg-white card-soft p-4">
+            <div className="mt-4 rounded-2xl card-soft p-4">
               <div className="text-xs text-neutral-500">데이터 출처 (업로드 파일)</div>
               <ul className="mt-1.5 space-y-1.5 text-sm">
                 {sources.slice(0, 5).map((s) => (
@@ -487,7 +487,7 @@ function MeasurementBanner({
   if (chips.length === 0) return null;
 
   return (
-    <div className="mb-5 flex flex-wrap items-center gap-2 rounded-[20px] bg-white card-soft px-4 py-3">
+    <div className="mb-5 flex flex-wrap items-center gap-2 rounded-xl card-soft px-4 py-3">
       <span className="text-xs font-medium text-neutral-500">측정 보정</span>
       {chips.map((c) => (
         <span

--- a/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
@@ -105,7 +105,7 @@ export default function PlanEditor({
   // N5: '플랜 만들기' 자동 draft 생성 제거 — 플랜은 ⑤ 가이드 업로드로만 적재
   if (!plan) {
     return (
-      <div className="mt-6 rounded-[24px] bg-white card-soft p-6">
+      <div className="mt-6 rounded-2xl card-soft p-6">
         <p className="text-sm text-neutral-600">
           이 캠페인에 연결된 가격 가이드(플랜)가 없습니다. 플랜은 업로드 페이지의 ⑤ 캠페인
           플랜 가이드로 적재해요 — 빈 플랜을 자동으로 만들지 않습니다.
@@ -334,7 +334,7 @@ export default function PlanEditor({
 
       {/* SKU 단위 예상 수량 롤업 */}
       {planTotals.skuExpectedQty.size > 0 && (
-        <div className="mt-6 rounded-[20px] bg-white card-soft p-4">
+        <div className="mt-6 rounded-xl card-soft p-4">
           <h3 className="text-sm font-medium">SKU 단위 예상 판매수 (전 옵션 합산)</h3>
           <div className="mt-2 overflow-x-auto">
             <table className="w-full text-left text-sm">
@@ -409,7 +409,7 @@ function Stat({
 }) {
   return (
     <div
-      className={`rounded-[20px] p-4 ${primary ? "bg-brand-50" : "bg-white card-soft"}`}
+      className={`rounded-xl p-4 ${primary ? "bg-brand-50" : "card-soft"}`}
     >
       <div className="text-xs text-neutral-500">{label}</div>
       <div className="mt-1 text-lg font-semibold">{value}</div>
@@ -441,7 +441,7 @@ function OptionCard({
   onRemoveItem: (itemKey: string) => void;
 }) {
   return (
-    <div className="rounded-[20px] bg-white card-soft p-4">
+    <div className="rounded-xl card-soft p-4">
       <div className="flex flex-wrap items-center gap-2">
         <input
           className="min-w-[10rem] flex-1 rounded-lg border border-neutral-200 px-2.5 py-1.5 text-sm font-medium disabled:bg-neutral-50"

--- a/promo-analytics/app/(dash)/settings/page.tsx
+++ b/promo-analytics/app/(dash)/settings/page.tsx
@@ -56,7 +56,7 @@ function ListEditor({ kind, title, hint }: { kind: Kind; title: string; hint: st
   }
 
   return (
-    <div className="rounded-[24px] bg-white p-5 card-soft">
+    <div className="rounded-2xl p-5 card-soft">
       <h2 className="text-sm font-semibold text-neutral-700">{title}</h2>
       <p className="mt-0.5 text-xs text-neutral-400">{hint}</p>
 

--- a/promo-analytics/app/(dash)/upload/page.tsx
+++ b/promo-analytics/app/(dash)/upload/page.tsx
@@ -127,7 +127,7 @@ function UploadHistory() {
   }, [load]);
 
   return (
-    <div className="mt-6 rounded-[24px] bg-white card-soft p-5">
+    <div className="mt-6 rounded-2xl card-soft p-5">
       <div className="flex items-center justify-between">
         <h2 className="font-medium">연동 이력</h2>
         <button
@@ -561,7 +561,7 @@ function UploadCard({ def }: { def: CardDef }) {
     p.total && p.total > 0 && p.done != null ? Math.round((p.done / p.total) * 100) : null;
 
   return (
-    <div className="rounded-[24px] bg-white card-soft p-5">
+    <div className="rounded-2xl card-soft p-5">
       <div className="flex items-start justify-between gap-4">
         <div>
           <h2 className="font-medium">{def.title}</h2>
@@ -942,7 +942,7 @@ function PriceMasterCard() {
       : null;
 
   return (
-    <div className="rounded-[24px] bg-white card-soft p-5">
+    <div className="rounded-2xl card-soft p-5">
       <div className="flex items-start justify-between gap-4">
         <div>
           <h2 className="font-medium">④ 가격 마스터 (가격가이드 워크북)</h2>
@@ -1355,7 +1355,7 @@ function PlanGuideImportCard() {
   const busy = p.phase === "reading" || p.phase === "parsing" || p.phase === "uploading";
 
   return (
-    <div className="rounded-[24px] bg-white card-soft p-5">
+    <div className="rounded-2xl card-soft p-5">
       <div className="flex items-start justify-between gap-4">
         <div>
           <h2 className="font-medium">⑤ 캠페인 플랜 가이드 (예상 적재)</h2>

--- a/promo-analytics/app/globals.css
+++ b/promo-analytics/app/globals.css
@@ -5,8 +5,13 @@
    빌드 시 외부 네트워크(Google Fonts) 의존 없음. 한글은 ASTA Sans 자체 글리프 +
    Pretendard 폴백으로 커버. */
 
+/* N6 R2.1: 뉴모피즘 → 모던 플랫 (밀도 우선).
+   클래스명(card-soft 등)은 유지하고 의미만 재정의 — 전 화면 일괄 전환.
+   상용 애널리틱스 표준: 중립 캔버스 + 흰 카드 + 헤어라인 보더 + 절제된 그림자,
+   강조는 코랄 단일색. */
+
 @theme {
-  /* 키컬러: 톤다운 코랄 (한 가지 강조색만 — 화려함 억제) */
+  /* 키컬러: 톤다운 코랄 (단일 강조색) */
   --color-brand-50: #fbf2ed;
   --color-brand-100: #f5dfd1;
   --color-brand-200: #ebbfa3;
@@ -16,11 +21,12 @@
   --color-brand-600: #ad5436;
   --color-brand-700: #8a4128;
 
-  /* 캔버스: 약간 차가운 라이트 그레이 — 뉴모피즘 듀얼 그림자가 보이게 */
-  --color-canvas: #ECEEF3;
-  --color-surface: #F4F5F9;
-  --color-soft: #E1E4EB;
-  --color-line: #D5D9E1;
+  /* 캔버스/표면: 흰 카드가 떠 보이는 옅은 중립 회색 */
+  --color-canvas: #F6F7F9;
+  --color-card: #FFFFFF;
+  --color-surface: #FFFFFF;
+  --color-soft: #EEF0F4;
+  --color-line: #E4E7EC;
 
   --color-ink: #1B1F2A;
   --color-ink-2: #3A4254;
@@ -41,34 +47,35 @@ html {
 body {
   background: var(--color-canvas);
   color: var(--color-ink);
+  font-variant-numeric: tabular-nums;
 }
 
-/* 절제된 뉴모피즘: 듀얼 방향 그림자, 강도는 가이드보다 낮춤 */
+:focus-visible {
+  outline: 2px solid var(--color-brand-400);
+  outline-offset: 2px;
+}
+
+/* 카드: 흰 표면 + 헤어라인 + 미세 그림자 */
 @utility card-soft {
-  box-shadow:
-    5px 5px 12px rgba(120, 130, 150, 0.16),
-    -4px -4px 11px rgba(255, 255, 255, 0.82);
+  background-color: var(--color-card);
+  border: 1px solid var(--color-line);
+  box-shadow: 0 1px 2px rgba(16, 24, 40, 0.04);
 }
 
 @utility card-soft-h {
-  box-shadow:
-    8px 8px 18px rgba(120, 130, 150, 0.22),
-    -6px -6px 14px rgba(255, 255, 255, 0.90);
+  background-color: var(--color-card);
+  border: 1px solid var(--color-line);
+  box-shadow: 0 4px 16px rgba(16, 24, 40, 0.08);
 }
 
-/* 눌린 표면 — 표 셀, 입력, 인사이트 박스, 선택 상태 */
+/* (구)눌린 표면 → 음각 대신 옅은 채움 — 선택 상태·칩·입력 배경 */
 @utility surface-pressed {
-  background: var(--color-canvas);
-  box-shadow:
-    inset 3px 3px 6px rgba(120, 130, 150, 0.16),
-    inset -3px -3px 6px rgba(255, 255, 255, 0.70);
+  background: var(--color-soft);
+  border: 1px solid var(--color-line);
 }
 
 @utility surface-pressed-soft {
-  background: var(--color-canvas);
-  box-shadow:
-    inset 2px 2px 4px rgba(120, 130, 150, 0.10),
-    inset -2px -2px 4px rgba(255, 255, 255, 0.55);
+  background: var(--color-soft);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/promo-analytics/app/login/page.tsx
+++ b/promo-analytics/app/login/page.tsx
@@ -24,8 +24,8 @@ export default function LoginPage() {
 
   return (
     <main className="flex min-h-screen items-center justify-center bg-canvas p-6">
-      <div className="w-full max-w-sm rounded-[28px] bg-canvas p-8 card-soft">
-        <div className="mb-5 flex h-12 w-12 items-center justify-center rounded-2xl bg-canvas text-base font-bold text-brand-600 card-soft">
+      <div className="w-full max-w-sm rounded-2xl p-8 card-soft">
+        <div className="mb-5 flex h-12 w-12 items-center justify-center rounded-2xl text-base font-bold text-brand-600 card-soft">
           P
         </div>
         <h1 className="text-xl font-semibold text-ink">
@@ -44,7 +44,7 @@ export default function LoginPage() {
         <button
           onClick={signIn}
           disabled={loading}
-          className="mt-6 flex w-full items-center justify-center gap-2 rounded-2xl bg-canvas px-4 py-2.5 text-sm font-semibold text-ink card-soft transition hover:card-soft-h disabled:opacity-60"
+          className="mt-6 flex w-full items-center justify-center gap-2 rounded-2xl px-4 py-2.5 text-sm font-semibold text-ink card-soft transition hover:card-soft-h disabled:opacity-60"
         >
           <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden>
             <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.76h3.56c2.08-1.92 3.28-4.74 3.28-8.09Z" />

--- a/promo-analytics/package-lock.json
+++ b/promo-analytics/package-lock.json
@@ -11,6 +11,7 @@
         "@fontsource-variable/asta-sans": "^5.2.4",
         "@supabase/ssr": "^0.10.3",
         "@supabase/supabase-js": "^2.107.0",
+        "cmdk": "^1.1.1",
         "next": "16.2.7",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -1261,6 +1262,336 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
+      "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
+      "integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.16.tgz",
+      "integrity": "sha512-l9ok83YBclEZhbjgzt76Hw733e6cvRKPNgO6GJ/IETlufXG9p+fRu2wlvpImQvR6xdJ8h7J8J2DBvsPEiEsKMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.9",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-portal": "1.1.11",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-slot": "1.2.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.12.tgz",
+      "integrity": "sha512-MhoruH6xEzsbvOmo4TNgMfmtvRGyDZw4MDSdf4ybMHfezjqwzv6hyd4lsMzBp8K9Sn6sGzCF62x1I7BYUECXOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-escape-keydown": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
+      "integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.9.tgz",
+      "integrity": "sha512-9Se8t+Zry+1rEOL7Y6l/4ANYU/TOtAtf8O2fKdwLltcaMcm6kOqYGbzO4tMFQ0bvzO920pRAoHpFZ4W85S3keQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.11.tgz",
+      "integrity": "sha512-UEytdjgEh2tJGgD/gZK4FUx6t1rNIlM3U0DENhSrG7I75FGm1DnaDuVUWF1pWAWUwGmn1sCJ1VGHn8LhN1aTOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
+      "integrity": "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.5.tgz",
+      "integrity": "sha512-zifXeB8Y88qCYx8PLZ5oQb32KwZub+s925mMoZsBBq9KUQqWKkREubTfs6ASjRPPBe7Jt9O8OHH89+95VG+grA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.5.tgz",
+      "integrity": "sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.2.tgz",
+      "integrity": "sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
@@ -1811,7 +2142,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -2503,6 +2834,18 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -2928,6 +3271,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/codepage": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
@@ -3276,6 +3635,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -4189,6 +4554,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-proto": {
@@ -6016,6 +6390,75 @@
         }
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/recharts": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
@@ -7069,6 +7512,49 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-sync-external-store": {

--- a/promo-analytics/package.json
+++ b/promo-analytics/package.json
@@ -12,6 +12,7 @@
     "@fontsource-variable/asta-sans": "^5.2.4",
     "@supabase/ssr": "^0.10.3",
     "@supabase/supabase-js": "^2.107.0",
+    "cmdk": "^1.1.1",
     "next": "16.2.7",
     "react": "19.2.4",
     "react-dom": "19.2.4",


### PR DESCRIPTION
N6 R2.1 — 비주얼 대수술 1단계. 이번 PR부터 화면이 눈에 띄게 달라집니다.

## 디자인 시스템: 뉴모피즘 → 모던 플랫 (§6 결정 1 확정)
- `globals.css` 토큰만 재정의하고 클래스명(`card-soft`/`surface-pressed`/`ink-*`)은 유지 → **전 화면(6개 메뉴 + 로그인 + 스켈레톤)이 한 번에 새 룩으로 전환**
- 상용 애널리틱스 표준: 옅은 중립 캔버스 + 흰 카드 + 헤어라인 보더 + 절제된 그림자, 코랄 단일 강조 유지
- 라운드 정규화(밀도 ↑), `tabular-nums` 전역, `:focus-visible` 링(접근성), 사이드바 활성 = 브랜드 칩
- 본문을 감싸던 거대 뉴모피즘 카드 제거 — 콘텐츠가 캔버스 위에 바로 배치

## 홈 KPI 타일 — Triple Whale Summary 패턴
- 모든 타일: 수치 + **전기간 대비 델타 칩** + **스파크라인** + **클릭 드릴**
- 구성: 기여 총매출(월별 추세) · 매출 달성률(플랜 가중) · 평소 대비 행사 배율 · 간접 매출 비중

## ⌘K 커맨드 팔레트 (cmdk)
- ⌘K/Ctrl+K 또는 사이드바 검색 버튼 → 페이지 점프 + 캠페인 이름/코드 검색 → 상세 직행

## 다음 (R2.2)
메뉴별 시각화 채우기 — 시뮬레이터 민감도 차트, 추천 근거 차트, 라이브러리 비교 오버레이, 상세 ECharts brush/zoom. 이 PR의 프리뷰에서 새 룩을 먼저 확인해 주세요.

https://claude.ai/code/session_01JDEWhEszHRLfEdSo18ej1w

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDEWhEszHRLfEdSo18ej1w)_