### PR TITLE
N6: 플랜·실적 비교 UX 개편 — 인라인 SKU 연동 + 역링크 + 모바일 수정

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/ActualsLink.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/ActualsLink.tsx
@@ -58,11 +58,11 @@ export default function ActualsLink({
         가이드(⑤)와 실적(②)이 서로 다른 코드로 업로드된 경우 다른 캠페인을 지정해 짝지어
         비교하세요. 모든 달성률·진단이 선택한 실적 기준으로 다시 계산됩니다.
       </p>
-      <div className="mt-3 grid gap-2 sm:grid-cols-[1fr_auto_auto]">
+      <div className="mt-3 grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto_auto]">
         <select
           value={pick}
           onChange={(e) => setPick(e.target.value)}
-          className="rounded-xl px-3 py-2 text-sm surface-pressed-soft focus:outline-none"
+          className="w-full min-w-0 truncate rounded-xl border border-line bg-card px-3 py-2 text-sm focus:outline-none"
         >
           <option value="">자기 캠페인 실적 (기본)</option>
           {candidates

--- a/promo-analytics/app/(dash)/promotions/[id]/CampaignTrend.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/CampaignTrend.tsx
@@ -45,7 +45,7 @@ export default function CampaignTrend({
           )}
         </div>
       </div>
-      <div className="mt-3 h-64">
+      <div className="mt-3 h-52 sm:h-64">
         <ResponsiveContainer width="100%" height="100%">
           <ComposedChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
             <XAxis

--- a/promo-analytics/app/(dash)/promotions/[id]/SkuMatchPanel.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/SkuMatchPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import { won, wonShort, num } from "@/lib/format";
 
 // promo.sku_match_diagnostic() 반환 행
@@ -22,8 +23,32 @@ export type SkuMapping = {
   actual_product_id: string;
 };
 
-// 양쪽 SKU 리스트에서 선택해 수동 매핑하는 패널.
-// product_id 가 다른 경로(가이드 임포터 ⑤ vs 실적 시트 ②)로 등록된 같은 SKU 를 연결.
+// SQL promo.normalize_sku_name(0018) 의 클라이언트 미러 — 추천 정렬용(표시 전용).
+// 실제 매칭 판정은 항상 서버가 한다.
+function normalize(name: string): string {
+  return name
+    .replace(/\([^)]*\)|\[[^\]]*\]/g, "")
+    .replace(/닥터펠리스/g, "")
+    .replace(/[\s\-_·.,/+]/g, "")
+    .toLowerCase();
+}
+
+// 추천 점수: 정규화 동일 > 포함 > 공통 prefix 길이
+function similarity(a: string, b: string): number {
+  const na = normalize(a);
+  const nb = normalize(b);
+  if (!na || !nb) return 0;
+  if (na === nb) return 1000;
+  if (na.includes(nb) || nb.includes(na)) return 500 + Math.min(na.length, nb.length);
+  let i = 0;
+  while (i < Math.min(na.length, nb.length) && na[i] === nb[i]) i++;
+  return i;
+}
+
+// 플랜 ↔ 실적 SKU 매칭 패널 (N6 비교 UX 개편판).
+// - 미매칭 플랜 SKU 마다 행 안에서 바로 실적 SKU 를 골라 연동 (왕복 제거)
+// - 실적 후보는 이름 유사도순 정렬, 최상위 후보 '추천' 표기
+// - 요약은 카드 대신 칩 한 줄, 진단 표는 검색 필터 지원
 export default function SkuMatchPanel({
   promotionId,
   rows,
@@ -34,150 +59,143 @@ export default function SkuMatchPanel({
   mappings: SkuMapping[];
 }) {
   const router = useRouter();
-  const [planPick, setPlanPick] = useState<string>("");
-  const [actualPick, setActualPick] = useState<string>("");
-  const [busy, setBusy] = useState(false);
-  const [err, setErr] = useState<string | null>(null);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [picks, setPicks] = useState<Record<string, string>>({}); // plan pid → actual pid
+  const [query, setQuery] = useState("");
+  const [showAll, setShowAll] = useState(false);
 
   const matched = rows.filter((r) => r.side === "both");
-  const planOnly = rows.filter((r) => r.side === "plan");
-  const actualOnly = rows.filter((r) => r.side === "actual");
+  const planOnly = rows.filter((r) => r.side === "plan" && !r.is_mapped);
+  const actualOnly = rows.filter((r) => r.side === "actual" && !r.is_mapped);
+  const nameOf = useMemo(() => {
+    const m = new Map(rows.map((r) => [r.product_id, r.base_name]));
+    return (pid: string) => m.get(pid) ?? `${pid.slice(0, 8)}…`;
+  }, [rows]);
 
-  const mappingPairs = useMemo(() => {
-    const byPlan = new Map<string, string[]>();
-    for (const m of mappings) {
-      const arr = byPlan.get(m.plan_product_id) ?? [];
-      arr.push(m.actual_product_id);
-      byPlan.set(m.plan_product_id, arr);
-    }
-    return byPlan;
-  }, [mappings]);
-
-  async function addMapping() {
-    if (!planPick || !actualPick) return;
-    setBusy(true);
-    setErr(null);
+  async function addMapping(planPid: string, actualPid: string) {
+    if (!actualPid) return;
+    setBusyKey(planPid);
     const res = await fetch(`/api/promotions/${promotionId}/sku-mappings`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        plan_product_id: planPick,
-        actual_product_id: actualPick,
-      }),
+      body: JSON.stringify({ plan_product_id: planPid, actual_product_id: actualPid }),
     });
-    setBusy(false);
+    setBusyKey(null);
     if (!res.ok) {
       const j = await res.json().catch(() => ({}));
-      setErr(j.error ?? "매핑 추가 실패");
+      toast.error(j.error ?? "연동 실패", {
+        action: { label: "다시 시도", onClick: () => addMapping(planPid, actualPid) },
+      });
       return;
     }
-    setPlanPick("");
-    setActualPick("");
+    toast.success(`${nameOf(planPid)} 연동됨`);
     router.refresh();
   }
 
   async function removeMapping(plan_product_id: string, actual_product_id: string) {
-    setBusy(true);
-    setErr(null);
+    setBusyKey(plan_product_id);
     const res = await fetch(`/api/promotions/${promotionId}/sku-mappings`, {
       method: "DELETE",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ plan_product_id, actual_product_id }),
     });
-    setBusy(false);
+    setBusyKey(null);
     if (!res.ok) {
       const j = await res.json().catch(() => ({}));
-      setErr(j.error ?? "매핑 삭제 실패");
+      toast.error(j.error ?? "해제 실패");
       return;
     }
     router.refresh();
   }
 
-  return (
-    <section className="mt-6">
-      <h2 className="mb-2 text-sm font-semibold text-ink-2">SKU 매칭 진단</h2>
-      <p className="mb-3 text-xs text-ink-4">
-        플랜·실적 시트가 같은 SKU를 서로 다른 품목명/품목코드로 등록하면 자동 매칭이 안 됩니다.
-        아래 양쪽 리스트에서 같은 SKU를 골라 수동 연동하세요. 매칭한 실적은 달성률 집계에 합산됩니다.
-      </p>
+  const filtered = query.trim()
+    ? rows.filter(
+        (r) =>
+          r.base_name.includes(query.trim()) ||
+          (r.dr_code ?? "").includes(query.trim()),
+      )
+    : rows;
 
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-        <Stat label="자동 매칭됨" value={matched.length} tone="ok" />
-        <Stat label="플랜만 (실적 없음)" value={planOnly.length} tone="warn" />
-        <Stat label="실적만 (플랜 없음)" value={actualOnly.length} tone="warn" />
+  return (
+    <section className="mt-5">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold text-ink-2">SKU 매칭</h3>
+        {/* 요약 칩 한 줄 — 큰 카드 3개 대체 */}
+        <div className="flex flex-wrap items-center gap-1.5 text-[11px] font-medium">
+          <span className="rounded-full bg-emerald-50 px-2 py-0.5 text-emerald-700">
+            자동 {matched.filter((r) => !r.is_mapped).length}
+          </span>
+          <span className="rounded-full bg-brand-50 px-2 py-0.5 text-brand-700">
+            수동 {mappings.length}
+          </span>
+          {planOnly.length > 0 && (
+            <span className="rounded-full bg-amber-50 px-2 py-0.5 text-amber-700">
+              플랜 미매칭 {planOnly.length}
+            </span>
+          )}
+          {actualOnly.length > 0 && (
+            <span className="rounded-full bg-soft px-2 py-0.5 text-ink-3">
+              실적 미매칭 {actualOnly.length}
+            </span>
+          )}
+        </div>
       </div>
 
-      {/* 수동 매핑 추가 */}
-      {(planOnly.length > 0 || actualOnly.length > 0) && (
-        <div className="mt-4 rounded-xl p-4 card-soft">
-          <h3 className="mb-2 text-xs font-semibold text-ink-2">수동 매핑 추가</h3>
-          <div className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_auto_1fr_auto]">
-            <select
-              value={planPick}
-              onChange={(e) => setPlanPick(e.target.value)}
-              className="rounded-xl px-3 py-2 text-sm surface-pressed-soft focus:outline-none"
-            >
-              <option value="">플랜 SKU 선택 …</option>
-              {planOnly.map((r) => (
-                <option key={r.product_id} value={r.product_id}>
-                  [{r.dr_code ?? "—"}] {r.base_name}
-                </option>
-              ))}
-            </select>
-            <span className="self-center text-center text-xs text-ink-4">↔</span>
-            <select
-              value={actualPick}
-              onChange={(e) => setActualPick(e.target.value)}
-              className="rounded-xl px-3 py-2 text-sm surface-pressed-soft focus:outline-none"
-            >
-              <option value="">실적 SKU 선택 …</option>
-              {actualOnly.map((r) => (
-                <option key={r.product_id} value={r.product_id}>
-                  [{r.dr_code ?? "—"}] {r.base_name}
-                </option>
-              ))}
-            </select>
-            <button
-              onClick={addMapping}
-              disabled={busy || !planPick || !actualPick}
-              className="rounded-full bg-brand-500 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-600 disabled:opacity-50"
-            >
-              연동
-            </button>
+      {/* 미매칭 플랜 SKU — 행 안에서 바로 연동 */}
+      {planOnly.length > 0 && (
+        <div className="mt-3 overflow-hidden rounded-xl card-soft">
+          <div className="border-b border-line bg-amber-50/50 px-4 py-2.5 text-xs font-medium text-amber-800">
+            플랜에 있는데 실적과 매칭 안 된 SKU {planOnly.length}개 — 행에서 바로
+            실적 SKU를 골라 연동하세요 (추천순 정렬)
           </div>
-          {err && <p className="mt-2 text-xs text-brand-700">{err}</p>}
-        </div>
-      )}
-
-      {/* 현재 매핑 목록 */}
-      {mappings.length > 0 && (
-        <div className="mt-3 rounded-xl p-4 card-soft">
-          <h3 className="mb-2 text-xs font-semibold text-ink-2">
-            현재 매핑 ({mappings.length}건)
-          </h3>
-          <ul className="space-y-1.5 text-xs">
-            {mappings.map((m) => {
-              const planName =
-                rows.find((r) => r.product_id === m.plan_product_id)?.base_name ??
-                m.plan_product_id;
+          <ul className="divide-y divide-line/70">
+            {planOnly.map((p) => {
+              const candidates = [...actualOnly].sort(
+                (a, b) =>
+                  similarity(p.base_name, b.base_name) -
+                  similarity(p.base_name, a.base_name),
+              );
+              const best = candidates[0];
+              const bestScore = best ? similarity(p.base_name, best.base_name) : 0;
+              const pick = picks[p.product_id] ?? (bestScore >= 500 ? best.product_id : "");
               return (
                 <li
-                  key={`${m.plan_product_id}-${m.actual_product_id}`}
-                  className="flex items-center justify-between gap-2"
+                  key={p.product_id}
+                  className="flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center"
                 >
-                  <span className="truncate text-ink-2">
-                    {planName}{" "}
-                    <span className="text-ink-4">
-                      ← actual {m.actual_product_id.slice(0, 8)}…
-                    </span>
-                  </span>
-                  <button
-                    onClick={() => removeMapping(m.plan_product_id, m.actual_product_id)}
-                    disabled={busy}
-                    className="text-xs text-ink-4 hover:text-brand-700"
-                  >
-                    해제
-                  </button>
+                  <div className="min-w-0 sm:w-2/5">
+                    <div className="truncate text-sm text-ink" title={p.base_name}>
+                      {p.base_name}
+                    </div>
+                    <div className="text-[10px] text-ink-4">
+                      {p.dr_code ?? "코드 없음"} · 기대 {num(p.expected_qty)}개 ·{" "}
+                      {wonShort(p.expected_revenue)}
+                    </div>
+                  </div>
+                  <div className="flex min-w-0 flex-1 items-center gap-2">
+                    <select
+                      value={pick}
+                      onChange={(e) =>
+                        setPicks((s) => ({ ...s, [p.product_id]: e.target.value }))
+                      }
+                      className="w-full min-w-0 flex-1 truncate rounded-xl border border-line bg-card px-3 py-2 text-sm text-ink-2 focus:outline-none"
+                    >
+                      <option value="">실적 SKU 선택…</option>
+                      {candidates.map((c, i) => (
+                        <option key={c.product_id} value={c.product_id}>
+                          {i === 0 && bestScore >= 500 ? "★ " : ""}
+                          {c.base_name}
+                        </option>
+                      ))}
+                    </select>
+                    <button
+                      onClick={() => addMapping(p.product_id, pick)}
+                      disabled={!pick || busyKey === p.product_id}
+                      className="shrink-0 rounded-full bg-brand-500 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-600 disabled:opacity-40"
+                    >
+                      {busyKey === p.product_id ? "…" : "연동"}
+                    </button>
+                  </div>
                 </li>
               );
             })}
@@ -185,82 +203,102 @@ export default function SkuMatchPanel({
         </div>
       )}
 
-      {/* SKU 진단 표 */}
-      <div className="mt-3 overflow-x-auto rounded-xl card-soft">
-        <table className="w-full min-w-[640px] text-xs">
-          <thead className="text-left text-ink-4">
-            <tr>
-              <th className="px-3 py-2 font-medium">상태</th>
-              <th className="px-3 py-2 font-medium">SKU</th>
-              <th className="px-3 py-2 text-right font-medium">기대수량</th>
-              <th className="px-3 py-2 text-right font-medium">기대매출</th>
-              <th className="px-3 py-2 text-right font-medium">실수량</th>
-              <th className="px-3 py-2 text-right font-medium">실매출</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((r) => {
-              const linked = (mappingPairs.get(r.product_id)?.length ?? 0) > 0;
-              return (
-                <tr
-                  key={r.product_id}
-                  className="border-t border-[var(--color-line)]/60"
+      {/* 수동 매핑 현황 */}
+      {mappings.length > 0 && (
+        <div className="mt-3 rounded-xl card-soft px-4 py-3">
+          <h4 className="text-xs font-semibold text-ink-2">수동 연동 {mappings.length}건</h4>
+          <ul className="mt-1.5 space-y-1 text-xs">
+            {mappings.map((m) => (
+              <li
+                key={`${m.plan_product_id}-${m.actual_product_id}`}
+                className="flex items-center justify-between gap-2"
+              >
+                <span className="min-w-0 truncate text-ink-2">
+                  {nameOf(m.plan_product_id)}{" "}
+                  <span className="text-ink-4">↔ {nameOf(m.actual_product_id)}</span>
+                </span>
+                <button
+                  onClick={() => removeMapping(m.plan_product_id, m.actual_product_id)}
+                  disabled={busyKey != null}
+                  className="shrink-0 text-[11px] text-ink-4 hover:text-brand-700"
                 >
-                  <td className="px-3 py-2">
-                    <SideBadge side={r.side} isMapped={r.is_mapped || linked} />
-                  </td>
-                  <td className="px-3 py-2">
-                    <div className="text-ink">{r.base_name}</div>
-                    {r.dr_code && (
-                      <div className="text-[10px] text-ink-4">{r.dr_code}</div>
-                    )}
-                  </td>
-                  <td className="px-3 py-2 text-right text-ink-3">
-                    {r.expected_qty ? num(r.expected_qty) : "—"}
-                  </td>
-                  <td className="px-3 py-2 text-right text-ink-3">
-                    {r.expected_revenue ? wonShort(r.expected_revenue) : "—"}
-                  </td>
-                  <td className="px-3 py-2 text-right text-ink-3">
-                    {r.actual_qty ? num(r.actual_qty) : "—"}
-                  </td>
-                  <td className="px-3 py-2 text-right text-ink-3">
-                    {r.actual_revenue ? won(r.actual_revenue) : "—"}
-                  </td>
-                </tr>
-              );
-            })}
-            {rows.length === 0 && (
-              <tr>
-                <td colSpan={6} className="px-3 py-6 text-center text-ink-4">
-                  플랜·실적 모두 없습니다.
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
+                  해제
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* 전체 진단 표 — 접이식 + 검색 */}
+      <div className="mt-3 rounded-xl card-soft">
+        <button
+          onClick={() => setShowAll((v) => !v)}
+          className="flex w-full items-center justify-between px-4 py-3 text-left text-xs font-semibold text-ink-2"
+        >
+          전체 SKU 진단 표 ({rows.length})
+          <span className="text-ink-4">{showAll ? "접기 ▴" : "펼치기 ▾"}</span>
+        </button>
+        {showAll && (
+          <div className="border-t border-line/70 px-4 pb-4">
+            <input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="SKU 이름·코드 검색…"
+              className="mt-3 w-full rounded-xl border border-line bg-card px-3 py-2 text-sm focus:outline-none sm:max-w-xs"
+            />
+            <div className="mt-3 overflow-x-auto">
+              <table className="w-full min-w-[640px] text-xs">
+                <thead className="text-left text-ink-4">
+                  <tr>
+                    <th className="px-2 py-2 font-medium">상태</th>
+                    <th className="px-2 py-2 font-medium">SKU</th>
+                    <th className="px-2 py-2 text-right font-medium">기대수량</th>
+                    <th className="px-2 py-2 text-right font-medium">기대매출</th>
+                    <th className="px-2 py-2 text-right font-medium">실수량</th>
+                    <th className="px-2 py-2 text-right font-medium">실매출</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filtered.map((r) => (
+                    <tr key={r.product_id} className="border-t border-line/60">
+                      <td className="px-2 py-2">
+                        <SideBadge side={r.side} isMapped={r.is_mapped} />
+                      </td>
+                      <td className="px-2 py-2">
+                        <div className="text-ink">{r.base_name}</div>
+                        {r.dr_code && (
+                          <div className="text-[10px] text-ink-4">{r.dr_code}</div>
+                        )}
+                      </td>
+                      <td className="px-2 py-2 text-right text-ink-3">
+                        {r.expected_qty ? num(r.expected_qty) : "—"}
+                      </td>
+                      <td className="px-2 py-2 text-right text-ink-3">
+                        {r.expected_revenue ? wonShort(r.expected_revenue) : "—"}
+                      </td>
+                      <td className="px-2 py-2 text-right text-ink-3">
+                        {r.actual_qty ? num(r.actual_qty) : "—"}
+                      </td>
+                      <td className="px-2 py-2 text-right text-ink-3">
+                        {r.actual_revenue ? won(r.actual_revenue) : "—"}
+                      </td>
+                    </tr>
+                  ))}
+                  {filtered.length === 0 && (
+                    <tr>
+                      <td colSpan={6} className="px-2 py-6 text-center text-ink-4">
+                        {query ? "검색 결과가 없습니다." : "플랜·실적 모두 없습니다."}
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
       </div>
     </section>
-  );
-}
-
-function Stat({
-  label,
-  value,
-  tone,
-}: {
-  label: string;
-  value: number;
-  tone: "ok" | "warn";
-}) {
-  const color = tone === "ok" ? "text-brand-600" : "text-ink-2";
-  return (
-    <div className="rounded-xl p-4 card-soft">
-      <div className="text-[11px] font-semibold uppercase tracking-[1.4px] text-ink-4">
-        {label}
-      </div>
-      <div className={`mt-1 text-2xl font-bold tabular-nums ${color}`}>{value}</div>
-    </div>
   );
 }
 
@@ -271,22 +309,22 @@ function SideBadge({
   side: DiagnosticRow["side"];
   isMapped: boolean;
 }) {
-  if (side === "both") {
+  if (side === "both" || isMapped) {
     return (
-      <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold text-brand-700 surface-pressed-soft">
-        {isMapped ? "매핑됨" : "자동 매칭"}
+      <span className="inline-flex items-center rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] font-semibold text-emerald-700">
+        {isMapped ? "수동 연동" : "자동 매칭"}
       </span>
     );
   }
   if (side === "plan") {
     return (
-      <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold text-ink-3 surface-pressed-soft">
+      <span className="inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-semibold text-amber-700">
         플랜만
       </span>
     );
   }
   return (
-    <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold text-ink-3 surface-pressed-soft">
+    <span className="inline-flex items-center rounded-full bg-soft px-2 py-0.5 text-[10px] font-semibold text-ink-3">
       실적만
     </span>
   );

--- a/promo-analytics/app/(dash)/promotions/[id]/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/page.tsx
@@ -42,6 +42,7 @@ type DetailBundle = {
     actual_promotion_id: string | null;
   } | null;
   candidates: ActualsCandidate[];
+  linked_plans: { plan_id: string; code: string | null; name: string | null; promotion_id: string | null }[];
   option_infos: string[];
   order_count: number;
   mappings: SkuMapping[];
@@ -86,6 +87,10 @@ export default async function PromotionDetail({
   const notes = bundle?.notes ?? [];
   const plan = bundle?.plan ?? null;
   const candidates = bundle?.candidates ?? [];
+  const linkedPlans = bundle?.linked_plans ?? [];
+  const linkedActualName = plan?.actual_promotion_id
+    ? candidates.find((c) => c.id === plan.actual_promotion_id)?.name ?? null
+    : null;
 
   const achSummary = bundle?.rollup?.pva_summary ?? null;
   const achRows = bundle?.rollup?.pva_rows ?? [];
@@ -167,6 +172,33 @@ export default async function PromotionDetail({
         </Link>
       </header>
 
+      {/* 역링크 (N6): 이 캠페인의 실적을 비교 대상으로 쓰는 플랜 안내 —
+          "플랜은 저쪽 캠페인에 있다"를 명시해 어디서 매칭할지 혼란 제거 */}
+      {linkedPlans.length > 0 && (
+        <div className="mb-5 rounded-xl border border-brand-200 bg-brand-50/60 px-4 py-3 text-sm text-ink-2">
+          이 캠페인의 실적은{" "}
+          {linkedPlans.map((lp, i) => (
+            <span key={lp.plan_id}>
+              {i > 0 && ", "}
+              {lp.promotion_id ? (
+                <Link
+                  href={`/promotions/${lp.promotion_id}`}
+                  className="font-semibold text-brand-700 hover:underline"
+                >
+                  {lp.name ?? lp.code} 플랜
+                </Link>
+              ) : (
+                <Link href="/plans" className="font-semibold text-brand-700 hover:underline">
+                  {lp.name ?? lp.code} 플랜
+                </Link>
+              )}
+            </span>
+          ))}
+          의 비교 대상입니다. <strong>플랜 vs 실적 비교·SKU 매칭은 플랜이 있는 캠페인에서</strong>{" "}
+          진행하세요.
+        </div>
+      )}
+
       {!hasBaseline && (
         <div className="mb-5 rounded-lg bg-amber-50 px-4 py-3 text-sm text-amber-800">
           직전 8주 baseline 데이터가 부족합니다. <strong>일별 매출 추이</strong>를
@@ -230,7 +262,14 @@ export default async function PromotionDetail({
                 · 예상 매출 {won(plan.expected_revenue_total)} · 예상 공헌이익{" "}
                 {won(plan.expected_contribution_total)}
               </p>
-            ) : (
+            ) : null}
+            {plan && plan.status !== "confirmed" && (
+              <p className="mt-1 text-xs text-amber-700">
+                draft 상태 — 플랜을 <strong>확정</strong>해야 달성률 집계와 홈 페이싱
+                알림에 포함됩니다. (플랜 편집 → 확정)
+              </p>
+            )}
+            {!plan && (
               <p className="mt-1 text-sm text-neutral-500">
                 아직 플랜이 없습니다. 옵션(다중 SKU 묶음)·예상 세트수로 예상 성과를 미리
                 계산하세요.
@@ -273,10 +312,18 @@ export default async function PromotionDetail({
               중복 캠페인이 있나요? 병합 도구 →
             </Link>
           </div>
-          <p className="mt-1 text-xs text-neutral-400">
-            플랜이 비교할 실적 캠페인과 SKU 매칭을 여기서 한 번에 끝내세요. 연동이 끝나면
-            아래 달성률이 자동으로 채워집니다.
-          </p>
+          {linkedActualName ? (
+            <p className="mt-1 text-xs text-ink-3">
+              비교 구도: <strong className="text-ink">이 캠페인의 플랜</strong> ↔{" "}
+              <strong className="text-brand-700">{linkedActualName}</strong> 실적 —
+              아래 달성률·SKU 매칭이 모두 이 구도 기준으로 계산됩니다.
+            </p>
+          ) : (
+            <p className="mt-1 text-xs text-neutral-400">
+              플랜이 비교할 실적 캠페인과 SKU 매칭을 여기서 한 번에 끝내세요. 연동이 끝나면
+              아래 달성률이 자동으로 채워집니다.
+            </p>
+          )}
           {plan && (
             <ActualsLink
               promotionId={id}

--- a/promo-analytics/supabase/migrations/0027_detail_linked_plans.sql
+++ b/promo-analytics/supabase/migrations/0027_detail_linked_plans.sql
@@ -1,0 +1,61 @@
+-- 0027: 상세 번들에 역링크 추가 — 이 캠페인을 '비교 대상 실적'으로 쓰는 플랜 목록.
+-- 실적 캠페인 상세에서 "플랜은 저쪽에 있다"를 안내해 멘탈 모델 분열 해소.
+-- (플랜 ↔ 실적이 서로 다른 캠페인일 때, 실적 쪽 SKU 진단이 '실적만 N'으로만
+--  보이던 혼란의 원인 — 진단·매칭은 플랜이 붙은 캠페인에서 수행해야 함)
+create or replace function promo.promotion_detail_bundle(p_id uuid)
+returns jsonb
+language plpgsql
+set search_path = ''
+as $$
+declare result jsonb;
+begin
+  perform promo.ensure_rollups_fresh();
+  select jsonb_build_object(
+    'promo',  (select to_jsonb(p.*) from promo.promotions p where p.id = p_id),
+    'rollup', (select to_jsonb(r.*) from promo.campaign_rollups r where r.promotion_id = p_id),
+    'notes',
+      (select coalesce(jsonb_agg(to_jsonb(n.*) order by n.created_at desc), '[]'::jsonb)
+       from promo.promotion_notes n where n.promotion_id = p_id),
+    'plan',
+      (select to_jsonb(cp.*) from promo.campaign_plans cp
+       where cp.promotion_id = p_id and cp.is_current limit 1),
+    'linked_plans',
+      coalesce((select jsonb_agg(jsonb_build_object(
+         'plan_id', pl.id,
+         'code', pl.code,
+         'name', coalesce(pl.name, pr2.name, pl.code),
+         'promotion_id', pl.promotion_id))
+       from promo.campaign_plans pl
+       left join promo.promotions pr2 on pr2.id = pl.promotion_id
+       where pl.is_current and pl.actual_promotion_id = p_id), '[]'::jsonb),
+    'candidates',
+      (select coalesce(jsonb_agg(to_jsonb(c.*)), '[]'::jsonb)
+       from promo.campaigns_with_actuals() c),
+    'option_infos',
+      (select coalesce(jsonb_agg(distinct ps.option_info), '[]'::jsonb)
+       from promo.promotion_sales ps
+       where ps.promotion_id = p_id and ps.option_info is not null
+         and length(trim(ps.option_info)) > 0),
+    'order_count',
+      (select coalesce(sum(ps.order_count), 0)
+       from promo.promotion_sales ps where ps.promotion_id = p_id),
+    'mappings',
+      (select coalesce(jsonb_agg(jsonb_build_object(
+         'plan_product_id', m.plan_product_id,
+         'actual_product_id', m.actual_product_id)), '[]'::jsonb)
+       from promo.promotion_sku_mappings m where m.promotion_id = p_id),
+    'weights',
+      (select coalesce(jsonb_agg(to_jsonb(w.*)), '[]'::jsonb)
+       from promo.effective_purpose_weights(p_id) w),
+    'sources',
+      coalesce((select jsonb_agg(to_jsonb(u.*) order by u.created_at desc)
+        from promo.upload_log u, promo.promotions p2
+        where p2.id = p_id and p2.code is not null
+          and u.codes is not null and p2.code = any(u.codes)), '[]'::jsonb)
+  ) into result;
+  return result;
+end;
+$$;
+
+grant execute on all functions in schema promo to authenticated;
+notify pgrst, 'reload schema';


### PR DESCRIPTION
모바일 스크린샷 피드백 반영 — 플랜·실적 비교/분석의 사용성 전면 개편.

## 1. 멘탈 모델 통합 (가장 큰 혼란 해소)
스크린샷의 "실적만 48 / 플랜만 0" 화면은 **실적 캠페인(CF_P_260518)에서 진단을 보고 있었기 때문** — 플랜은 CF_P_260511에 있습니다. 수정:
- **역링크 배너**: 실적 캠페인 상단에 "이 캠페인의 실적은 CF_P_260511 플랜의 비교 대상입니다. 비교·SKU 매칭은 플랜이 있는 캠페인에서 진행하세요" + 원클릭 이동 (마이그레이션 0027, DB 적용 완료)
- **비교 구도 명시**: 연동 센터에 "이 캠페인의 플랜 ↔ {실적 캠페인명} 실적" 한 줄 — 지금 무엇과 무엇을 비교 중인지 항상 보임

## 2. SKU 매칭 전면 재작성
- 거대 숫자 카드 3개 → **요약 칩 한 줄** (자동 N · 수동 N · 플랜 미매칭 N · 실적 미매칭 N)
- **행 단위 인라인 연동**: 미매칭 플랜 SKU마다 그 행에서 실적 SKU 선택 → 연동. 별도 패널 왕복 제거
- **유사도 추천**: 실적 후보를 이름 유사도순 정렬(서버 정규화 로직 미러), 고신뢰 후보 ★ + 자동 프리셀렉트 — 대부분 "연동 버튼만 누르면" 되는 수준
- 수동 연동 목록에 실적 SKU **이름** 표시 (기존: uuid 조각)
- 전체 진단 표는 접이식 + 이름·코드 검색
- 연동/해제 결과 토스트 피드백

## 3. 모바일 레이아웃 수정 (스크린샷 깨짐)
- 셀렉트 오버플로(화면 이탈) 수정 — SkuMatchPanel·ActualsLink 모두 `w-full min-w-0` + 세로 스택
- CampaignTrend 모바일 높이 축소, 입력류 플랫 보더 스타일 통일
- draft 플랜에 "확정해야 달성률·페이싱에 포함" 안내

next build 통과.

https://claude.ai/code/session_01JDEWhEszHRLfEdSo18ej1w

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDEWhEszHRLfEdSo18ej1w)_