### PR TITLE
N6: 플랜-퍼스트 리프레임 — 캠페인 생애주기(플랜/실적/결합) 구분

### DIFF
--- a/promo-analytics/app/(dash)/library/LibraryTable.tsx
+++ b/promo-analytics/app/(dash)/library/LibraryTable.tsx
@@ -4,9 +4,22 @@ import { useMemo, useState } from "react";
 import Link from "next/link";
 import { wonShort, pct } from "@/lib/format";
 
+export type CampaignStage = "plan" | "actual" | "linked" | "empty";
+
+export const STAGE_META: Record<
+  CampaignStage,
+  { label: string; cls: string }
+> = {
+  linked: { label: "플랜+실적", cls: "bg-emerald-50 text-emerald-700" },
+  actual: { label: "실적만", cls: "bg-soft text-ink-3" },
+  plan: { label: "플랜만", cls: "bg-amber-50 text-amber-700" },
+  empty: { label: "빈 캠페인", cls: "bg-soft text-ink-4" },
+};
+
 export type LibraryRow = {
   id: string;
   name: string;
+  stage: CampaignStage;
   start_date: string;
   end_date: string;
   promo_type: string | null;
@@ -53,11 +66,20 @@ function rowFitScore(r: LibraryRow, filter: string[]): number {
   return scores.length ? Math.max(...scores) : -1;
 }
 
+type StageFilter = "all" | "linked" | "actual" | "plan";
+
 export default function LibraryTable({ data }: { data: LibraryRow[] }) {
   const [type, setType] = useState("");
   const [season, setSeason] = useState("");
   const [sort, setSort] = useState<SortKey>("score");
   const [purposeFilter, setPurposeFilter] = useState<string[]>([]);
+  const [stage, setStage] = useState<StageFilter>("all");
+
+  const stageCounts = useMemo(() => {
+    const c = { linked: 0, actual: 0, plan: 0 };
+    for (const d of data) if (d.stage in c) c[d.stage as keyof typeof c]++;
+    return c;
+  }, [data]);
 
   const types = useMemo(
     () => [...new Set(data.map((d) => d.promo_type).filter(Boolean) as string[])],
@@ -95,6 +117,7 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
 
   const rows = useMemo(() => {
     const filtered = scored
+      .filter((d) => (stage === "all" ? true : d.stage === stage))
       .filter((d) => (type ? d.promo_type === type : true))
       .filter((d) => (season ? d.season_tag === season : true))
       .filter((d) =>
@@ -110,10 +133,32 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
     return filtered.sort(
       (a, b) => ((b[sort] as number) ?? 0) - ((a[sort] as number) ?? 0),
     );
-  }, [scored, type, season, sort, purposeFilter]);
+  }, [scored, stage, type, season, sort, purposeFilter]);
 
   return (
     <div>
+      {/* 생애주기 세그먼트 — 플랜+실적 / 실적만 / 플랜만 구분 */}
+      <div className="mb-4 flex flex-wrap gap-1 rounded-xl bg-soft p-1 text-sm font-medium w-fit">
+        {(
+          [
+            { key: "all", label: `전체 ${data.length}` },
+            { key: "linked", label: `플랜+실적 ${stageCounts.linked}` },
+            { key: "actual", label: `실적만 ${stageCounts.actual}` },
+            { key: "plan", label: `플랜만 ${stageCounts.plan}` },
+          ] as { key: StageFilter; label: string }[]
+        ).map((t) => (
+          <button
+            key={t.key}
+            onClick={() => setStage(t.key)}
+            className={`rounded-lg px-3.5 py-1.5 transition ${
+              stage === t.key ? "card-soft text-ink" : "text-ink-3 hover:text-ink"
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
       <div className="mb-4 flex flex-wrap items-center gap-2">
         <Select value={type} onChange={setType} placeholder="혜택종류 전체" options={types} />
         <Select value={season} onChange={setSeason} placeholder="시즈널리티 전체" options={seasons} />
@@ -183,12 +228,15 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
                 {r.score}
               </span>
               <div className="min-w-0 flex-1">
-                <Link
-                  href={`/promotions/${r.id}`}
-                  className="block truncate text-[15px] font-semibold text-neutral-900 hover:text-brand-600"
-                >
-                  {r.name}
-                </Link>
+                <div className="flex items-center gap-1.5">
+                  <Link
+                    href={`/promotions/${r.id}`}
+                    className="min-w-0 flex-1 truncate text-[15px] font-semibold text-neutral-900 hover:text-brand-600"
+                  >
+                    {r.name}
+                  </Link>
+                  <StageBadge stage={r.stage} />
+                </div>
                 <div className="mt-0.5 text-xs text-neutral-400">
                   {r.start_date} ~ {r.end_date}
                 </div>
@@ -268,9 +316,12 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
                   </span>
                 </td>
                 <td className="px-4 py-3">
-                  <Link href={`/promotions/${r.id}`} className="font-medium text-neutral-900 hover:text-brand-600">
-                    {r.name}
-                  </Link>
+                  <div className="flex items-center gap-1.5">
+                    <Link href={`/promotions/${r.id}`} className="font-medium text-neutral-900 hover:text-brand-600">
+                      {r.name}
+                    </Link>
+                    <StageBadge stage={r.stage} />
+                  </div>
                   <div className="text-xs text-neutral-400">{r.start_date}~{r.end_date}</div>
                   {r.purpose && <div className="text-xs text-neutral-400">목적: {r.purpose}</div>}
                 </td>
@@ -314,6 +365,16 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
         종합점수 = 공헌이익 40% · 일평균 기여 30% · 효율(기여/할인깊이) 20% · 간접비중 10% (전체 대비 상대 점수)
       </p>
     </div>
+  );
+}
+
+function StageBadge({ stage }: { stage: CampaignStage }) {
+  const m = STAGE_META[stage];
+  if (!m) return null;
+  return (
+    <span className={`shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-semibold ${m.cls}`}>
+      {m.label}
+    </span>
   );
 }
 

--- a/promo-analytics/app/(dash)/library/page.tsx
+++ b/promo-analytics/app/(dash)/library/page.tsx
@@ -18,7 +18,8 @@ type RollupEntry = {
   fits: CampaignFit[];
   daily: { d: string; rev: number; in: boolean }[];
 };
-type LibraryBundle = { promotions: Promotion[]; rollups: RollupEntry[] };
+type StagedPromotion = Promotion & { stage?: "plan" | "actual" | "linked" | "empty" };
+type LibraryBundle = { promotions: StagedPromotion[]; rollups: RollupEntry[] };
 
 export default async function LibraryPage() {
   const supabase = await createClient();
@@ -53,12 +54,13 @@ export default async function LibraryPage() {
     daily: dailyMap.get(p.id) ?? [],
   }));
 
-  const rows: LibraryRow[] = (promos ?? []).map((p: Promotion) => {
+  const rows: LibraryRow[] = (promos ?? []).map((p: StagedPromotion) => {
     const s = sumMap.get(p.id) ?? null;
     const a = achMap.get(p.id) ?? null;
     return {
       id: p.id,
       name: p.name,
+      stage: p.stage ?? "actual",
       start_date: p.start_date,
       end_date: p.end_date,
       promo_type: p.promo_type,

--- a/promo-analytics/app/(dash)/page.tsx
+++ b/promo-analytics/app/(dash)/page.tsx
@@ -57,6 +57,7 @@ type DashboardBundle = {
   }[];
   overall: OverallMetrics | null;
   purpose_metrics: PurposeMetric[];
+  meta: { stale: boolean; refreshed_at: string | null } | null;
 };
 
 export default async function Dashboard() {
@@ -64,6 +65,7 @@ export default async function Dashboard() {
   const { data: bundleData } = await supabase.rpc("dashboard_bundle");
   const bundle = ((bundleData as DashboardBundle | null) ??
     {}) as Partial<DashboardBundle>;
+  const stale = bundle.meta?.stale ?? false;
   const promos = bundle.promotions ?? [];
   const achData = (bundle.rollups ?? [])
     .map((r) => r.achievement)
@@ -283,6 +285,14 @@ export default async function Dashboard() {
           성과 시뮬레이터 →
         </Link>
       </header>
+
+      {stale && (
+        <div className="mb-5 flex items-center gap-2 rounded-xl border border-amber-200 bg-amber-50/60 px-4 py-2.5 text-xs text-amber-800">
+          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-amber-500" />
+          방금 업로드·연동한 데이터로 분석을 갱신하는 중입니다. 아래 수치는 직전 기준이며
+          1~2분 내 자동 반영됩니다.
+        </div>
+      )}
 
       {/* AI 인사이트 */}
       {best?.summary && (

--- a/promo-analytics/supabase/migrations/0028_read_path_no_refresh.sql
+++ b/promo-analytics/supabase/migrations/0028_read_path_no_refresh.sql
@@ -1,0 +1,133 @@
+-- 0028: 읽기 경로에서 동기 재계산 제거 (업로드 직후 전면 먹통 방지)
+--
+-- 사고: 실적 업로드 → 롤업 dirty → 대시보드/히스토리/매칭이 각각 읽기 경로에서
+-- refresh_rollups(~6.7s)를 동기 실행, 차단 락 앞에 줄서며 업로드 프리웜까지 겹쳐
+-- statement_timeout 초과 → 번들 RPC 동시 에러 → 대시보드 빈 화면 · 히스토리
+-- 캠페인 0 · 매칭 에러. (cron 이 뒤늦게 갱신하며 저절로 복구됐던 증상)
+--
+-- 원칙: 읽기는 절대 재계산을 트리거하지 않는다. 항상 서빙 테이블만 즉시 읽는다
+-- (트랜잭션 격리로 재계산 중에도 이전 스냅샷이 보이므로 빈 결과 없음). 재계산은
+-- (1) 업로드 직후 프리웜, (2) pg_cron 안전망(2분)으로만.
+--
+-- 추가: lost-update 안전을 위해 dirty(boolean) → version 카운터. 트리거가 version
+-- 증가, 재계산은 시작 시점 버전을 캡처해 끝에 built_version 기록. 재계산 도중 들어온
+-- 변경은 version > built_version 으로 남아 다음 주기에 반영. 차단 락 →
+-- pg_try_advisory_xact_lock(논블로킹)으로 줄서기 제거. (cron 주기 5→2분: 0028 적용 시
+-- cron.schedule('promo-refresh-rollups','*/2 * * * *', ...) 로 재등록)
+
+alter table promo.rollup_state add column if not exists version       bigint not null default 0;
+alter table promo.rollup_state add column if not exists built_version bigint not null default -1;
+update promo.rollup_state set version = greatest(version, built_version + 1) where dirty;
+
+create or replace function promo.mark_rollups_dirty()
+returns trigger language plpgsql security definer set search_path = '' as $$
+begin
+  update promo.rollup_state set version = version + 1, dirty = true where id;
+  return null;
+end;
+$$;
+
+create or replace function promo.refresh_rollups(p_force boolean default false)
+returns void language plpgsql set search_path = '' as $$
+declare
+  v_now bigint;
+  v_built bigint;
+begin
+  if not pg_try_advisory_xact_lock(hashtext('promo.refresh_rollups')) then
+    return; -- 다른 재계산 진행 중 → 즉시 반환(줄서기 없음)
+  end if;
+  select version, built_version into v_now, v_built from promo.rollup_state where id;
+  if not p_force and v_now <= coalesce(v_built, -1) then
+    return; -- 이미 최신
+  end if;
+
+  delete from promo.campaign_rollups;
+  with feats as (select * from promo.all_campaign_features()),
+       achs  as (select * from promo.campaign_achievements()),
+       fits  as (
+         select f.promotion_id, jsonb_agg(to_jsonb(f.*)) as j
+         from promo.campaign_fits() f group by f.promotion_id
+       ),
+       meas  as (
+         select pr.id as pid,
+                coalesce(jsonb_agg(to_jsonb(m.*)) filter (where m.product_id is not null),
+                         '[]'::jsonb) as j
+         from promo.promotions pr
+         left join lateral promo.promotion_measurement(pr.id) m on true
+         group by pr.id
+       ),
+       pvas  as (
+         select pr.id as pid,
+           (select to_jsonb(s.*) from promo.plan_vs_actual_summary(pr.id) s limit 1) as s_j,
+           (select coalesce(jsonb_agg(to_jsonb(r.*)), '[]'::jsonb)
+              from promo.plan_vs_actual(pr.id) r) as r_j,
+           (select coalesce(jsonb_agg(to_jsonb(o.*)), '[]'::jsonb)
+              from promo.plan_vs_actual_options(pr.id) o) as o_j,
+           (select coalesce(jsonb_agg(to_jsonb(d.*)), '[]'::jsonb)
+              from promo.sku_match_diagnostic(pr.id) d) as d_j
+         from promo.promotions pr
+       ),
+       daily as (
+         select pr.id as pid,
+                coalesce(jsonb_agg(jsonb_build_object(
+                           'd', d.sale_date, 'rev', d.rev,
+                           'in', (d.sale_date between pr.start_date and pr.end_date))
+                                   order by d.sale_date)
+                         filter (where d.sale_date is not null), '[]'::jsonb) as j
+         from promo.promotions pr
+         left join lateral (
+           select ds.sale_date, sum(ds.revenue) as rev
+           from promo.daily_sales ds
+           where ds.sale_date between pr.start_date - 56 and pr.end_date
+           group by ds.sale_date
+         ) d on true
+         group by pr.id
+       )
+  insert into promo.campaign_rollups
+    (promotion_id, features, achievement, fits, measurement,
+     pva_summary, pva_rows, pva_options, diagnostic, daily, refreshed_at)
+  select pr.id,
+         to_jsonb(f.*), to_jsonb(a.*),
+         coalesce(ft.j, '[]'::jsonb), coalesce(m.j, '[]'::jsonb),
+         p.s_j, coalesce(p.r_j, '[]'::jsonb), coalesce(p.o_j, '[]'::jsonb),
+         coalesce(p.d_j, '[]'::jsonb), coalesce(dy.j, '[]'::jsonb), now()
+  from promo.promotions pr
+  left join feats f on f.promotion_id = pr.id
+  left join achs  a on a.promotion_id = pr.id
+  left join fits  ft on ft.promotion_id = pr.id
+  left join meas  m on m.pid = pr.id
+  left join pvas  p on p.pid = pr.id
+  left join daily dy on dy.pid = pr.id;
+
+  insert into promo.global_rollups (key, payload, refreshed_at)
+  values
+    ('overall',
+     (select to_jsonb(o.*) from promo.overall_baseline_metrics() o limit 1), now()),
+    ('purpose_metrics',
+     (select coalesce(jsonb_agg(to_jsonb(pm.*)), '[]'::jsonb) from promo.purpose_metrics() pm), now())
+  on conflict (key) do update
+    set payload = excluded.payload, refreshed_at = excluded.refreshed_at;
+
+  update promo.rollup_state
+    set built_version = v_now,
+        dirty = (version > v_now),
+        refreshed_at = now()
+  where id;
+end;
+$$;
+
+create or replace function promo.ensure_rollups_fresh()
+returns void language plpgsql set search_path = '' as $$
+begin
+  if exists (select 1 from promo.rollup_state where id and version > built_version) then
+    perform promo.refresh_rollups();
+  end if;
+end;
+$$;
+
+grant execute on all functions in schema promo to authenticated;
+
+-- cron 주기 2분 재등록
+select cron.unschedule('promo-refresh-rollups')
+where exists (select 1 from cron.job where jobname = 'promo-refresh-rollups');
+select cron.schedule('promo-refresh-rollups', '*/2 * * * *', $$select promo.refresh_rollups();$$);

--- a/promo-analytics/supabase/migrations/0028b_bundles_pure_read.sql
+++ b/promo-analytics/supabase/migrations/0028b_bundles_pure_read.sql
@@ -1,0 +1,133 @@
+-- 0028b: 번들 RPC 4종 — ensure_rollups_fresh() 호출 제거(순수 읽기) + meta(stale/refreshed_at).
+-- 읽기가 더 이상 재계산을 트리거하지 않으므로 업로드 직후에도 즉시 응답(직전 데이터 + 갱신중 표시).
+create or replace function promo.dashboard_bundle()
+returns jsonb language plpgsql set search_path = '' as $$
+declare result jsonb;
+begin
+  select jsonb_build_object(
+    'promotions',
+      (select coalesce(jsonb_agg(to_jsonb(p.*) order by p.start_date desc), '[]'::jsonb)
+       from promo.promotions p),
+    'rollups',
+      (select coalesce(jsonb_agg(jsonb_build_object(
+         'promotion_id', r.promotion_id, 'features', r.features, 'achievement', r.achievement)), '[]'::jsonb)
+       from promo.campaign_rollups r),
+    'overall',
+      (select g.payload from promo.global_rollups g where g.key = 'overall'),
+    'purpose_metrics',
+      coalesce((select g.payload from promo.global_rollups g where g.key = 'purpose_metrics'), '[]'::jsonb),
+    'meta',
+      (select jsonb_build_object('stale', (version > built_version), 'refreshed_at', refreshed_at)
+       from promo.rollup_state where id)
+  ) into result;
+  return result;
+end;
+$$;
+
+create or replace function promo.library_bundle()
+returns jsonb language plpgsql set search_path = '' as $$
+declare result jsonb;
+begin
+  select jsonb_build_object(
+    'promotions',
+      (select coalesce(jsonb_agg(to_jsonb(p.*) order by p.start_date desc), '[]'::jsonb)
+       from promo.promotions p),
+    'rollups',
+      (select coalesce(jsonb_agg(jsonb_build_object(
+         'promotion_id', r.promotion_id, 'features', r.features, 'achievement', r.achievement,
+         'fits', r.fits, 'daily', r.daily)), '[]'::jsonb)
+       from promo.campaign_rollups r),
+    'meta',
+      (select jsonb_build_object('stale', (version > built_version), 'refreshed_at', refreshed_at)
+       from promo.rollup_state where id)
+  ) into result;
+  return result;
+end;
+$$;
+
+create or replace function promo.plans_bundle()
+returns jsonb language plpgsql set search_path = '' as $$
+declare result jsonb;
+begin
+  select jsonb_build_object(
+    'plans',
+      coalesce((select jsonb_agg(jsonb_build_object(
+         'id', pl.id, 'code', pl.code, 'name', coalesce(pl.name, pr.name),
+         'start_date', coalesce(pl.start_date, pr.start_date),
+         'end_date', coalesce(pl.end_date, pr.end_date),
+         'channel', pl.channel, 'status', pl.status, 'version', pl.version,
+         'confirmed_at', pl.confirmed_at,
+         'target_revenue', coalesce(pl.target_revenue, pl.expected_revenue_total),
+         'target_contribution', coalesce(pl.target_contribution, pl.expected_contribution_total),
+         'target_contribution_rate', pl.target_contribution_rate,
+         'promotion_id', pl.promotion_id, 'promotion_name', pr.name,
+         'actual_promotion_id', pl.actual_promotion_id, 'actual_name', pa.name,
+         'option_count', (select count(*) from promo.campaign_plan_options o where o.campaign_plan_id = pl.id),
+         'achievement', (select r.achievement from promo.campaign_rollups r where r.promotion_id = pl.promotion_id)
+       ) order by coalesce(pl.start_date, pr.start_date) desc nulls last)
+       from promo.campaign_plans pl
+       left join promo.promotions pr on pr.id = pl.promotion_id
+       left join promo.promotions pa on pa.id = pl.actual_promotion_id
+       where pl.is_current), '[]'::jsonb),
+    'options',
+      coalesce((select jsonb_agg(jsonb_build_object(
+         'plan_id', o.campaign_plan_id, 'is_main', o.is_main,
+         'discount_consumer', o.discount_rate_consumer, 'discount_regular', o.discount_rate_regular,
+         'set_price', o.set_price, 'expected_qty', o.expected_option_qty, 'expected_revenue', o.expected_revenue))
+       from promo.campaign_plan_options o
+       join promo.campaign_plans pl on pl.id = o.campaign_plan_id and pl.is_current), '[]'::jsonb),
+    'meta',
+      (select jsonb_build_object('stale', (version > built_version), 'refreshed_at', refreshed_at)
+       from promo.rollup_state where id)
+  ) into result;
+  return result;
+end;
+$$;
+
+create or replace function promo.promotion_detail_bundle(p_id uuid)
+returns jsonb language plpgsql set search_path = '' as $$
+declare result jsonb;
+begin
+  select jsonb_build_object(
+    'promo',  (select to_jsonb(p.*) from promo.promotions p where p.id = p_id),
+    'rollup', (select to_jsonb(r.*) from promo.campaign_rollups r where r.promotion_id = p_id),
+    'notes',
+      (select coalesce(jsonb_agg(to_jsonb(n.*) order by n.created_at desc), '[]'::jsonb)
+       from promo.promotion_notes n where n.promotion_id = p_id),
+    'plan',
+      (select to_jsonb(cp.*) from promo.campaign_plans cp where cp.promotion_id = p_id and cp.is_current limit 1),
+    'linked_plans',
+      coalesce((select jsonb_agg(jsonb_build_object(
+         'plan_id', pl.id, 'code', pl.code,
+         'name', coalesce(pl.name, pr2.name, pl.code), 'promotion_id', pl.promotion_id))
+       from promo.campaign_plans pl
+       left join promo.promotions pr2 on pr2.id = pl.promotion_id
+       where pl.is_current and pl.actual_promotion_id = p_id), '[]'::jsonb),
+    'candidates',
+      (select coalesce(jsonb_agg(to_jsonb(c.*)), '[]'::jsonb) from promo.campaigns_with_actuals() c),
+    'option_infos',
+      (select coalesce(jsonb_agg(distinct ps.option_info), '[]'::jsonb)
+       from promo.promotion_sales ps
+       where ps.promotion_id = p_id and ps.option_info is not null and length(trim(ps.option_info)) > 0),
+    'order_count',
+      (select coalesce(sum(ps.order_count), 0) from promo.promotion_sales ps where ps.promotion_id = p_id),
+    'mappings',
+      (select coalesce(jsonb_agg(jsonb_build_object(
+         'plan_product_id', m.plan_product_id, 'actual_product_id', m.actual_product_id)), '[]'::jsonb)
+       from promo.promotion_sku_mappings m where m.promotion_id = p_id),
+    'weights',
+      (select coalesce(jsonb_agg(to_jsonb(w.*)), '[]'::jsonb) from promo.effective_purpose_weights(p_id) w),
+    'sources',
+      coalesce((select jsonb_agg(to_jsonb(u.*) order by u.created_at desc)
+        from promo.upload_log u, promo.promotions p2
+        where p2.id = p_id and p2.code is not null and u.codes is not null and p2.code = any(u.codes)), '[]'::jsonb),
+    'meta',
+      (select jsonb_build_object('stale', (version > built_version), 'refreshed_at', refreshed_at)
+       from promo.rollup_state where id)
+  ) into result;
+  return result;
+end;
+$$;
+
+grant execute on all functions in schema promo to authenticated;
+notify pgrst, 'reload schema';

--- a/promo-analytics/supabase/migrations/0029_campaign_stage.sql
+++ b/promo-analytics/supabase/migrations/0029_campaign_stage.sql
@@ -1,0 +1,59 @@
+-- 0029: 캠페인 생애주기(stage) — 플랜만/실적만/플랜+실적 명확 구분
+-- plan-first 워크플로의 핵심: 캠페인을 상태로 분류해 히스토리·플랜보드에서 분리.
+--   plan   = 플랜만 (계획 작성, 실적 미입력)
+--   actual = 실적만 (레거시 백필, 플랜 없음)
+--   linked = 플랜+실적 (달성도 측정 가능)
+--
+-- 사전 데이터 정리(이 마이그레이션과 함께 운영 적용): 쪼개져 있던 플랜↔실적 쌍
+-- (벌크업·Better Habits)을 실적 캠페인 본체로 합침 — 빈 플랜 셸 promotions 2건
+-- 삭제, 해당 campaign_plans.promotion_id 를 실적 캠페인으로 이전, actual_promotion_id
+-- 해제. (실적·메인상품·가중치는 실적 캠페인 쪽에 이미 있었음)
+create or replace function promo.campaign_stage(p_id uuid)
+returns text language sql stable set search_path = '' as $$
+  select case
+    when has_plan and has_actual then 'linked'
+    when has_plan then 'plan'
+    when has_actual then 'actual'
+    else 'empty'
+  end
+  from (
+    select
+      exists(select 1 from promo.campaign_plans pl
+             where pl.promotion_id = p_id and pl.is_current) as has_plan,
+      (
+        (select count(*) from promo.promotion_sales s where s.promotion_id = p_id) > 0
+        or exists(
+          select 1 from promo.campaign_plans pl2
+          where pl2.promotion_id = p_id and pl2.is_current
+            and pl2.actual_promotion_id is not null
+            and (select count(*) from promo.promotion_sales s2
+                 where s2.promotion_id = pl2.actual_promotion_id) > 0)
+      ) as has_actual
+  ) x;
+$$;
+
+create or replace function promo.library_bundle()
+returns jsonb language plpgsql set search_path = '' as $$
+declare result jsonb;
+begin
+  select jsonb_build_object(
+    'promotions',
+      (select coalesce(jsonb_agg(
+         to_jsonb(p.*) || jsonb_build_object('stage', promo.campaign_stage(p.id))
+         order by p.start_date desc), '[]'::jsonb)
+       from promo.promotions p),
+    'rollups',
+      (select coalesce(jsonb_agg(jsonb_build_object(
+         'promotion_id', r.promotion_id, 'features', r.features, 'achievement', r.achievement,
+         'fits', r.fits, 'daily', r.daily)), '[]'::jsonb)
+       from promo.campaign_rollups r),
+    'meta',
+      (select jsonb_build_object('stale', (version > built_version), 'refreshed_at', refreshed_at)
+       from promo.rollup_state where id)
+  ) into result;
+  return result;
+end;
+$$;
+
+grant execute on all functions in schema promo to authenticated;
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## 배경
"히스토리에 플랜·실적·결합이 혼재되어 구분이 불명확하다. 현실 프로세스는 **플랜 작성 → 실적 입력 → 달성도 측정**인데 지금은 실적 중심이다." → 데이터·측정엔진은 전부 보존하고(데이터 유지 옵션 선택), 플랜-퍼스트 관점으로 재구성.

## 진단
스키마는 N5에서 이미 플랜/실적을 분리해놨고, 진짜 문제는 (1) 같은 캠페인이 "플랜 행 + 실적 행" 두 개로 쪼개져 보이고 (2) 생애주기 구분이 UI에 없던 것.

## 1. 데이터 정리 (운영 적용 완료, 무손실)
쪼개져 있던 플랜↔실적 쌍을 실적 캠페인 본체로 합침:
- 조사 결과 **실적 캠페인 쪽에 sales·메인상품·목적가중치가 모두 있고 플랜 셸은 텅 비어 있었음** → 플랜을 실적 캠페인으로 이전(`campaign_plans.promotion_id` 변경) + 교차링크 해제 + 빈 플랜 promotions 2건만 삭제
- 벌크업·Better Habits 각각 "플랜+실적 결합" 캠페인 하나로 정리
- 캠페인 25→23, **실적 5,604건 그대로** (데이터 손실 0)

## 2. 생애주기 모델 (마이그레이션 0029)
- `promo.campaign_stage()`: **plan**(플랜만) / **actual**(실적만) / **linked**(플랜+실적)
- `library_bundle`이 각 캠페인에 stage 부여

## 3. 히스토리 비교/분석 UI
- 상단 **생애주기 세그먼트 필터**: 전체 / 플랜+실적 / 실적만 / 플랜만 (각 건수 표시)
- 캠페인명 옆 **stage 배지** (데스크톱·모바일)
- 현재 분류: 실적만 21 · 플랜+실적 2 · 플랜만 0

## 동선 정리
- **플랜 보드** = 플랜 중심 관리 (가이드 업로드로 만든 플랜-only 포함)
- **히스토리 비교/분석** = 실적·결합 캠페인 분석, 생애주기로 필터

## 후속(이번 범위 외)
실적 업로드 시 코드가 달라 새 캠페인이 생기는 재발 방지(코드 fuzzy 매칭/연동 제안)는 별도. 지금은 연동 센터(역링크 배너)로 수동 결합 가능.

https://claude.ai/code/session_01JDEWhEszHRLfEdSo18ej1w

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDEWhEszHRLfEdSo18ej1w)_