### PR TITLE
N7 P1: 매칭/플랜옵션 모델 기반 (pack_size · 구성 시그니처 · 다구성 적재)

### DIFF
--- a/HANDOFF_N7.md
+++ b/HANDOFF_N7.md
@@ -14,7 +14,7 @@
 - **작업 브랜치**: `claude/n5-plan-separation-10ikew` (계속 이 브랜치 사용). main에 squash 머지 반복 중.
 - **Supabase**: project_id `mlbtnnchbpctgjjawkue` (이름 "ryuhowoo-CXdashboard"), 스키마 **`promo`**.
   - 마이그레이션은 MCP `apply_migration`으로 **운영 DB에 직접 적용** + 같은 SQL을 `promo-analytics/supabase/migrations/000N_*.sql` 파일로 커밋(이중 기록).
-  - 현재 최신 마이그레이션: **0029_campaign_stage**. 다음은 0030부터.
+  - 현재 최신 마이그레이션: **0030_n7_matching_model** (N7 P1, 적용·커밋 완료). 다음은 0031부터.
 - **Vercel**: project `df-promo-dsbd`, team `team_NakdS71OJZl5NgmF18BQ2ZGb`, 프로덕션 `https://df-promo-dsbd.vercel.app`. PR마다 프리뷰 자동 빌드.
 - **PR 흐름**: 브랜치 푸시 → GitHub MCP로 draft PR → Vercel Ready 웹훅 확인 → squash 머지 → `git fetch origin main && git reset --hard origin/main`로 동기화.
 
@@ -47,6 +47,15 @@
 3. `parsePlanGuide.ts`: '구성(품목코드:수량,…)' 컬럼 있으면 components로 파싱, 없으면 현행 단품+혼합행 추론. 임포터가 items 다건 insert.
 4. 적재 후 `refresh_rollups(true)` + 번들 검증.
 → 이후 P2(달성 계산: SKU 1차/옵션 부가 RPC 재작성) → P3(UI: 구성·묶음 표시, 매칭 패널 SKU/옵션 탭) → P4(오염 옵션 보정/재임포트).
+
+### P1 진행 상황 (2026-06-15 완료)
+- 작업 브랜치: `claude/confident-dijkstra-d8zx86` (이 세션 지정 브랜치 — 핸드오프의 n5-plan-separation 과 다름).
+- **마이그레이션 0030_n7_matching_model** (운영 DB 적용 + 파일 커밋, 비파괴):
+  - `promotion_sales.pack_size int` + `promo.parse_pack(text)`(묶음수 best-effort: %·기간·중량 토큰 제거 후 첫 묶음단위(박스/개입/팩/…) 앞 숫자; 포/스틱/P 등 내용물단위 제외) + 과거 5,604행 백필(null 0). 신규/변경행은 BEFORE 트리거 자동 채움.
+  - `campaign_plan_options.option_signature`(구성=품목+개입수 정렬 md5) + `display_label`(구성×개입수 + 세트가 — 2개입/6개입 구분). `campaign_plan_option_items` 변경 시 AFTER 트리거가 두 파생값 재계산. 기존 38옵션 백필.
+- **임포터**(`lib/parsePlanGuide.ts` + `upload/page.tsx`): '구성'(품목코드:수량,…) 컬럼 파싱 → `components[]`. 없으면 현행 단품 1건 폴백. 커밋 시 옵션당 컴포넌트 N건 item insert(부분매칭 허용, set_price를 수량비중으로 SKU단가 환산).
+- 적재 후 `refresh_rollups(true)` 강제 + `rollup_state` fresh 확인(version=built_version). 기존 달성 RPC는 pack_size 미참조 → 현재 수치 불변.
+- **P2 시작점**: `plan_vs_actual`/`plan_vs_actual_options`(0018·이후)에서 실적 SKU 수량을 `quantity × pack_size`로 환산해 플랜 SKU 단위와 정합. 옵션 달성은 `option_signature` 기준 best-effort.
 
 ## 7. 확정된 설계 결정 (N7 §8 요약)
 1. 달성도 1차 진실 = **SKU(품목) 단위**, 옵션(묶음)은 부가 best-effort (실적 자유텍스트라 묶음 완전매칭 불가).

--- a/promo-analytics/app/(dash)/upload/page.tsx
+++ b/promo-analytics/app/(dash)/upload/page.tsx
@@ -1188,7 +1188,9 @@ function PlanGuideImportCard() {
       setP({ phase: "uploading", message: "품목 매칭 중…" });
 
       const allOptions = camps.flatMap((c) => c.options);
-      const itemCodes = [...new Set(allOptions.map((o) => o.item_code).filter(Boolean))];
+      // N7: 옵션은 1..N 구성(컴포넌트)으로 — 품목코드 기준 매칭, 단품은 옵션명 폴백
+      const allComps = allOptions.flatMap((o) => o.components);
+      const itemCodes = [...new Set(allComps.map((cp) => cp.item_code).filter(Boolean))];
       const byDr = new Map<string, { id: string; base_name: string }>();
       if (itemCodes.length > 0) {
         const { data } = await supabase
@@ -1201,22 +1203,25 @@ function PlanGuideImportCard() {
       }
       const needNames = [
         ...new Set(
-          allOptions
-            .filter((o) => !(o.item_code && byDr.has(o.item_code)))
-            .map((o) => o.option_label),
+          allComps
+            .filter((cp) => !(cp.item_code && byDr.has(cp.item_code)) && cp.name)
+            .map((cp) => cp.name),
         ),
       ];
       const byName =
         needNames.length > 0
           ? await productsLib.ensureProducts(supabase, needNames)
           : new Map<string, string>();
-      const resolve = (o: (typeof allOptions)[number]) => {
-        if (o.item_code && byDr.has(o.item_code)) {
-          const m = byDr.get(o.item_code)!;
+      const resolveComp = (comp: { item_code: string; name: string; qty: number }) => {
+        if (comp.item_code && byDr.has(comp.item_code)) {
+          const m = byDr.get(comp.item_code)!;
           return { product_id: m.id, base_name: m.base_name };
         }
-        const id = byName.get(o.option_label);
-        return id ? { product_id: id, base_name: o.option_label } : null;
+        if (comp.name) {
+          const id = byName.get(comp.name);
+          if (id) return { product_id: id, base_name: comp.name };
+        }
+        return null;
       };
 
       let created = 0,
@@ -1266,8 +1271,11 @@ function PlanGuideImportCard() {
           let revTotal = 0,
             contribTotal = 0;
           for (const [idx, o] of camp.options.entries()) {
-            const prod = resolve(o);
-            if (!prod) {
+            // 구성 컴포넌트별 SKU 매칭 — 하나라도 잡히면 진행(부분 매칭 허용), 전무하면 실패
+            const resolved = o.components
+              .map((comp) => ({ qty: comp.qty, prod: resolveComp(comp) }))
+              .filter((x) => x.prod !== null);
+            if (resolved.length === 0) {
               failed++;
               continue;
             }
@@ -1304,15 +1312,19 @@ function PlanGuideImportCard() {
               .select("id")
               .single();
             if (oErr) throw oErr;
-            const { error: iErr } = await supabase.from("campaign_plan_option_items").insert({
+            // set_price(번들 합계)를 구성 수량 비중으로 SKU 단가 환산
+            const totalQty = resolved.reduce((s, x) => s + (x.qty || 0), 0) || 1;
+            const items = resolved.map((x, si) => ({
               campaign_plan_option_id: newOpt.id,
-              product_id: prod.product_id,
-              base_name: prod.base_name,
-              sku_qty_per_option: o.pack_count,
-              // set_price는 번들 합계 → SKU 단가로 환산
-              unit_sale_price: o.pack_count > 0 ? o.set_price / o.pack_count : o.set_price,
-              sort: 0,
-            });
+              product_id: x.prod!.product_id,
+              base_name: x.prod!.base_name,
+              sku_qty_per_option: x.qty,
+              unit_sale_price: o.set_price > 0 ? o.set_price / totalQty : o.set_price,
+              sort: si,
+            }));
+            const { error: iErr } = await supabase
+              .from("campaign_plan_option_items")
+              .insert(items);
             if (iErr) throw iErr;
           }
           await supabase

--- a/promo-analytics/lib/parsePlanGuide.ts
+++ b/promo-analytics/lib/parsePlanGuide.ts
@@ -3,11 +3,19 @@ import * as XLSX from "xlsx";
 // 표준 '캠페인 플랜 가이드' 양식 파서 — 평평한 한 표(1행 = 옵션 1개).
 // 가이드(가설) → 캠페인 플랜(예상)으로 적재하기 위한 입력.
 
+// 한 옵션을 구성하는 단일 SKU(품목) 1건. 단품 옵션은 components 길이 1, 혼합 옵션은 N.
+export type PlanComponent = {
+  item_code: string; // 품목코드 (products.dr_code 매칭 키). 없으면 name 으로 매칭.
+  name: string; // 이름 폴백 (단품 옵션명 등). 구성 컬럼에서 온 경우 빈 문자열.
+  qty: number; // 이 SKU 의 옵션당 수량 (sku_qty_per_option)
+};
+
 export type PlanGuideOption = {
   product_code: string; // 상품코드
   item_code: string; // 품목코드 (products.dr_code 매칭 키)
   option_label: string; // 상품명(옵션명, 개입수 포함)
   pack_count: number; // 개입수 (옵션명에서 파싱)
+  components: PlanComponent[]; // N7: 구성(다구성 지원). 단품이면 1건.
   expected_qty: number; // 수량(예상 판매수량, 옵션)
   consumer_price: number;
   cost: number;
@@ -77,6 +85,23 @@ function findCol(header: unknown[], cands: string[]): number {
   for (let i = 0; i < normed.length; i++)
     if (cands.some((c) => normed[i].includes(norm(c)) && normed[i] !== "")) return i;
   return -1;
+}
+
+// '구성' 컬럼 파싱 (A안): "품목코드:수량, 품목코드:수량" → 컴포넌트 배열.
+// 구분자 관용: 항목 = 콤마/세미콜론/줄바꿈, 코드↔수량 = ':' '*' 'x' '×' '@'. 수량 생략 시 1.
+function parseComponents(raw: unknown): PlanComponent[] {
+  const s = String(raw ?? "").trim();
+  if (!s) return [];
+  const out: PlanComponent[] = [];
+  for (const part of s.split(/[,;\n]+/)) {
+    const seg = part.trim();
+    if (!seg) continue;
+    const m = seg.match(/^(.+?)\s*[:*x×@]\s*([\d.]+)\s*$/i);
+    const code = (m ? m[1] : seg).trim();
+    const qty = m ? Math.max(1, toNum(m[2]) || 1) : 1;
+    if (code) out.push({ item_code: code, name: "", qty });
+  }
+  return out;
 }
 
 // 옵션명에서 개입수(번들 SKU 수) 추정: [4팩], 2박스, 6팩, N입/개/묶음/구성 → N. 없으면 1.
@@ -149,6 +174,7 @@ export function parsePlanGuide(buf: ArrayBuffer): PlanGuideCampaign[] {
     pcode: findCol(H, ["상품코드"]),
     icode: findCol(H, ["품목코드"]),
     name: findCol(H, ["상품명", "옵션명"]),
+    components: findCol(H, ["구성", "구성품", "구성내역", "구성품목"]),
     qty: qtyIdx,
     pack: packIdx,
     consumer: findCol(H, ["소비자가"]),
@@ -187,11 +213,20 @@ export function parsePlanGuide(buf: ArrayBuffer): PlanGuideCampaign[] {
     const contribRate = c.contribRate >= 0 ? toNum(r[c.contribRate]) : 0;
 
     const packVal = c.pack >= 0 ? toNum(r[c.pack]) : 0;
+    const pack_count = packVal > 0 ? packVal : packFromName(name);
+    const item_code = c.icode >= 0 ? String(r[c.icode] ?? "").trim() : "";
+    // 구성 컬럼이 있고 값이 있으면 다구성으로, 없으면 현행 단품(품목코드 또는 옵션명) 1건.
+    const parsed = c.components >= 0 ? parseComponents(r[c.components]) : [];
+    const components: PlanComponent[] =
+      parsed.length > 0
+        ? parsed
+        : [{ item_code, name: item_code ? "" : name, qty: pack_count }];
     const opt: PlanGuideOption = {
       product_code: c.pcode >= 0 ? String(r[c.pcode] ?? "").trim() : "",
-      item_code: c.icode >= 0 ? String(r[c.icode] ?? "").trim() : "",
+      item_code,
       option_label: name,
-      pack_count: packVal > 0 ? packVal : packFromName(name),
+      pack_count,
+      components,
       expected_qty: toNum(r[c.qty]),
       consumer_price: consumer,
       cost: toNum(r[c.cost]),

--- a/promo-analytics/supabase/migrations/0030_n7_matching_model.sql
+++ b/promo-analytics/supabase/migrations/0030_n7_matching_model.sql
@@ -1,0 +1,148 @@
+-- 0030: N7 P1 — 매칭/플랜옵션 모델 기반 (비파괴: add column + 신규함수 위주, 멱등)
+--
+-- N7 설계(§6 P1, §7~8): 측정엔진·데이터는 보존하고 "매칭/플랜옵션" 레이어만 교체.
+-- 이 마이그레이션은 P1(모델/적재 기반)만 담당 — 달성 계산(P2)·UI(P3)는 후속.
+--
+-- (1) promotion_sales.pack_size  : 실적 "묶음수"(개입/팩/박스) 를 구조화.
+--     실적 option_info 는 자유텍스트라 묶음 완전매칭은 불가 → best-effort 파싱(§8.1/8.3).
+-- (2) campaign_plan_options.option_signature : 구성(품목+개입수) 시그니처 = 옵션 식별 키(§8.2).
+--     campaign_plan_options.display_label     : 구성+개입수+세트가 기반 표시 라벨(라벨 단독 금지, §8.2).
+--     (campaign_plan_option_items 는 이미 1옵션:N아이템 구조 → 다구성 지원은 구조적으로 존재.
+--      여기서는 파생값이 다구성에서 올바르게 계산되도록 함수/트리거만 확립.)
+--
+-- 기존 달성 RPC(plan_vs_actual 등)는 pack_size 를 아직 참조하지 않음 → 현재 수치 불변.
+
+-- ── (1) parse_pack: option_info → 묶음수(best-effort) ─────────────────────
+-- 규칙: %·기간(개월/달)·중량(kg/g/ml) 토큰을 먼저 제거한 뒤, 첫 "묶음 단위"
+--       (박스/개입/팩/묶음/세트/병/캔/봉/입/개) 앞 숫자를 채택. 없으면 1.
+--       포/스틱/P 등 "내용물 단위"는 묶음이 아니므로 제외("1개월/30포" → 30 오인 방지).
+create or replace function promo.parse_pack(txt text)
+returns int
+language sql
+immutable
+parallel safe
+set search_path = ''
+as $$
+  with cleaned as (
+    select regexp_replace(
+      regexp_replace(
+        regexp_replace(lower(coalesce(txt, '')), '[0-9]+\s*%', '', 'g'),
+        '[0-9]+\s*(개월|달)', '', 'g'),
+      '[0-9]+(\.[0-9]+)?\s*(kg|g|ml)\b', '', 'g'
+    ) as c
+  )
+  select greatest(1, coalesce(
+    (regexp_match((select c from cleaned),
+       '([0-9]+)\s*(박스|개입|팩|묶음|세트|병|캔|봉|입|개)'))[1]::int,
+    1));
+$$;
+
+alter table promo.promotion_sales
+  add column if not exists pack_size int;
+
+-- 신규/변경 실적행은 트리거가 pack_size 자동 채움 (적재 경로 코드변경 의존 제거)
+create or replace function promo.set_promotion_sales_pack()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  if tg_op = 'INSERT' then
+    if new.pack_size is null then
+      new.pack_size := promo.parse_pack(new.option_info);
+    end if;
+  elsif new.option_info is distinct from old.option_info then
+    new.pack_size := promo.parse_pack(new.option_info);
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists promotion_sales_pack_size on promo.promotion_sales;
+create trigger promotion_sales_pack_size
+  before insert or update on promo.promotion_sales
+  for each row execute function promo.set_promotion_sales_pack();
+
+-- 과거분 백필 (option_info 불변 → 위 트리거가 덮어쓰지 않음)
+update promo.promotion_sales
+   set pack_size = promo.parse_pack(option_info)
+ where pack_size is null;
+
+-- ── (2) 플랜옵션 파생: option_signature / display_label ───────────────────
+alter table promo.campaign_plan_options
+  add column if not exists option_signature text,
+  add column if not exists display_label text;
+
+-- 구성 시그니처: (품목, 개입수) 집합의 정렬 해시. 같은 구성 = 같은 옵션(2개입/6개입은 다름).
+create or replace function promo.compute_option_signature(p_option_id uuid)
+returns text
+language sql
+stable
+set search_path = ''
+as $$
+  select md5(coalesce(string_agg(
+      coalesce(i.product_id::text, '?') || ':' || i.sku_qty_per_option::text,
+      '|' order by coalesce(i.product_id::text, ''), i.sku_qty_per_option), ''))
+  from promo.campaign_plan_option_items i
+  where i.campaign_plan_option_id = p_option_id;
+$$;
+
+-- 표시 라벨: 구성(품목×개입수) + 세트가. 라벨 단독으로는 2개입/6개입 구분 불가(핵심 불만) → 구조에서 재구성.
+create or replace function promo.compute_option_display_label(p_option_id uuid)
+returns text
+language sql
+stable
+set search_path = ''
+as $$
+  with parts as (
+    select string_agg(
+        i.base_name || case when i.sku_qty_per_option > 1
+             then ' ' || trim(to_char(i.sku_qty_per_option, 'FM999990')) || '개입'
+             else '' end,
+        ' + ' order by i.sort, i.base_name) as comp
+    from promo.campaign_plan_option_items i
+    where i.campaign_plan_option_id = p_option_id
+  )
+  select case
+    when (select comp from parts) is null or (select comp from parts) = '' then o.option_label
+    else (select comp from parts)
+      || case when o.set_price is not null and o.set_price > 0
+         then ' · ' || trim(to_char(o.set_price, 'FM999,999,999')) || '원'
+         else '' end
+  end
+  from promo.campaign_plan_options o
+  where o.id = p_option_id;
+$$;
+
+-- 아이템 변경 시 소속 옵션의 파생값 갱신 (다구성 insert 다건도 매행 반영)
+create or replace function promo.refresh_plan_option_derived()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+declare
+  oid uuid;
+begin
+  oid := coalesce(new.campaign_plan_option_id, old.campaign_plan_option_id);
+  update promo.campaign_plan_options o
+     set option_signature = promo.compute_option_signature(oid),
+         display_label = promo.compute_option_display_label(oid),
+         updated_at = now()
+   where o.id = oid;
+  return null;
+end;
+$$;
+
+drop trigger if exists plan_option_items_derived on promo.campaign_plan_option_items;
+create trigger plan_option_items_derived
+  after insert or update or delete on promo.campaign_plan_option_items
+  for each row execute function promo.refresh_plan_option_derived();
+
+-- 기존 옵션 백필
+update promo.campaign_plan_options o
+   set option_signature = promo.compute_option_signature(o.id),
+       display_label = promo.compute_option_display_label(o.id);
+
+grant execute on all functions in schema promo to authenticated;
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## N7 P1 — 모델/적재 기반

플랜↔실적 매칭 재설계(N7)의 **P1(모델/적재 기반)**. 측정엔진·데이터는 보존하고 매칭·플랜옵션 레이어의 토대만 추가. 비파괴(add column + 신규함수 위주)·멱등.

> ⚠️ 브랜치 메모: 이 세션은 `claude/confident-dijkstra-d8zx86`에 작업했습니다 (핸드오프의 `claude/n5-plan-separation-10ikew`와 다름). base는 `main`.

### 1) 실적 묶음수 구조화 — `migration 0030`
- `promotion_sales.pack_size int` 추가.
- `promo.parse_pack(text)`: `option_info`에서 묶음수 best-effort 파싱.
  - `%`·기간(`개월`/`달`)·중량(`kg`/`g`/`ml`) 토큰을 먼저 제거한 뒤, **첫 "묶음 단위"**(박스/개입/팩/묶음/세트/병/캔/봉/입/개) 앞 숫자 채택. 없으면 1.
  - 포/스틱/P 등 **내용물 단위는 제외** (`1개월/30포` → 30 오인 방지).
- 과거 5,604행 백필 (null 0건). 신규/변경행은 `BEFORE INSERT/UPDATE` 트리거가 자동 채움.

### 2) 옵션 식별/표시 파생 — `migration 0030`
- `campaign_plan_options.option_signature`: 구성(품목+개입수) 정렬 md5 = 옵션 식별 키.
- `campaign_plan_options.display_label`: `구성 × 개입수 + 세트가`. 라벨 단독으로 구분 안 되던 **2개입/6개입을 구조에서 재구성**.
  - 예: `퍼펙트 연어 150g [15p] 2개입 · 33,000원`, `… 6개입`, 혼합 `치킨 3개입 + 연어 3개입`.
- `campaign_plan_option_items`(이미 1:N 구조) 변경 시 `AFTER` 트리거가 두 파생값 재계산. 기존 38옵션 백필.

### 3) 임포터 — 다구성 적재
- `lib/parsePlanGuide.ts`: **'구성'(품목코드:수량,…) 컬럼** 파싱 → `components[]`. 미존재 시 현행 **단품 1건 폴백**.
- `upload/page.tsx` commit: 옵션당 컴포넌트 **N건 item insert**(부분 매칭 허용). `set_price`를 수량 비중으로 SKU 단가 환산.

### 검증
- `refresh_rollups(true)` 강제 후 `rollup_state` fresh (`version = built_version = 146`).
- 기존 달성 RPC(`plan_vs_actual` 등)는 `pack_size` 미참조 → **현재 수치 불변**.
- `tsc --noEmit` 0 에러, `next build` 통과. (line 123 eslint 경고는 pre-existing, 무관)

### 다음 (P2)
`plan_vs_actual`/`plan_vs_actual_options`에서 실적 SKU 수량을 `quantity × pack_size`로 환산해 플랜 SKU 단위와 정합. 옵션 달성은 `option_signature` 기준 best-effort.

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_