### PR TITLE
N7 P3: 매칭/달성 UI 통합 (SKU·옵션 탭, display_label, match_source)

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/Achievement.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/Achievement.tsx
@@ -9,21 +9,35 @@ import type {
   PlanVsActualOption,
 } from "@/lib/types";
 import { won, wonShort, pct, num } from "@/lib/format";
+import SkuMatchPanel, { type DiagnosticRow, type SkuMapping } from "./SkuMatchPanel";
 
+// N7 P3: 달성 & 매칭을 한 블록으로 통합.
+// - 상단: SKU 기준 총 달성률 카드 (1차 진실)
+// - 탭: SKU(품목) = 기본·신뢰 / 옵션(묶음) = 구성·묶음 best-effort 보기
+// - SKU 탭에 SKU 매칭 패널을 흡수 (이전엔 별도 '연동 센터'로 분리돼 혼란)
 export default function Achievement({
   promotionId,
   summary,
   rows,
   options,
   optionInfos,
+  diagnosticRows,
+  skuMappings,
 }: {
   promotionId: string;
   summary: PlanVsActualSummary | null;
   rows: PlanVsActualRow[];
   options: PlanVsActualOption[];
   optionInfos: string[];
+  diagnosticRows: DiagnosticRow[];
+  skuMappings: SkuMapping[];
 }) {
-  if (!summary || !summary.has_confirmed_plan) {
+  const [tab, setTab] = useState<"sku" | "option">("sku");
+
+  const hasConfirmed = !!summary?.has_confirmed_plan;
+  const hasMatchData = diagnosticRows.length > 0 || skuMappings.length > 0;
+
+  if (!hasConfirmed && !hasMatchData && options.length === 0) {
     return (
       <section className="mt-6">
         <h2 className="mb-2 text-sm font-semibold text-neutral-700">달성률 (계획 대비 실적)</h2>
@@ -40,137 +54,181 @@ export default function Achievement({
 
   const planRows = rows.filter((r) => r.status !== "unplanned");
   const unplanned = rows.filter((r) => r.status === "unplanned");
+  const unmatched = diagnosticRows.filter((r) => r.side !== "both" && !r.is_mapped).length;
 
   return (
     <section className="mt-6">
-      <h2 className="mb-2 text-sm font-semibold text-neutral-700">달성률 (계획 대비 실적)</h2>
+      <h2 className="mb-2 text-sm font-semibold text-neutral-700">달성 & 매칭 (계획 대비 실적)</h2>
 
-      {/* 3종 카드 */}
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-        <AchCard
-          label="매출 달성률"
-          ach={summary.ach_revenue}
-          actual={summary.actual_revenue_total}
-          expected={summary.expected_revenue_total}
-          primary
-        />
-        <AchCard
-          label="수량 달성률"
-          ach={summary.ach_qty}
-          actual={summary.actual_qty_total}
-          expected={summary.expected_qty_total}
-          isQty
-          lowData={summary.quantity_reliable === false}
-        />
-        <AchCard
-          label="공헌이익 달성률"
-          ach={summary.ach_contribution}
-          actual={summary.actual_contribution_total}
-          expected={summary.expected_contribution_total}
-        />
-      </div>
-
-      {/* SKU 단위 가이드 vs 실적 */}
-      <div className="mt-4 overflow-x-auto rounded-2xl card-soft">
-        <table className="w-full min-w-[720px] text-sm">
-          <thead className="bg-neutral-50 text-left text-xs text-neutral-500">
-            <tr>
-              <th className="px-3 py-2.5 font-medium">SKU</th>
-              <th className="px-3 py-2.5 text-right font-medium">기대 매출</th>
-              <th className="px-3 py-2.5 text-right font-medium">실 매출</th>
-              <th className="px-3 py-2.5 text-right font-medium">매출 달성</th>
-              <th className="px-3 py-2.5 text-right font-medium">기대 수량</th>
-              <th className="px-3 py-2.5 text-right font-medium">실 수량</th>
-              <th className="px-3 py-2.5 text-right font-medium">공헌 달성</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-neutral-100">
-            {planRows.map((r) => (
-              <tr key={r.product_id} className={r.status === "unsold" ? "bg-red-50/40" : ""}>
-                <td className="px-3 py-2.5">
-                  {r.base_name}
-                  {r.status === "unsold" && (
-                    <span className="ml-1.5 rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-medium text-red-600">
-                      미판매
-                    </span>
-                  )}
-                </td>
-                <td className="px-3 py-2.5 text-right text-neutral-500">{won(r.expected_revenue)}</td>
-                <td className="px-3 py-2.5 text-right">{won(r.actual_revenue)}</td>
-                <td className="px-3 py-2.5 text-right">
-                  <AchPct v={r.ach_revenue} />
-                </td>
-                <td className="px-3 py-2.5 text-right text-neutral-500">{num(r.expected_qty)}</td>
-                <td className="px-3 py-2.5 text-right">{num(r.actual_qty)}</td>
-                <td className="px-3 py-2.5 text-right">
-                  <AchPct v={r.ach_contribution} />
-                </td>
-              </tr>
-            ))}
-            {planRows.length === 0 && (
-              <tr>
-                <td colSpan={7} className="px-3 py-4 text-center text-xs text-neutral-400">
-                  계획된 SKU가 없습니다.
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
-      </div>
-
-      {/* 옵션 단위 보조 */}
-      <div className="mt-4">
-        <h3 className="mb-1 text-xs font-semibold text-neutral-500">옵션 단위 (보조)</h3>
-        <p className="mb-2 text-[11px] text-neutral-400">
-          SKU 단위 매칭은 품목 코드 기준 자동 — 위 표에 반영됩니다. 옵션 단위는 옵션 라벨↔실적 옵션정보 부분일치로
-          기본 매핑되며, 빗나간 옵션만 수동으로 보정하세요.
+      {/* 총 달성률 (SKU 기준 1차 진실) */}
+      {hasConfirmed ? (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <AchCard
+            label="매출 달성률"
+            ach={summary!.ach_revenue}
+            actual={summary!.actual_revenue_total}
+            expected={summary!.expected_revenue_total}
+            primary
+          />
+          <AchCard
+            label="수량 달성률"
+            ach={summary!.ach_qty}
+            actual={summary!.actual_qty_total}
+            expected={summary!.expected_qty_total}
+            isQty
+            lowData={summary!.quantity_reliable === false}
+          />
+          <AchCard
+            label="공헌이익 달성률"
+            ach={summary!.ach_contribution}
+            actual={summary!.actual_contribution_total}
+            expected={summary!.expected_contribution_total}
+          />
+        </div>
+      ) : (
+        <p className="rounded-xl card-soft px-4 py-3 text-xs text-neutral-500">
+          확정 플랜이 아니라 총 달성률은 미표시 — 아래에서 SKU 매칭만 정리할 수 있습니다.{" "}
+          <Link href={`/promotions/${promotionId}/plan`} className="text-brand-600 hover:underline">
+            플랜 확정 →
+          </Link>
         </p>
-        <div className="space-y-2">
-          {options.map((o) => (
-            <OptionRow
-              key={o.option_id}
-              promotionId={promotionId}
-              opt={o}
-              optionInfos={optionInfos}
-            />
-          ))}
-          {options.length === 0 && (
-            <p className="text-xs text-neutral-400">옵션이 없습니다.</p>
+      )}
+
+      {/* 탭: SKU(품목) 기본 / 옵션(묶음) 보조 */}
+      <div className="mt-4 inline-flex rounded-xl bg-soft p-1 text-xs font-medium">
+        <button
+          onClick={() => setTab("sku")}
+          className={`rounded-lg px-3 py-1.5 ${tab === "sku" ? "bg-card text-ink shadow-sm" : "text-ink-3"}`}
+        >
+          SKU(품목)
+          {unmatched > 0 && (
+            <span className="ml-1.5 rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] text-amber-700">
+              미매칭 {unmatched}
+            </span>
+          )}
+        </button>
+        <button
+          onClick={() => setTab("option")}
+          className={`rounded-lg px-3 py-1.5 ${tab === "option" ? "bg-card text-ink shadow-sm" : "text-ink-3"}`}
+        >
+          옵션(묶음){options.length > 0 ? ` ${options.length}` : ""}
+        </button>
+      </div>
+
+      {tab === "sku" ? (
+        <div className="mt-3">
+          <p className="mb-2 text-[11px] text-neutral-400">
+            품목(SKU) 단위가 달성도의 1차 기준입니다 — 품목 코드·정규화 이름으로 자동 매칭되며, 빗나간 것만 아래에서 보정하세요.
+          </p>
+
+          {/* SKU 단위 가이드 vs 실적 */}
+          {hasConfirmed && (
+            <div className="overflow-x-auto rounded-2xl card-soft">
+              <table className="w-full min-w-[720px] text-sm">
+                <thead className="bg-neutral-50 text-left text-xs text-neutral-500">
+                  <tr>
+                    <th className="px-3 py-2.5 font-medium">SKU</th>
+                    <th className="px-3 py-2.5 text-right font-medium">기대 매출</th>
+                    <th className="px-3 py-2.5 text-right font-medium">실 매출</th>
+                    <th className="px-3 py-2.5 text-right font-medium">매출 달성</th>
+                    <th className="px-3 py-2.5 text-right font-medium">기대 수량</th>
+                    <th className="px-3 py-2.5 text-right font-medium">실 수량</th>
+                    <th className="px-3 py-2.5 text-right font-medium">공헌 달성</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-neutral-100">
+                  {planRows.map((r) => (
+                    <tr key={r.product_id} className={r.status === "unsold" ? "bg-red-50/40" : ""}>
+                      <td className="px-3 py-2.5">
+                        {r.base_name}
+                        {r.status === "unsold" && (
+                          <span className="ml-1.5 rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-medium text-red-600">
+                            미판매
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-3 py-2.5 text-right text-neutral-500">{won(r.expected_revenue)}</td>
+                      <td className="px-3 py-2.5 text-right">{won(r.actual_revenue)}</td>
+                      <td className="px-3 py-2.5 text-right">
+                        <AchPct v={r.ach_revenue} />
+                      </td>
+                      <td className="px-3 py-2.5 text-right text-neutral-500">{num(r.expected_qty)}</td>
+                      <td className="px-3 py-2.5 text-right">{num(r.actual_qty)}</td>
+                      <td className="px-3 py-2.5 text-right">
+                        <AchPct v={r.ach_contribution} />
+                      </td>
+                    </tr>
+                  ))}
+                  {planRows.length === 0 && (
+                    <tr>
+                      <td colSpan={7} className="px-3 py-4 text-center text-xs text-neutral-400">
+                        계획된 SKU가 없습니다.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {/* SKU 매칭 패널 (이전 '연동 센터'에서 흡수) */}
+          {hasMatchData && (
+            <SkuMatchPanel promotionId={promotionId} rows={diagnosticRows} mappings={skuMappings} />
+          )}
+
+          {/* 계획 외 판매 */}
+          {hasConfirmed && unplanned.length > 0 && (
+            <details className="mt-4 rounded-xl bg-amber-50/60 p-4">
+              <summary className="cursor-pointer text-sm font-medium text-amber-800">
+                계획 외 판매 — {unplanned.length}개 SKU · 매출 {wonShort(summary!.unplanned_revenue)} · 공헌{" "}
+                {wonShort(summary!.unplanned_contribution)}
+                <span className="ml-1 text-xs font-normal text-amber-600">
+                  (전체 달성률 분모에서 제외)
+                </span>
+              </summary>
+              <div className="mt-3 overflow-x-auto">
+                <table className="w-full text-left text-xs">
+                  <thead className="text-amber-700/70">
+                    <tr>
+                      <th className="py-1 pr-3">SKU</th>
+                      <th className="py-1 pr-3 text-right">실 매출</th>
+                      <th className="py-1 text-right">실 수량</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {unplanned.map((r) => (
+                      <tr key={r.product_id} className="border-t border-amber-100">
+                        <td className="py-1 pr-3">{r.base_name}</td>
+                        <td className="py-1 pr-3 text-right">{won(r.actual_revenue)}</td>
+                        <td className="py-1 text-right">{num(r.actual_qty)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </details>
           )}
         </div>
-      </div>
-
-      {/* 계획 외 판매 */}
-      {unplanned.length > 0 && (
-        <details className="mt-4 rounded-xl bg-amber-50/60 p-4">
-          <summary className="cursor-pointer text-sm font-medium text-amber-800">
-            계획 외 판매 — {unplanned.length}개 SKU · 매출 {wonShort(summary.unplanned_revenue)} · 공헌{" "}
-            {wonShort(summary.unplanned_contribution)}
-            <span className="ml-1 text-xs font-normal text-amber-600">
-              (전체 달성률 분모에서 제외)
-            </span>
-          </summary>
-          <div className="mt-3 overflow-x-auto">
-            <table className="w-full text-left text-xs">
-              <thead className="text-amber-700/70">
-                <tr>
-                  <th className="py-1 pr-3">SKU</th>
-                  <th className="py-1 pr-3 text-right">실 매출</th>
-                  <th className="py-1 text-right">실 수량</th>
-                </tr>
-              </thead>
-              <tbody>
-                {unplanned.map((r) => (
-                  <tr key={r.product_id} className="border-t border-amber-100">
-                    <td className="py-1 pr-3">{r.base_name}</td>
-                    <td className="py-1 pr-3 text-right">{won(r.actual_revenue)}</td>
-                    <td className="py-1 text-right">{num(r.actual_qty)}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+      ) : (
+        <div className="mt-3">
+          <p className="mb-2 text-[11px] text-neutral-400">
+            옵션(묶음) 달성은 <strong>구성·묶음수 기반 best-effort</strong> 입니다 — 실적 옵션정보가 자유 텍스트라 완전 매칭은 불가하며,
+            같은 구성의 중복 옵션엔 매출을 분배해 보여줍니다. 신뢰 기준은 위 SKU 탭입니다.
+          </p>
+          <div className="space-y-2">
+            {options.map((o) => (
+              <OptionRow
+                key={o.option_id}
+                promotionId={promotionId}
+                opt={o}
+                optionInfos={optionInfos}
+              />
+            ))}
+            {options.length === 0 && (
+              <p className="text-xs text-neutral-400">옵션이 없습니다.</p>
+            )}
           </div>
-        </details>
+        </div>
       )}
     </section>
   );
@@ -220,6 +278,27 @@ function AchPct({ v }: { v: number | null }) {
   return <span className={color}>{pct(v, 0)}</span>;
 }
 
+// 매칭 출처 배지 — best-effort 신뢰도를 한눈에
+function SourceBadge({ src }: { src: PlanVsActualOption["match_source"] }) {
+  if (src === "routed")
+    return (
+      <span className="rounded bg-green-100 px-1.5 py-0.5 text-[10px] font-medium text-green-700">
+        자동 (구성·묶음)
+      </span>
+    );
+  if (src === "manual")
+    return (
+      <span className="rounded bg-brand-100 px-1.5 py-0.5 text-[10px] font-medium text-brand-700">
+        수동 매핑
+      </span>
+    );
+  return (
+    <span className="rounded bg-neutral-100 px-1.5 py-0.5 text-[10px] font-medium text-neutral-500">
+      미매칭
+    </span>
+  );
+}
+
 function OptionRow({
   promotionId,
   opt,
@@ -260,17 +339,12 @@ function OptionRow({
   return (
     <div className="rounded-[16px] card-soft p-3">
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <div className="flex items-center gap-2">
-          <span className="text-sm font-medium">{opt.option_label}</span>
-          {opt.matched ? (
-            <span className="rounded bg-green-100 px-1.5 py-0.5 text-[10px] font-medium text-green-700">
-              매칭됨
-            </span>
-          ) : (
-            <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700">
-              옵션 매핑 필요
-            </span>
-          )}
+        <div className="flex min-w-0 items-center gap-2">
+          {/* 구성·묶음·세트가 노출 — 라벨 단독 금지 (2개입/6개입 구분) */}
+          <span className="min-w-0 text-sm font-medium text-ink" title={opt.option_label}>
+            {opt.display_label ?? opt.option_label}
+          </span>
+          <SourceBadge src={opt.match_source} />
         </div>
         <div className="flex items-center gap-3 text-xs text-neutral-500">
           <span>
@@ -283,7 +357,7 @@ function OptionRow({
             onClick={() => setEditing((v) => !v)}
             className="rounded-lg border border-neutral-200 px-2 py-1 text-xs hover:bg-neutral-50"
           >
-            {editing ? "닫기" : "매핑"}
+            {editing ? "닫기" : "수동 보정"}
           </button>
         </div>
       </div>
@@ -291,7 +365,7 @@ function OptionRow({
       {editing && (
         <div className="mt-3 border-t border-neutral-100 pt-3">
           <p className="mb-2 text-xs text-neutral-500">
-            이 옵션에 해당하는 실적 옵션정보를 선택하세요 (부분일치).
+            자동(구성·묶음) 라우팅이 빗나갔다면, 이 옵션에 해당하는 실적 옵션정보를 직접 고르세요 (부분일치). 저장 시 수동 매핑이 우선합니다.
           </p>
           {optionInfos.length === 0 ? (
             <p className="text-xs text-neutral-400">

--- a/promo-analytics/app/(dash)/promotions/[id]/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/page.tsx
@@ -15,7 +15,7 @@ import UpliftChart from "./UpliftChart";
 import Notes from "./Notes";
 import Achievement from "./Achievement";
 import PurposeBlock, { type PurposeMetricRow } from "./PurposeBlock";
-import SkuMatchPanel, { type DiagnosticRow, type SkuMapping } from "./SkuMatchPanel";
+import { type DiagnosticRow, type SkuMapping } from "./SkuMatchPanel";
 import ActualsLink, { type ActualsCandidate } from "./ActualsLink";
 import CampaignTrend, { type DailyPoint } from "./CampaignTrend";
 
@@ -285,23 +285,15 @@ export default async function PromotionDetail({
         </div>
       </div>
 
-      {/* 연동 센터 (N6 R1.4) — 비교 대상·SKU 매칭·병합을 한 곳에서 */}
-      {(plan || diagnosticRows.length > 0 || skuMappings.length > 0) && (
+      {/* 비교 대상 연동 — 어떤 실적 캠페인과 비교할지 선택 (SKU 매칭은 아래 달성 블록으로 통합) */}
+      {plan && (
         <section className="mt-6 rounded-2xl card-soft p-5">
           <div className="flex flex-wrap items-center justify-between gap-2">
             <div className="flex items-center gap-2">
-              <h2 className="text-sm font-semibold text-neutral-700">
-                플랜 ↔ 실적 연동 센터
-              </h2>
-              {plan && !plan.actual_promotion_id && (
+              <h2 className="text-sm font-semibold text-neutral-700">비교 대상 연동</h2>
+              {!plan.actual_promotion_id && (
                 <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-700">
                   비교 대상 미지정
-                </span>
-              )}
-              {diagnosticRows.some((r) => r.side !== "both" && !r.is_mapped) && (
-                <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-700">
-                  미매칭 SKU{" "}
-                  {diagnosticRows.filter((r) => r.side !== "both" && !r.is_mapped).length}
                 </span>
               )}
             </div>
@@ -316,38 +308,30 @@ export default async function PromotionDetail({
             <p className="mt-1 text-xs text-ink-3">
               비교 구도: <strong className="text-ink">이 캠페인의 플랜</strong> ↔{" "}
               <strong className="text-brand-700">{linkedActualName}</strong> 실적 —
-              아래 달성률·SKU 매칭이 모두 이 구도 기준으로 계산됩니다.
+              아래 달성 블록이 이 구도 기준으로 계산됩니다.
             </p>
           ) : (
             <p className="mt-1 text-xs text-neutral-400">
-              플랜이 비교할 실적 캠페인과 SKU 매칭을 여기서 한 번에 끝내세요. 연동이 끝나면
-              아래 달성률이 자동으로 채워집니다.
+              비교할 실적 캠페인을 지정하면 아래 달성 블록이 자동으로 채워집니다. SKU·옵션 매칭은 달성 블록에서 보정하세요.
             </p>
           )}
-          {plan && (
-            <ActualsLink
-              promotionId={id}
-              currentLinkId={plan.actual_promotion_id}
-              candidates={candidates}
-            />
-          )}
-          {(diagnosticRows.length > 0 || skuMappings.length > 0) && (
-            <SkuMatchPanel
-              promotionId={id}
-              rows={diagnosticRows}
-              mappings={skuMappings}
-            />
-          )}
+          <ActualsLink
+            promotionId={id}
+            currentLinkId={plan.actual_promotion_id}
+            candidates={candidates}
+          />
         </section>
       )}
 
-      {/* 달성률 (S3) */}
+      {/* 달성 & 매칭 (S3 + N7 P3 통합) */}
       <Achievement
         promotionId={id}
         summary={achSummary}
         rows={achRows}
         options={achOptions}
         optionInfos={optionInfos}
+        diagnosticRows={diagnosticRows}
+        skuMappings={skuMappings}
       />
 
       {/* 목적별 핵심 지표 (S5.4) */}

--- a/promo-analytics/lib/types.ts
+++ b/promo-analytics/lib/types.ts
@@ -232,11 +232,16 @@ export type PlanVsActualSummary = {
 export type PlanVsActualOption = {
   option_id: string;
   option_label: string;
+  // N7 P2: 구성 기반 파생 표시·식별 (라벨 단독 금지 — 2개입/6개입·세트가 구분)
+  display_label: string | null;
+  option_signature: string | null;
   expected_option_qty: number;
   expected_revenue: number | null;
   expected_contribution: number | null;
   match_patterns: string[];
   matched: boolean;
+  // N7 P2: 'routed'(구성·묶음 자동 라우팅) | 'manual'(수동 패턴) | 'none'(미매칭/저신뢰)
+  match_source: "routed" | "manual" | "none";
   actual_revenue: number;
   actual_qty: number;
   ach_revenue: number | null;


### PR DESCRIPTION
## N7 P3 — 매칭/달성 UI 통합 (설계 §4)

사용자 지적("매칭이 너무 복잡하고 개선이 없다")과 설계 §4를 직접 반영.

### 1) 두 갈래 매칭 UI → 한 블록 통합
- 기존: 상단 '플랜↔실적 연동 센터'(SKU 수동 매핑) + 별도 '달성률'(옵션 매핑) — 목적이 겹쳐 혼란.
- 변경: **달성 & 매칭** 한 블록으로 통합. 별도 섹션은 **비교 대상 선택(`ActualsLink`)만** 남김. SKU 매칭 패널은 달성 블록의 SKU 탭으로 흡수.

### 2) SKU 탭 / 옵션 탭 (설계 §4.2)
- **SKU(품목) 탭** = 기본·신뢰: 상품별 예상 vs 실적 vs 달성률 + SKU 매칭 보정 + 계획 외 판매. 미매칭 SKU 배지.
- **옵션(묶음) 탭** = 구성·묶음 best-effort 보기.

### 3) 옵션 표기 = 구성·묶음·세트가 (설계 §4.1, 핵심 불만 해결)
- 옵션 행을 `display_label`(예: `퍼펙트 연어 [15p] 2개입 · 33,000원`, 혼합 `치킨 3개입 + 연어 3개입`)로 표기 — **라벨 단독 금지**, 2개입/6개입 한눈에 구분.
- `match_source` 배지: **자동(구성·묶음)** / **수동 매핑** / **미매칭** 으로 best-effort 신뢰도 노출.
- P2 라우팅 덕에 깨져있던 **옵션 0% 표가 실수치**(예: 57·86·103·130%)로 의미있게 표시. 수동 보정은 '수동 우선'으로 유지.

### 타입
`PlanVsActualOption`에 `display_label`·`option_signature`·`match_source` 추가.

### 검증
- `tsc --noEmit` 0 에러, `next build` 통과. 데이터 배선(번들 `rollup.pva_options`/`diagnostic`)은 P2에서 이미 채워짐 — UI만 재구성.

### 다음
- **P4**: 오염 옵션 보정 + 수동 매핑 데이터 정리(플랜+실적 둘 다 있는 캠페인만 보존, 나머지 초기화).

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_