### PR TITLE
fix: 연동 직후 404 오인 — RPC 타임아웃 분기 + 롤업 백그라운드 갱신

### DIFF
--- a/promo-analytics/app/(dash)/error.tsx
+++ b/promo-analytics/app/(dash)/error.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+// (dash) 그룹 에러 바운더리 — RPC 타임아웃 등 일시 오류를 404/백지 대신
+// 재시도 가능한 화면으로. (N6: 연동 직후 롤업 재계산이 길어질 때 대비)
+export default function DashError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="px-4 py-16 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-md rounded-2xl card-soft p-8 text-center">
+        <div className="text-base font-semibold text-ink">
+          데이터를 불러오지 못했습니다
+        </div>
+        <p className="mt-2 text-sm leading-relaxed text-ink-3">
+          업로드·연동 직후에는 분석 재계산이 잠시 걸릴 수 있습니다.
+          몇 초 뒤 다시 시도해 주세요.
+        </p>
+        {error?.message && (
+          <p className="mt-2 break-all text-[11px] text-ink-4">{error.message}</p>
+        )}
+        <button
+          onClick={() => reset()}
+          className="mt-5 rounded-full bg-brand-500 px-6 py-2.5 text-sm font-semibold text-white hover:bg-brand-600"
+        >
+          다시 시도
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/promo-analytics/app/(dash)/promotions/[id]/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/page.tsx
@@ -67,9 +67,14 @@ export default async function PromotionDetail({
   const { id } = await params;
   const supabase = await createClient();
 
-  const { data: bundleData } = await supabase.rpc("promotion_detail_bundle", {
-    p_id: id,
-  });
+  const { data: bundleData, error: bundleError } = await supabase.rpc(
+    "promotion_detail_bundle",
+    { p_id: id },
+  );
+  // RPC 실패(타임아웃 등)는 '캠페인 없음'이 아니다 — 404 대신 에러 바운더리로.
+  if (bundleError) {
+    throw new Error(`분석 데이터를 불러오지 못했습니다: ${bundleError.message}`);
+  }
   const bundle = (bundleData as DetailBundle | null) ?? null;
   const promo = bundle?.promo ?? null;
   if (!promo) notFound();

--- a/promo-analytics/supabase/migrations/0026_rollup_timeout_cron.sql
+++ b/promo-analytics/supabase/migrations/0026_rollup_timeout_cron.sql
@@ -1,0 +1,23 @@
+-- 0026: 롤업 재계산 타임아웃·백그라운드 갱신 (404 오인 사고 후속)
+--
+-- 문제: 변이(플랜 연동 등) 후 첫 조회가 refresh_rollups(~6.5s)를 동기 수행 →
+--       authenticated 기본 statement_timeout(8s)에 걸리면 번들 RPC가 에러 →
+--       상세 페이지가 이를 '캠페인 없음'으로 오인해 404 렌더.
+-- 해결: (1) authenticated 타임아웃 30s 상향 (재계산 헤드룸)
+--       (2) pg_cron 5분 주기 promo.refresh_rollups() — dirty 아닐 땐 즉시
+--           no-op. 사용자가 콜드 경로(동기 재계산)를 밟을 일이 거의 없어짐.
+--       (3) 앱: 상세 페이지 RPC 에러를 404 가 아닌 에러 바운더리로 분기,
+--           (dash)/error.tsx 재시도 화면 추가. (코드 변경, 본 파일 외)
+
+alter role authenticated set statement_timeout = '30s';
+
+create extension if not exists pg_cron;
+
+select cron.unschedule('promo-refresh-rollups')
+where exists (select 1 from cron.job where jobname = 'promo-refresh-rollups');
+
+select cron.schedule(
+  'promo-refresh-rollups',
+  '*/5 * * * *',
+  $$select promo.refresh_rollups();$$
+);


### PR DESCRIPTION
## 증상
벌크업 플랜에 실적 캠페인을 연동한 직후 캠페인 상세가 **404** 표시.

## 원인 (캠페인은 멀쩡함)
연동(변이) → 롤업 dirty 마킹 → 다음 조회가 재계산(~6.5s)을 동기 수행 → **authenticated 기본 statement_timeout(8초)에 걸려 번들 RPC가 에러** → 상세 페이지가 RPC 에러를 '캠페인 없음'으로 오인해 `notFound()` 렌더. DB 확인 결과 dirty=true로 재계산이 계속 실패하고 있었음 (플랜·캠페인·연동 데이터는 모두 정상).

## 수정
- **0026 (DB 적용 완료)**: authenticated 타임아웃 8s→30s, pg_cron 5분 주기 `refresh_rollups()` (dirty 아닐 땐 no-op — 사용자가 콜드 재계산 경로를 밟을 일이 거의 없어짐)
- **상세 페이지**: RPC 에러는 404가 아닌 throw → 에러 바운더리로
- **`(dash)/error.tsx` 신설**: "업로드·연동 직후에는 재계산이 잠시 걸릴 수 있습니다 — 다시 시도" 화면

## 사후 조치
막혀 있던 dirty를 수동 refresh로 즉시 해소 — **벌크업 상세는 지금 바로 정상 조회됩니다** (이 PR 머지 전에도).

https://claude.ai/code/session_01JDEWhEszHRLfEdSo18ej1w

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDEWhEszHRLfEdSo18ej1w)_