### PR TITLE
N7 P4: 오염 옵션 보정 + 브랜드 동의어(세븐플러스=7+) 정규화

### DIFF
--- a/promo-analytics/supabase/migrations/0032_n7_fix_polluted_options.sql
+++ b/promo-analytics/supabase/migrations/0032_n7_fix_polluted_options.sql
@@ -1,0 +1,35 @@
+-- 0032: N7 P4 — 오염 플랜옵션 구성 보정 (라벨↔구성 SKU 불일치 교정)
+--
+-- 배경(설계 §0): 구 임포터(1행=1옵션=단일 SKU)가 품목코드 누락/이름 충돌 시 옵션을
+--   엉뚱한 product 에 매핑 → "퍼펙트 연어" 옵션의 구성이 "퍼펙트 치킨"으로, "7+ 케어 치킨"이
+--   "퍼펙트 치킨"으로 저장되는 등 구성 오염. 단일구성 옵션 11건에서 라벨 SKU ≠ 구성 SKU.
+--   이 오염은 SKU 달성 귀속을 왜곡(연어 옵션이 치킨 기대치로 합산).
+--
+-- 보정 원칙(결정적·비추측): 오염 단일구성 옵션의 item 을, base_name 이 옵션 라벨과
+--   **정확히 일치**하는 제품으로 재지정. 사전 점검 결과 11건 모두 정확일치 제품이 1개씩 존재
+--   (no_exact=0, ambiguous=0) → 추측 없이 안전. 멱등(정규화 일치하면 재실행시 0건).
+--   set_price/econ/expected_* 등 폼 경제값은 보존(데이터 보존 원칙) — product 정체성만 교정.
+--   item 변경 트리거가 option_signature/display_label 재계산.
+--
+-- 수동 매핑 정리(설계 §8.8 사용자 결정: 플랜+실적 동시 보유 캠페인만 보존, 나머지 초기화):
+--   현 상태 promotion_sku_mappings 0건, 커스텀 match_patterns 1건(= Better Habits, 연동 캠페인)
+--   → 보존 대상만 존재하므로 파괴적 초기화 불필요(조건 이미 충족). 비파괴 유지.
+
+update promo.campaign_plan_option_items it
+set product_id = sub.correct_pid,
+    base_name = sub.correct_name,
+    updated_at = now()
+from (
+  select i.id as item_id,
+    (select pr.id from promo.products pr where pr.base_name = o.option_label limit 1) as correct_pid,
+    (select pr.base_name from promo.products pr where pr.base_name = o.option_label limit 1) as correct_name
+  from promo.campaign_plan_options o
+  join promo.campaign_plan_option_items i on i.campaign_plan_option_id = o.id
+  where (select count(*) from promo.campaign_plan_option_items i2
+           where i2.campaign_plan_option_id = o.id) = 1
+    and promo.normalize_sku_name(i.base_name) <> promo.normalize_sku_name(o.option_label)
+    and (select count(*) from promo.products pr where pr.base_name = o.option_label) = 1
+) sub
+where it.id = sub.item_id and sub.correct_pid is not null;
+
+notify pgrst, 'reload schema';

--- a/promo-analytics/supabase/migrations/0033_n7_brand_synonym_normalize.sql
+++ b/promo-analytics/supabase/migrations/0033_n7_brand_synonym_normalize.sql
@@ -1,0 +1,33 @@
+-- 0033: N7 P4 — SKU 정규화에 브랜드 동의어 '세븐플러스'(=7+) 추가
+--
+-- 배경: 플랜은 "(제품) 닥터펠리스 7+ 케어 스틱 연어", 실적은 "세븐플러스 7+ 케어 스틱 연어"로
+--   같은 SKU 를 다른 브랜드 문자열로 기록 → normalize_sku_name 이 '세븐플러스'를 못 지워
+--   서로 다른 키가 되어 매칭 실패(7+ 케어 라인이 실제 ~8.8M 팔렸는데 '미판매'로 표시).
+--
+-- 해결: 0018 의 정규화에 '닥터펠리스'처럼 '세븐플러스'(7+ 브랜드명)도 제거 토큰으로 추가.
+--   → 양쪽 모두 "7케어스틱연어150g15p" 로 수렴해 매칭. 다른 SKU 와 충돌 없음(세븐플러스는 7+ 전용).
+--   immutable SQL 함수 교체 → plan_vs_actual / sku_match_diagnostic / plan_vs_actual_options 전부 자동 반영.
+--   적용 후 refresh_rollups(true) 필요.
+
+create or replace function promo.normalize_sku_name(name text)
+returns text
+language sql
+immutable
+parallel safe
+set search_path = ''
+as $$
+  select lower(regexp_replace(
+    regexp_replace(
+      regexp_replace(
+        regexp_replace(coalesce(name, ''), '\([^)]*\)', '', 'g'),
+        '(닥터펠리스|세븐플러스)', '', 'g'
+      ),
+      '\s+', '', 'g'
+    ),
+    '[\[\](){}.,/+\-]', '', 'g'
+  ));
+$$;
+
+grant execute on all functions in schema promo to authenticated;
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## N7 P4 — 데이터 정리 (오염 옵션 보정 + 브랜드 동의어 정규화)

### 1) 오염 옵션 구성 보정 (`migration 0032`)
설계 §0의 구성 오염 실증 케이스 교정. 단일구성 옵션 중 **라벨 SKU ≠ 구성 SKU**인 11건 (예: `퍼펙트 연어` 옵션의 구성이 `퍼펙트 치킨`, `7+ 케어 치킨` 옵션이 `퍼펙트 치킨 ×2`).
- 보정 규칙: 옵션 라벨과 `base_name`이 **정확히 일치**하는 제품으로 item 재지정. 사전 점검 결과 11건 모두 정확일치 제품이 **1개씩** 존재(`no_exact=0, ambiguous=0`) → 추측 없이 결정적·안전. 멱등.
- 폼 경제값(set_price/expected_*/econ)은 **보존**(데이터 보존 원칙), product 정체성만 교정. 트리거가 `option_signature`/`display_label` 재계산.

### 2) 브랜드 동의어 정규화 (`migration 0033`)
보정이 드러낸 매칭 갭: 플랜 `(제품) 닥터펠리스 7+ 케어`, 실적 `세븐플러스 7+ 케어` — **같은 SKU, 다른 브랜드 문자열**. `normalize_sku_name`이 `세븐플러스`를 못 지워 7+ 케어 라인이 실제 ~8.8M 팔렸는데 '미판매'로 표시.
- `normalize_sku_name`에 `세븐플러스`(7+ 브랜드명)를 `닥터펠리스`처럼 제거 토큰으로 추가 → 양쪽 키 수렴. SKU 엔진 전반 자동 반영.

### 수동 매핑 정리 (결정 §8.8)
"플랜+실적 둘 다 있는 캠페인만 보존, 나머지 초기화" — 현 상태 `promotion_sku_mappings` **0건**, 커스텀 `match_patterns` **1건(= Better Habits, 연동 캠페인)** → 보존 대상만 존재. **파괴적 초기화 불필요**(조건 이미 충족).

### 검증 (운영 DB 적용 + `refresh_rollups(true)`)
- 오염 잔여 **0건**. Better Habits 4개 SKU 전부 `matched`, `unsold 0`:
  - 퍼펙트 치킨 **98%** · 퍼펙트 연어 **72%** · 7+ 케어 연어 **24%** · 7+ 케어 치킨 **51%**
- 이전엔 오염으로 7+ 옵션이 퍼펙트 치킨에 **거짓 합산**돼 가려졌던 **7+ 케어 라인 대규모 미달**(30M 계획 대비 저조)이 정직하게 드러남.
- 회귀 점검: 벌크UP `matched 10, unsold 0` 정상. `rollup_state` fresh.

이로써 N7 P1~P4 완료 — 모델/적재 → 옵션 달성 엔진 → UI 통합 → 데이터 정리.

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_