### PR TITLE
fix: 업로드 직후 전면 먹통 — 읽기 경로에서 동기 재계산 제거

### DIFF
--- a/promo-analytics/app/(dash)/page.tsx
+++ b/promo-analytics/app/(dash)/page.tsx
@@ -57,6 +57,7 @@ type DashboardBundle = {
   }[];
   overall: OverallMetrics | null;
   purpose_metrics: PurposeMetric[];
+  meta: { stale: boolean; refreshed_at: string | null } | null;
 };
 
 export default async function Dashboard() {
@@ -64,6 +65,7 @@ export default async function Dashboard() {
   const { data: bundleData } = await supabase.rpc("dashboard_bundle");
   const bundle = ((bundleData as DashboardBundle | null) ??
     {}) as Partial<DashboardBundle>;
+  const stale = bundle.meta?.stale ?? false;
   const promos = bundle.promotions ?? [];
   const achData = (bundle.rollups ?? [])
     .map((r) => r.achievement)
@@ -283,6 +285,14 @@ export default async function Dashboard() {
           성과 시뮬레이터 →
         </Link>
       </header>
+
+      {stale && (
+        <div className="mb-5 flex items-center gap-2 rounded-xl border border-amber-200 bg-amber-50/60 px-4 py-2.5 text-xs text-amber-800">
+          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-amber-500" />
+          방금 업로드·연동한 데이터로 분석을 갱신하는 중입니다. 아래 수치는 직전 기준이며
+          1~2분 내 자동 반영됩니다.
+        </div>
+      )}
 
       {/* AI 인사이트 */}
       {best?.summary && (

--- a/promo-analytics/supabase/migrations/0028_read_path_no_refresh.sql
+++ b/promo-analytics/supabase/migrations/0028_read_path_no_refresh.sql
@@ -1,0 +1,133 @@
+-- 0028: 읽기 경로에서 동기 재계산 제거 (업로드 직후 전면 먹통 방지)
+--
+-- 사고: 실적 업로드 → 롤업 dirty → 대시보드/히스토리/매칭이 각각 읽기 경로에서
+-- refresh_rollups(~6.7s)를 동기 실행, 차단 락 앞에 줄서며 업로드 프리웜까지 겹쳐
+-- statement_timeout 초과 → 번들 RPC 동시 에러 → 대시보드 빈 화면 · 히스토리
+-- 캠페인 0 · 매칭 에러. (cron 이 뒤늦게 갱신하며 저절로 복구됐던 증상)
+--
+-- 원칙: 읽기는 절대 재계산을 트리거하지 않는다. 항상 서빙 테이블만 즉시 읽는다
+-- (트랜잭션 격리로 재계산 중에도 이전 스냅샷이 보이므로 빈 결과 없음). 재계산은
+-- (1) 업로드 직후 프리웜, (2) pg_cron 안전망(2분)으로만.
+--
+-- 추가: lost-update 안전을 위해 dirty(boolean) → version 카운터. 트리거가 version
+-- 증가, 재계산은 시작 시점 버전을 캡처해 끝에 built_version 기록. 재계산 도중 들어온
+-- 변경은 version > built_version 으로 남아 다음 주기에 반영. 차단 락 →
+-- pg_try_advisory_xact_lock(논블로킹)으로 줄서기 제거. (cron 주기 5→2분: 0028 적용 시
+-- cron.schedule('promo-refresh-rollups','*/2 * * * *', ...) 로 재등록)
+
+alter table promo.rollup_state add column if not exists version       bigint not null default 0;
+alter table promo.rollup_state add column if not exists built_version bigint not null default -1;
+update promo.rollup_state set version = greatest(version, built_version + 1) where dirty;
+
+create or replace function promo.mark_rollups_dirty()
+returns trigger language plpgsql security definer set search_path = '' as $$
+begin
+  update promo.rollup_state set version = version + 1, dirty = true where id;
+  return null;
+end;
+$$;
+
+create or replace function promo.refresh_rollups(p_force boolean default false)
+returns void language plpgsql set search_path = '' as $$
+declare
+  v_now bigint;
+  v_built bigint;
+begin
+  if not pg_try_advisory_xact_lock(hashtext('promo.refresh_rollups')) then
+    return; -- 다른 재계산 진행 중 → 즉시 반환(줄서기 없음)
+  end if;
+  select version, built_version into v_now, v_built from promo.rollup_state where id;
+  if not p_force and v_now <= coalesce(v_built, -1) then
+    return; -- 이미 최신
+  end if;
+
+  delete from promo.campaign_rollups;
+  with feats as (select * from promo.all_campaign_features()),
+       achs  as (select * from promo.campaign_achievements()),
+       fits  as (
+         select f.promotion_id, jsonb_agg(to_jsonb(f.*)) as j
+         from promo.campaign_fits() f group by f.promotion_id
+       ),
+       meas  as (
+         select pr.id as pid,
+                coalesce(jsonb_agg(to_jsonb(m.*)) filter (where m.product_id is not null),
+                         '[]'::jsonb) as j
+         from promo.promotions pr
+         left join lateral promo.promotion_measurement(pr.id) m on true
+         group by pr.id
+       ),
+       pvas  as (
+         select pr.id as pid,
+           (select to_jsonb(s.*) from promo.plan_vs_actual_summary(pr.id) s limit 1) as s_j,
+           (select coalesce(jsonb_agg(to_jsonb(r.*)), '[]'::jsonb)
+              from promo.plan_vs_actual(pr.id) r) as r_j,
+           (select coalesce(jsonb_agg(to_jsonb(o.*)), '[]'::jsonb)
+              from promo.plan_vs_actual_options(pr.id) o) as o_j,
+           (select coalesce(jsonb_agg(to_jsonb(d.*)), '[]'::jsonb)
+              from promo.sku_match_diagnostic(pr.id) d) as d_j
+         from promo.promotions pr
+       ),
+       daily as (
+         select pr.id as pid,
+                coalesce(jsonb_agg(jsonb_build_object(
+                           'd', d.sale_date, 'rev', d.rev,
+                           'in', (d.sale_date between pr.start_date and pr.end_date))
+                                   order by d.sale_date)
+                         filter (where d.sale_date is not null), '[]'::jsonb) as j
+         from promo.promotions pr
+         left join lateral (
+           select ds.sale_date, sum(ds.revenue) as rev
+           from promo.daily_sales ds
+           where ds.sale_date between pr.start_date - 56 and pr.end_date
+           group by ds.sale_date
+         ) d on true
+         group by pr.id
+       )
+  insert into promo.campaign_rollups
+    (promotion_id, features, achievement, fits, measurement,
+     pva_summary, pva_rows, pva_options, diagnostic, daily, refreshed_at)
+  select pr.id,
+         to_jsonb(f.*), to_jsonb(a.*),
+         coalesce(ft.j, '[]'::jsonb), coalesce(m.j, '[]'::jsonb),
+         p.s_j, coalesce(p.r_j, '[]'::jsonb), coalesce(p.o_j, '[]'::jsonb),
+         coalesce(p.d_j, '[]'::jsonb), coalesce(dy.j, '[]'::jsonb), now()
+  from promo.promotions pr
+  left join feats f on f.promotion_id = pr.id
+  left join achs  a on a.promotion_id = pr.id
+  left join fits  ft on ft.promotion_id = pr.id
+  left join meas  m on m.pid = pr.id
+  left join pvas  p on p.pid = pr.id
+  left join daily dy on dy.pid = pr.id;
+
+  insert into promo.global_rollups (key, payload, refreshed_at)
+  values
+    ('overall',
+     (select to_jsonb(o.*) from promo.overall_baseline_metrics() o limit 1), now()),
+    ('purpose_metrics',
+     (select coalesce(jsonb_agg(to_jsonb(pm.*)), '[]'::jsonb) from promo.purpose_metrics() pm), now())
+  on conflict (key) do update
+    set payload = excluded.payload, refreshed_at = excluded.refreshed_at;
+
+  update promo.rollup_state
+    set built_version = v_now,
+        dirty = (version > v_now),
+        refreshed_at = now()
+  where id;
+end;
+$$;
+
+create or replace function promo.ensure_rollups_fresh()
+returns void language plpgsql set search_path = '' as $$
+begin
+  if exists (select 1 from promo.rollup_state where id and version > built_version) then
+    perform promo.refresh_rollups();
+  end if;
+end;
+$$;
+
+grant execute on all functions in schema promo to authenticated;
+
+-- cron 주기 2분 재등록
+select cron.unschedule('promo-refresh-rollups')
+where exists (select 1 from cron.job where jobname = 'promo-refresh-rollups');
+select cron.schedule('promo-refresh-rollups', '*/2 * * * *', $$select promo.refresh_rollups();$$);

--- a/promo-analytics/supabase/migrations/0028b_bundles_pure_read.sql
+++ b/promo-analytics/supabase/migrations/0028b_bundles_pure_read.sql
@@ -1,0 +1,133 @@
+-- 0028b: 번들 RPC 4종 — ensure_rollups_fresh() 호출 제거(순수 읽기) + meta(stale/refreshed_at).
+-- 읽기가 더 이상 재계산을 트리거하지 않으므로 업로드 직후에도 즉시 응답(직전 데이터 + 갱신중 표시).
+create or replace function promo.dashboard_bundle()
+returns jsonb language plpgsql set search_path = '' as $$
+declare result jsonb;
+begin
+  select jsonb_build_object(
+    'promotions',
+      (select coalesce(jsonb_agg(to_jsonb(p.*) order by p.start_date desc), '[]'::jsonb)
+       from promo.promotions p),
+    'rollups',
+      (select coalesce(jsonb_agg(jsonb_build_object(
+         'promotion_id', r.promotion_id, 'features', r.features, 'achievement', r.achievement)), '[]'::jsonb)
+       from promo.campaign_rollups r),
+    'overall',
+      (select g.payload from promo.global_rollups g where g.key = 'overall'),
+    'purpose_metrics',
+      coalesce((select g.payload from promo.global_rollups g where g.key = 'purpose_metrics'), '[]'::jsonb),
+    'meta',
+      (select jsonb_build_object('stale', (version > built_version), 'refreshed_at', refreshed_at)
+       from promo.rollup_state where id)
+  ) into result;
+  return result;
+end;
+$$;
+
+create or replace function promo.library_bundle()
+returns jsonb language plpgsql set search_path = '' as $$
+declare result jsonb;
+begin
+  select jsonb_build_object(
+    'promotions',
+      (select coalesce(jsonb_agg(to_jsonb(p.*) order by p.start_date desc), '[]'::jsonb)
+       from promo.promotions p),
+    'rollups',
+      (select coalesce(jsonb_agg(jsonb_build_object(
+         'promotion_id', r.promotion_id, 'features', r.features, 'achievement', r.achievement,
+         'fits', r.fits, 'daily', r.daily)), '[]'::jsonb)
+       from promo.campaign_rollups r),
+    'meta',
+      (select jsonb_build_object('stale', (version > built_version), 'refreshed_at', refreshed_at)
+       from promo.rollup_state where id)
+  ) into result;
+  return result;
+end;
+$$;
+
+create or replace function promo.plans_bundle()
+returns jsonb language plpgsql set search_path = '' as $$
+declare result jsonb;
+begin
+  select jsonb_build_object(
+    'plans',
+      coalesce((select jsonb_agg(jsonb_build_object(
+         'id', pl.id, 'code', pl.code, 'name', coalesce(pl.name, pr.name),
+         'start_date', coalesce(pl.start_date, pr.start_date),
+         'end_date', coalesce(pl.end_date, pr.end_date),
+         'channel', pl.channel, 'status', pl.status, 'version', pl.version,
+         'confirmed_at', pl.confirmed_at,
+         'target_revenue', coalesce(pl.target_revenue, pl.expected_revenue_total),
+         'target_contribution', coalesce(pl.target_contribution, pl.expected_contribution_total),
+         'target_contribution_rate', pl.target_contribution_rate,
+         'promotion_id', pl.promotion_id, 'promotion_name', pr.name,
+         'actual_promotion_id', pl.actual_promotion_id, 'actual_name', pa.name,
+         'option_count', (select count(*) from promo.campaign_plan_options o where o.campaign_plan_id = pl.id),
+         'achievement', (select r.achievement from promo.campaign_rollups r where r.promotion_id = pl.promotion_id)
+       ) order by coalesce(pl.start_date, pr.start_date) desc nulls last)
+       from promo.campaign_plans pl
+       left join promo.promotions pr on pr.id = pl.promotion_id
+       left join promo.promotions pa on pa.id = pl.actual_promotion_id
+       where pl.is_current), '[]'::jsonb),
+    'options',
+      coalesce((select jsonb_agg(jsonb_build_object(
+         'plan_id', o.campaign_plan_id, 'is_main', o.is_main,
+         'discount_consumer', o.discount_rate_consumer, 'discount_regular', o.discount_rate_regular,
+         'set_price', o.set_price, 'expected_qty', o.expected_option_qty, 'expected_revenue', o.expected_revenue))
+       from promo.campaign_plan_options o
+       join promo.campaign_plans pl on pl.id = o.campaign_plan_id and pl.is_current), '[]'::jsonb),
+    'meta',
+      (select jsonb_build_object('stale', (version > built_version), 'refreshed_at', refreshed_at)
+       from promo.rollup_state where id)
+  ) into result;
+  return result;
+end;
+$$;
+
+create or replace function promo.promotion_detail_bundle(p_id uuid)
+returns jsonb language plpgsql set search_path = '' as $$
+declare result jsonb;
+begin
+  select jsonb_build_object(
+    'promo',  (select to_jsonb(p.*) from promo.promotions p where p.id = p_id),
+    'rollup', (select to_jsonb(r.*) from promo.campaign_rollups r where r.promotion_id = p_id),
+    'notes',
+      (select coalesce(jsonb_agg(to_jsonb(n.*) order by n.created_at desc), '[]'::jsonb)
+       from promo.promotion_notes n where n.promotion_id = p_id),
+    'plan',
+      (select to_jsonb(cp.*) from promo.campaign_plans cp where cp.promotion_id = p_id and cp.is_current limit 1),
+    'linked_plans',
+      coalesce((select jsonb_agg(jsonb_build_object(
+         'plan_id', pl.id, 'code', pl.code,
+         'name', coalesce(pl.name, pr2.name, pl.code), 'promotion_id', pl.promotion_id))
+       from promo.campaign_plans pl
+       left join promo.promotions pr2 on pr2.id = pl.promotion_id
+       where pl.is_current and pl.actual_promotion_id = p_id), '[]'::jsonb),
+    'candidates',
+      (select coalesce(jsonb_agg(to_jsonb(c.*)), '[]'::jsonb) from promo.campaigns_with_actuals() c),
+    'option_infos',
+      (select coalesce(jsonb_agg(distinct ps.option_info), '[]'::jsonb)
+       from promo.promotion_sales ps
+       where ps.promotion_id = p_id and ps.option_info is not null and length(trim(ps.option_info)) > 0),
+    'order_count',
+      (select coalesce(sum(ps.order_count), 0) from promo.promotion_sales ps where ps.promotion_id = p_id),
+    'mappings',
+      (select coalesce(jsonb_agg(jsonb_build_object(
+         'plan_product_id', m.plan_product_id, 'actual_product_id', m.actual_product_id)), '[]'::jsonb)
+       from promo.promotion_sku_mappings m where m.promotion_id = p_id),
+    'weights',
+      (select coalesce(jsonb_agg(to_jsonb(w.*)), '[]'::jsonb) from promo.effective_purpose_weights(p_id) w),
+    'sources',
+      coalesce((select jsonb_agg(to_jsonb(u.*) order by u.created_at desc)
+        from promo.upload_log u, promo.promotions p2
+        where p2.id = p_id and p2.code is not null and u.codes is not null and p2.code = any(u.codes)), '[]'::jsonb),
+    'meta',
+      (select jsonb_build_object('stale', (version > built_version), 'refreshed_at', refreshed_at)
+       from promo.rollup_state where id)
+  ) into result;
+  return result;
+end;
+$$;
+
+grant execute on all functions in schema promo to authenticated;
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## 증상
Better Habits 실적 업로드 직후 **대시보드 빈 화면 · 히스토리 캠페인 0개 · 플랜-실적 매칭 에러**가 동시 발생. (스크린샷)

## 원인 — 데이터는 멀쩡, 읽기 경로가 무너진 것
DB 확인 결과 캠페인 25개·실적 5,604행 모두 정상 적재됨. 문제는 구조:
- 번들 RPC(dashboard/library/detail/plans)가 **읽기 경로 안에서 `refresh_rollups`(~6.7초)를 동기 실행**
- 업로드로 롤업이 dirty 된 직후 여러 페이지를 오가면 각 요청이 **차단 락(blocking advisory lock) 앞에 줄서고**, 업로드 자체의 프리웜까지 겹쳐 `statement_timeout(30s)` 초과
- → 번들 RPC가 동시에 에러 → 대시보드는 빈 데이터(EmptyState), 히스토리는 캠페인 0, 매칭은 에러 바운더리
- cron이 5분 뒤 갱신을 끝내며 저절로 복구되던 것 (재현성 있는 일시 장애)

## 수정 (마이그레이션 0028 / 0028b, 운영 DB 적용·검증 완료)
1. **읽기는 재계산을 절대 트리거하지 않음** — 모든 번들에서 `ensure_rollups_fresh()` 제거. 서빙 테이블만 즉시 읽음(트랜잭션 격리 덕에 재계산 중에도 직전 스냅샷이 보여 빈 결과 없음). 번들 응답 ~5ms.
2. **재계산 경합 안전화**: `dirty` boolean → `version` 카운터(재계산 도중 들어온 변경을 잃지 않음), 차단 락 → `pg_try_advisory_xact_lock`(논블로킹, 줄서기 제거).
3. 재계산은 **업로드 프리웜 + pg_cron(5→2분)**으로만.
4. 번들에 `meta(stale, refreshed_at)` 추가 + 대시보드에 "분석 갱신 중" 안내 배너 — 업로드 직후 직전 수치를 보여주되 갱신 중임을 명시.

## 검증
dirty 상태를 강제한 뒤에도 번들이 **3ms에 캠페인 25개를 정상 반환**(stale=true). 더 이상 빈 화면/타임아웃 없음.

## 참고 (별개 사항)
업로드한 `CF_P_260608` 실적이 기존 플랜 캠페인 `CF_P_260608_BETTER HABITS`와 **다른 코드라 새 캠페인으로 생성**됨(벌크업과 같은 플랜/실적 분리). 비교하려면 플랜 캠페인의 연동 센터에서 비교 대상을 이 실적으로 지정하면 됩니다. 데이터 초기화는 불필요.

https://claude.ai/code/session_01JDEWhEszHRLfEdSo18ej1w

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDEWhEszHRLfEdSo18ej1w)_