### PR TITLE
N6 R2.2: 전 메뉴 시각화 — 상세 시계열·비교 오버레이·후보 비교·산점도

### DIFF
--- a/promo-analytics/app/(dash)/library/LibraryCompare.tsx
+++ b/promo-analytics/app/(dash)/library/LibraryCompare.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  Line,
+  LineChart,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { wonShort } from "@/lib/format";
+
+const COLORS = ["#c66a48", "#3A4254", "#7C9885"];
+
+export type CompareCampaign = {
+  id: string;
+  name: string;
+  daily: { d: string; rev: number; in: boolean }[];
+};
+
+// N6 R2.2: 캠페인 기간 정규화(D1·D2·…) 오버레이 비교 — 최대 3개.
+// 서로 다른 시기의 캠페인을 같은 일차 축에 겹쳐 흐름·체급을 비교한다.
+export default function LibraryCompare({ campaigns }: { campaigns: CompareCampaign[] }) {
+  const candidates = useMemo(
+    () => campaigns.filter((c) => c.daily.some((p) => p.in)),
+    [campaigns],
+  );
+  const [picks, setPicks] = useState<string[]>(() =>
+    candidates.slice(0, 2).map((c) => c.id),
+  );
+
+  const setPick = (idx: number, id: string) => {
+    setPicks((p) => {
+      const next = [...p];
+      if (id === "") next.splice(idx, 1);
+      else next[idx] = id;
+      return [...new Set(next)];
+    });
+  };
+
+  const series = picks
+    .map((id) => candidates.find((c) => c.id === id))
+    .filter((c): c is CompareCampaign => c != null);
+
+  const chartData = useMemo(() => {
+    const maxLen = Math.max(0, ...series.map((s) => s.daily.filter((p) => p.in).length));
+    const rows: Record<string, number | string>[] = [];
+    for (let i = 0; i < maxLen; i++) {
+      const row: Record<string, number | string> = { day: `D${i + 1}` };
+      for (const s of series) {
+        const promoDays = s.daily.filter((p) => p.in);
+        if (promoDays[i]) row[s.id] = promoDays[i].rev;
+      }
+      rows.push(row);
+    }
+    return rows;
+  }, [series]);
+
+  if (candidates.length < 2) return null;
+
+  return (
+    <section className="mt-6 rounded-2xl card-soft p-5">
+      <h2 className="text-sm font-semibold text-neutral-700">캠페인 비교 (기간 정규화)</h2>
+      <p className="mt-1 text-xs text-neutral-400">
+        시기가 달라도 캠페인 1일차(D1) 기준으로 겹쳐 일매출 흐름을 비교합니다. 최대 3개.
+      </p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {[0, 1, 2].map((idx) => (
+          <select
+            key={idx}
+            value={picks[idx] ?? ""}
+            onChange={(e) => setPick(idx, e.target.value)}
+            className="max-w-[260px] rounded-xl border border-line bg-card px-3 py-2 text-sm text-ink-2 focus:outline-none"
+          >
+            <option value="">{idx < picks.length ? "— 제거" : `+ 캠페인 ${idx + 1}`}</option>
+            {candidates.map((c) => (
+              <option key={c.id} value={c.id} disabled={picks.includes(c.id) && picks[idx] !== c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        ))}
+      </div>
+      {series.length >= 2 && (
+        <div className="mt-4 h-60">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={chartData} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
+              <XAxis dataKey="day" tick={{ fontSize: 11, fill: "#9CA4B4" }} tickLine={false} axisLine={{ stroke: "#E4E7EC" }} />
+              <YAxis tickFormatter={(v: number) => wonShort(v)} tick={{ fontSize: 11, fill: "#9CA4B4" }} tickLine={false} axisLine={false} width={56} />
+              <Tooltip
+                formatter={(v, key) => {
+                  const c = series.find((s) => s.id === key);
+                  return [wonShort(Number(v)), c?.name ?? String(key)] as [string, string];
+                }}
+                contentStyle={{ borderRadius: 12, border: "1px solid #E4E7EC", boxShadow: "0 8px 24px -8px rgba(0,0,0,.15)", fontSize: 12 }}
+              />
+              <Legend
+                formatter={(key: string) => {
+                  const c = series.find((s) => s.id === key);
+                  return <span style={{ fontSize: 12 }}>{c?.name ?? key}</span>;
+                }}
+              />
+              {series.map((s, i) => (
+                <Line
+                  key={s.id}
+                  dataKey={s.id}
+                  type="monotone"
+                  stroke={COLORS[i % COLORS.length]}
+                  strokeWidth={2}
+                  dot={{ r: 2.5 }}
+                  isAnimationActive={false}
+                />
+              ))}
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/promo-analytics/app/(dash)/library/page.tsx
+++ b/promo-analytics/app/(dash)/library/page.tsx
@@ -6,6 +6,7 @@ import type {
   CampaignFit,
 } from "@/lib/types";
 import LibraryTable, { type LibraryRow } from "./LibraryTable";
+import LibraryCompare, { type CompareCampaign } from "./LibraryCompare";
 
 export const dynamic = "force-dynamic";
 
@@ -15,6 +16,7 @@ type RollupEntry = {
   features: (PromotionSummary & { promotion_id: string }) | null;
   achievement: CampaignAchievement | null;
   fits: CampaignFit[];
+  daily: { d: string; rev: number; in: boolean }[];
 };
 type LibraryBundle = { promotions: Promotion[]; rollups: RollupEntry[] };
 
@@ -42,6 +44,14 @@ export default async function LibraryPage() {
       })),
     );
   }
+
+  // 비교 오버레이용: 일별 시리즈 보유 캠페인 (이름은 promotions 기준)
+  const dailyMap = new Map(rollups.map((r) => [r.promotion_id, r.daily ?? []]));
+  const compareCampaigns: CompareCampaign[] = (promos ?? []).map((p) => ({
+    id: p.id,
+    name: p.name,
+    daily: dailyMap.get(p.id) ?? [],
+  }));
 
   const rows: LibraryRow[] = (promos ?? []).map((p: Promotion) => {
     const s = sumMap.get(p.id) ?? null;
@@ -76,6 +86,7 @@ export default async function LibraryPage() {
       <p className="mt-1 text-sm text-neutral-500">
         과거 캠페인을 유형·시즈널리티·성과 기준으로 비교·분석하세요.
       </p>
+      <LibraryCompare campaigns={compareCampaigns} />
       <div className="mt-6">
         <LibraryTable data={rows} />
       </div>

--- a/promo-analytics/app/(dash)/predict/Simulator.tsx
+++ b/promo-analytics/app/(dash)/predict/Simulator.tsx
@@ -7,6 +7,8 @@ import {
   LineChart,
   ReferenceDot,
   ResponsiveContainer,
+  Scatter,
+  ScatterChart,
   Tooltip,
   XAxis,
   YAxis,
@@ -238,6 +240,77 @@ export default function Simulator({ cases, options }: { cases: CaseFeature[]; op
             <Line type="monotone" dataKey="uplift" stroke={BRAND} strokeWidth={2.5} dot={{ r: 0 }} activeDot={{ r: 5 }} />
             <ReferenceDot x={discount} y={curUplift} r={6} fill={BRAND} stroke="#fff" strokeWidth={2} />
           </LineChart>
+        </ResponsiveContainer>
+
+        {/* 과거 캠페인 분포 (N6 R2.2): 내 조건이 과거 어디쯤인지 */}
+        <p className="mb-2 mt-5 text-xs font-medium text-neutral-500">
+          과거 캠페인 분포 — 할인율 × 일평균 증분
+          <span className="ml-2 font-normal text-neutral-400">
+            (코랄 = 같은 혜택 유형 · 회색 = 기타 · ◎ = 현재 조건)
+          </span>
+        </p>
+        <ResponsiveContainer width="100%" height={200}>
+          <ScatterChart margin={{ top: 8, right: 12, left: 4, bottom: 0 }}>
+            <XAxis
+              type="number"
+              dataKey="x"
+              name="할인율"
+              domain={[0, 70]}
+              tickFormatter={(d) => `${d}%`}
+              fontSize={11}
+              stroke="#bcb8b3"
+              tickLine={false}
+              axisLine={false}
+            />
+            <YAxis
+              type="number"
+              dataKey="y"
+              name="일평균 증분"
+              tickFormatter={(v) => wonShort(v)}
+              fontSize={11}
+              stroke="#bcb8b3"
+              tickLine={false}
+              axisLine={false}
+              width={56}
+            />
+            <Tooltip
+              cursor={{ strokeDasharray: "4 4" }}
+              formatter={(v, key) =>
+                [key === "y" ? wonShort(Number(v)) : `${v}%`, key === "y" ? "일평균 증분" : "할인율"] as [string, string]
+              }
+              labelFormatter={() => ""}
+              content={({ payload }) => {
+                const p = payload?.[0]?.payload as { name?: string; x: number; y: number } | undefined;
+                if (!p) return null;
+                return (
+                  <div className="rounded-xl border border-line bg-card px-3 py-2 text-xs shadow-md">
+                    <div className="font-medium text-ink">{p.name ?? "현재 조건"}</div>
+                    <div className="mt-0.5 text-ink-3">할인 {p.x}% · 일평균 증분 {wonShort(p.y)}</div>
+                  </div>
+                );
+              }}
+            />
+            <Scatter
+              data={cases
+                .filter((c) => c.discount_rate != null && c.promo_type !== promoType)
+                .map((c) => ({ x: Math.round((c.discount_rate ?? 0) * 100), y: c.uplift_per_day, name: c.name }))}
+              fill="#C7CCD6"
+              isAnimationActive={false}
+            />
+            <Scatter
+              data={cases
+                .filter((c) => c.discount_rate != null && c.promo_type === promoType)
+                .map((c) => ({ x: Math.round((c.discount_rate ?? 0) * 100), y: c.uplift_per_day, name: c.name }))}
+              fill={BRAND}
+              isAnimationActive={false}
+            />
+            <Scatter
+              data={[{ x: discount, y: days > 0 ? curUplift / days : curUplift, name: "현재 조건 (예측)" }]}
+              fill="#1B1F2A"
+              shape="diamond"
+              isAnimationActive={false}
+            />
+          </ScatterChart>
         </ResponsiveContainer>
       </section>
 

--- a/promo-analytics/app/(dash)/prescribe/Recommend.tsx
+++ b/promo-analytics/app/(dash)/prescribe/Recommend.tsx
@@ -171,6 +171,48 @@ export default function Recommend({ options }: { options: Options }) {
               추천할 사례가 부족합니다. 캠페인 데이터를 더 쌓아주세요.
             </p>
           ) : (
+            <>
+            {/* 후보 비교 (N6 R2.2): 종합 점수·예측 증분을 한눈에 */}
+            {recs.length > 1 && (
+              <div className="mb-4 rounded-2xl p-5 card-soft">
+                <h2 className="text-sm font-semibold text-neutral-700">후보 비교</h2>
+                <div className="mt-3 space-y-2.5">
+                  {recs.map((r, i) => {
+                    const maxUplift = Math.max(...recs.map((x) => x.predicted_uplift), 1);
+                    return (
+                      <div key={i}>
+                        <div className="mb-1 flex items-center justify-between gap-2 text-xs">
+                          <span className="min-w-0 flex-1 truncate font-medium text-neutral-700">
+                            {i + 1}. {r.promo_type}
+                            {r.discount_rate != null && ` · ${pct(r.discount_rate, 0)}`}
+                          </span>
+                          <span className="shrink-0 text-neutral-500">
+                            점수 {Math.round(r.score)} · 예측 증분 {wonShort(r.predicted_uplift)}
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-1.5">
+                          <div className="h-2 flex-1 overflow-hidden rounded-full bg-soft">
+                            <div
+                              className={`h-full rounded-full ${i === 0 ? "bg-brand-500" : "bg-brand-200"}`}
+                              style={{ width: `${Math.max(2, Math.min(100, r.score))}%` }}
+                            />
+                          </div>
+                          <div className="h-2 w-24 overflow-hidden rounded-full bg-soft" title="예측 증분 (상대)">
+                            <div
+                              className="h-full rounded-full bg-neutral-400"
+                              style={{ width: `${Math.max(2, (r.predicted_uplift / maxUplift) * 100)}%` }}
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+                <p className="mt-2 text-[11px] text-neutral-400">
+                  코랄 = 종합 점수(0~100) · 회색 = 예측 증분(최대 대비)
+                </p>
+              </div>
+            )}
             <div className="space-y-3">
               {recs.map((r, i) => (
                 <div key={i} className={`rounded-2xl p-5 card-soft ${i === 0 ? "ring-2 ring-brand-500" : ""}`}>
@@ -257,6 +299,7 @@ export default function Recommend({ options }: { options: Options }) {
                 </div>
               ))}
             </div>
+            </>
           )}
         </div>
       )}

--- a/promo-analytics/app/(dash)/promotions/[id]/CampaignTrend.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/CampaignTrend.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import {
+  Area,
+  Bar,
+  Brush,
+  Cell,
+  ComposedChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { wonShort } from "@/lib/format";
+
+const BRAND = "#c66a48";
+const GRAY = "#C7CCD6";
+
+export type DailyPoint = { d: string; rev: number; in: boolean };
+
+// N6 R2.2: 캠페인 일별 매출 시계열 — 직전 8주 맥락 + 캠페인 기간 강조 + 브러시 줌.
+// 회색 = 평시(직전 8주), 코랄 = 캠페인 기간. 점선 = 평시 일평균(baseline).
+export default function CampaignTrend({
+  data,
+  baselineDaily,
+}: {
+  data: DailyPoint[];
+  baselineDaily: number | null;
+}) {
+  if (data.length < 2) return null;
+  const promoStart = data.findIndex((p) => p.in);
+  // 기본 뷰: 캠페인 시작 2주 전부터 (브러시로 전체 8주 탐색 가능)
+  const defaultStart = Math.max(0, promoStart - 14);
+
+  return (
+    <section className="mt-6 rounded-2xl card-soft p-5">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h2 className="text-sm font-semibold text-neutral-700">일별 매출 흐름</h2>
+        <div className="flex items-center gap-3 text-[11px] text-neutral-400">
+          <span><span className="mr-1 inline-block h-2 w-2 rounded-sm" style={{ background: GRAY }} />평시 (직전 8주)</span>
+          <span><span className="mr-1 inline-block h-2 w-2 rounded-sm" style={{ background: BRAND }} />캠페인 기간</span>
+          {baselineDaily != null && baselineDaily > 0 && (
+            <span>― ― 평시 일평균 {wonShort(baselineDaily)}</span>
+          )}
+        </div>
+      </div>
+      <div className="mt-3 h-64">
+        <ResponsiveContainer width="100%" height="100%">
+          <ComposedChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
+            <XAxis
+              dataKey="d"
+              tickFormatter={(v: string) => v.slice(5)}
+              tick={{ fontSize: 11, fill: "#9CA4B4" }}
+              tickLine={false}
+              axisLine={{ stroke: "#E4E7EC" }}
+              minTickGap={28}
+            />
+            <YAxis
+              tickFormatter={(v: number) => wonShort(v)}
+              tick={{ fontSize: 11, fill: "#9CA4B4" }}
+              tickLine={false}
+              axisLine={false}
+              width={56}
+            />
+            <Tooltip
+              formatter={(v) => [wonShort(Number(v)), "일매출"] as [string, string]}
+              labelFormatter={(l) => String(l)}
+              contentStyle={{
+                borderRadius: 12,
+                border: "1px solid #E4E7EC",
+                boxShadow: "0 8px 24px -8px rgba(0,0,0,.15)",
+                fontSize: 12,
+              }}
+            />
+            {baselineDaily != null && baselineDaily > 0 && (
+              <ReferenceLine
+                y={baselineDaily}
+                stroke="#9CA4B4"
+                strokeDasharray="5 4"
+                strokeWidth={1}
+              />
+            )}
+            <Bar dataKey="rev" radius={[3, 3, 0, 0]} isAnimationActive={false}>
+              {data.map((p) => (
+                <Cell key={p.d} fill={p.in ? BRAND : GRAY} fillOpacity={p.in ? 1 : 0.55} />
+              ))}
+            </Bar>
+            <Area
+              type="monotone"
+              dataKey="rev"
+              stroke="transparent"
+              fill="transparent"
+              isAnimationActive={false}
+            />
+            <Brush
+              dataKey="d"
+              startIndex={defaultStart}
+              height={22}
+              travellerWidth={8}
+              stroke="#C7CCD6"
+              fill="#F6F7F9"
+              tickFormatter={(v: string) => v.slice(5)}
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+      <p className="mt-2 text-[11px] text-neutral-400">
+        매장 전체 일매출 기준 · 드래그(브러시)로 구간을 좁혀 캠페인 전후 흐름을 비교하세요.
+      </p>
+    </section>
+  );
+}

--- a/promo-analytics/app/(dash)/promotions/[id]/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/page.tsx
@@ -17,6 +17,7 @@ import Achievement from "./Achievement";
 import PurposeBlock, { type PurposeMetricRow } from "./PurposeBlock";
 import SkuMatchPanel, { type DiagnosticRow, type SkuMapping } from "./SkuMatchPanel";
 import ActualsLink, { type ActualsCandidate } from "./ActualsLink";
+import CampaignTrend, { type DailyPoint } from "./CampaignTrend";
 
 export const dynamic = "force-dynamic";
 
@@ -24,12 +25,13 @@ export const dynamic = "force-dynamic";
 type DetailBundle = {
   promo: Promotion | null;
   rollup: {
-    features: PromotionSummary | null;
+    features: (PromotionSummary & { baseline_daily?: number }) | null;
     measurement: MeasurementRow[];
     pva_summary: PlanVsActualSummary | null;
     pva_rows: PlanVsActualRow[];
     pva_options: PlanVsActualOption[];
     diagnostic: DiagnosticRow[];
+    daily: DailyPoint[];
   } | null;
   notes: PromotionNote[];
   plan: {
@@ -194,6 +196,16 @@ export default async function PromotionDetail({
           }
         />
       </div>
+
+      {/* 일별 매출 시계열 (N6 R2.2) — 평시 8주 맥락 + 캠페인 강조 + 브러시 줌 */}
+      <CampaignTrend
+        data={bundle?.rollup?.daily ?? []}
+        baselineDaily={
+          bundle?.rollup?.features?.baseline_daily != null
+            ? Number(bundle.rollup.features.baseline_daily)
+            : null
+        }
+      />
 
       {/* 가격 가이드(플랜) 요약 + CTA */}
       <div className="mt-6 rounded-2xl card-soft p-5">

--- a/promo-analytics/supabase/migrations/0024_daily_series.sql
+++ b/promo-analytics/supabase/migrations/0024_daily_series.sql
@@ -1,0 +1,132 @@
+-- 0024: 캠페인 일별 매출 시리즈 롤업 (N6 R2.2)
+--
+-- 캠페인 상세 시계열(브러시 줌)·히스토리 비교 오버레이용.
+-- 캠페인 기간 내 daily_sales 일자 합계를 rollup에 사전 적재.
+-- (promotion_sales 는 일자 granularity 가 없으므로 전장 daily_sales 기준 —
+--  '캠페인 기간의 매장 전체 일매출' 시리즈. baseline 대비선과 함께 읽는 용도)
+
+alter table promo.campaign_rollups
+  add column if not exists daily jsonb not null default '[]';
+
+create or replace function promo.refresh_rollups(p_force boolean default false)
+returns void
+language plpgsql
+set search_path = ''
+as $$
+declare
+  is_dirty boolean;
+begin
+  perform pg_advisory_xact_lock(hashtext('promo.refresh_rollups'));
+  select dirty into is_dirty from promo.rollup_state where id;
+  if not p_force and not coalesce(is_dirty, true) then
+    return;
+  end if;
+
+  delete from promo.campaign_rollups;
+  with feats as (select * from promo.all_campaign_features()),
+       achs  as (select * from promo.campaign_achievements()),
+       fits  as (
+         select f.promotion_id, jsonb_agg(to_jsonb(f.*)) as j
+         from promo.campaign_fits() f group by f.promotion_id
+       ),
+       meas  as (
+         select pr.id as pid,
+                coalesce(jsonb_agg(to_jsonb(m.*)) filter (where m.product_id is not null),
+                         '[]'::jsonb) as j
+         from promo.promotions pr
+         left join lateral promo.promotion_measurement(pr.id) m on true
+         group by pr.id
+       ),
+       pvas  as (
+         select pr.id as pid,
+           (select to_jsonb(s.*) from promo.plan_vs_actual_summary(pr.id) s limit 1) as s_j,
+           (select coalesce(jsonb_agg(to_jsonb(r.*)), '[]'::jsonb)
+              from promo.plan_vs_actual(pr.id) r) as r_j,
+           (select coalesce(jsonb_agg(to_jsonb(o.*)), '[]'::jsonb)
+              from promo.plan_vs_actual_options(pr.id) o) as o_j,
+           (select coalesce(jsonb_agg(to_jsonb(d.*)), '[]'::jsonb)
+              from promo.sku_match_diagnostic(pr.id) d) as d_j
+         from promo.promotions pr
+       ),
+       -- 직전 8주 맥락 포함 ('in' = 캠페인 기간 여부) — 상세 시계열에서
+       -- baseline 구간 대비 스파이크가 보이게
+       daily as (
+         select pr.id as pid,
+                coalesce(jsonb_agg(jsonb_build_object(
+                           'd', d.sale_date, 'rev', d.rev,
+                           'in', (d.sale_date between pr.start_date and pr.end_date))
+                                   order by d.sale_date)
+                         filter (where d.sale_date is not null), '[]'::jsonb) as j
+         from promo.promotions pr
+         left join lateral (
+           select ds.sale_date, sum(ds.revenue) as rev
+           from promo.daily_sales ds
+           where ds.sale_date between pr.start_date - 56 and pr.end_date
+           group by ds.sale_date
+         ) d on true
+         group by pr.id
+       )
+  insert into promo.campaign_rollups
+    (promotion_id, features, achievement, fits, measurement,
+     pva_summary, pva_rows, pva_options, diagnostic, daily, refreshed_at)
+  select pr.id,
+         to_jsonb(f.*),
+         to_jsonb(a.*),
+         coalesce(ft.j, '[]'::jsonb),
+         coalesce(m.j,  '[]'::jsonb),
+         p.s_j,
+         coalesce(p.r_j, '[]'::jsonb),
+         coalesce(p.o_j, '[]'::jsonb),
+         coalesce(p.d_j, '[]'::jsonb),
+         coalesce(dy.j, '[]'::jsonb),
+         now()
+  from promo.promotions pr
+  left join feats f on f.promotion_id = pr.id
+  left join achs  a on a.promotion_id = pr.id
+  left join fits  ft on ft.promotion_id = pr.id
+  left join meas  m on m.pid = pr.id
+  left join pvas  p on p.pid = pr.id
+  left join daily dy on dy.pid = pr.id;
+
+  insert into promo.global_rollups (key, payload, refreshed_at)
+  values
+    ('overall',
+     (select to_jsonb(o.*) from promo.overall_baseline_metrics() o limit 1), now()),
+    ('purpose_metrics',
+     (select coalesce(jsonb_agg(to_jsonb(pm.*)), '[]'::jsonb) from promo.purpose_metrics() pm), now())
+  on conflict (key) do update
+    set payload = excluded.payload, refreshed_at = excluded.refreshed_at;
+
+  update promo.rollup_state set dirty = false, refreshed_at = now() where id;
+end;
+$$;
+
+-- library_bundle 에 daily 포함 (히스토리 비교 오버레이용)
+create or replace function promo.library_bundle()
+returns jsonb
+language plpgsql
+set search_path = ''
+as $$
+declare result jsonb;
+begin
+  perform promo.ensure_rollups_fresh();
+  select jsonb_build_object(
+    'promotions',
+      (select coalesce(jsonb_agg(to_jsonb(p.*) order by p.start_date desc), '[]'::jsonb)
+       from promo.promotions p),
+    'rollups',
+      (select coalesce(jsonb_agg(jsonb_build_object(
+         'promotion_id', r.promotion_id,
+         'features', r.features,
+         'achievement', r.achievement,
+         'fits', r.fits,
+         'daily', r.daily)), '[]'::jsonb)
+       from promo.campaign_rollups r)
+  ) into result;
+  return result;
+end;
+$$;
+
+grant execute on all functions in schema promo to authenticated;
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
N6 R2.2 — "다이어그램이 각 메뉴에 적극적으로". 6개 메뉴 전부 시각화 보유 상태가 됩니다.

## 캠페인 상세 — 일별 매출 시계열 (브러시 줌)
- 직전 8주 평시(회색) vs 캠페인 기간(코랄) 바차트 + 평시 일평균 점선 — 스파이크가 한눈에
- 하단 브러시 드래그로 구간 줌 (기본 뷰: 캠페인 시작 2주 전부터)
- 데이터는 마이그레이션 0024로 롤업에 사전 적재 (`campaign_rollups.daily`, DB 적용 완료) — 페이지 추가 쿼리 0

## 히스토리 비교/분석 — 캠페인 오버레이 비교
- 캠페인 최대 3개를 골라 **D1(캠페인 1일차) 기준 기간 정규화**로 일매출 흐름을 겹쳐 비교 — 시기가 달라도 체급·흐름 비교 가능

## 캠페인 추천 — 후보 비교 블록
- 추천 후보들의 종합 점수(0~100)와 예측 증분을 듀얼 바로 한눈에, 1순위 강조

## 성과 시뮬레이터 — 과거 캠페인 분포 산점도
- 할인율 × 일평균 증분 분포에 과거 캠페인 전부를 찍고(같은 혜택 유형=코랄), **현재 시뮬 조건을 다이아몬드로 표시** — "내 조건이 과거 분포의 어디쯤인지"

next build + 타입체크 통과.

https://claude.ai/code/session_01JDEWhEszHRLfEdSo18ej1w

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDEWhEszHRLfEdSo18ej1w)_