### PR TITLE
N8 P3: 함께 구매 벤치마크 + 전체매출 추정/역추정 (추천 프로토타입)

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/plan/HaloRecommendPanel.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/HaloRecommendPanel.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { wonShort, pct } from "@/lib/format";
+
+// N8 P3: 함께 구매 벤치마크 + 전체매출 추정/역추정 (추천 프로토타입).
+// - 캠페인 자유 태그로 '유사 성격' 그룹핑 → 그 그룹의 평균 함께구매 비율 사용
+// - 메인 제품 명시 지정(없으면 플랜 SKU 전체가 메인)
+// ⚠️ 현재 확정 캠페인이 적어 추정은 프로토타입 — 데이터가 쌓일수록 정교해짐.
+
+export type Bench = {
+  promotion_id: string;
+  name: string;
+  season: string | null;
+  tags: string[];
+  halo_ratio: number | null;
+  revenue_ach_total: number | null;
+};
+type Sku = { product_id: string; base_name: string };
+type Opt = { expected_revenue: number; product_ids: string[] };
+
+export default function HaloRecommendPanel({
+  promotionId,
+  benchmarks,
+  tags,
+  mainProductIds,
+  skus,
+  options,
+  planTarget,
+}: {
+  promotionId: string;
+  benchmarks: Bench[];
+  tags: string[];
+  mainProductIds: string[] | null;
+  skus: Sku[];
+  options: Opt[];
+  planTarget: number;
+}) {
+  const router = useRouter();
+  const [localTags, setLocalTags] = useState<string[]>(tags);
+  const [tagInput, setTagInput] = useState("");
+  const [mainSet, setMainSet] = useState<string[] | null>(mainProductIds);
+  const [busy, setBusy] = useState(false);
+
+  const isAllMain = mainSet === null;
+  const mainIds = isAllMain ? skus.map((s) => s.product_id) : mainSet;
+
+  // 관련 벤치마크: 태그가 하나라도 겹치면 그 그룹, 태그 미설정이면 전체
+  const related = useMemo(() => {
+    const withRatio = benchmarks.filter(
+      (b) => b.halo_ratio != null && b.promotion_id !== promotionId,
+    );
+    if (localTags.length === 0) return withRatio;
+    const f = withRatio.filter((b) => b.tags.some((t) => localTags.includes(t)));
+    return f.length ? f : withRatio;
+  }, [benchmarks, localTags, promotionId]);
+
+  const avgRatio = related.length
+    ? related.reduce((s, b) => s + (b.halo_ratio ?? 0), 0) / related.length
+    : null;
+
+  const mainExpected = options
+    .filter((o) => o.product_ids.some((p) => mainIds.includes(p)))
+    .reduce((s, o) => s + o.expected_revenue, 0);
+  const projectedTotal = avgRatio != null ? mainExpected * (1 + avgRatio) : null;
+  const requiredMain = avgRatio != null && avgRatio > -1 ? planTarget / (1 + avgRatio) : null;
+
+  async function save(patch: { tags?: string[]; main_product_ids?: string[] | null }) {
+    setBusy(true);
+    const res = await fetch(`/api/promotions/${promotionId}/plan/meta`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(patch),
+    });
+    setBusy(false);
+    if (!res.ok) {
+      const j = await res.json().catch(() => ({}));
+      toast.error(j.error ?? "저장 실패");
+      return false;
+    }
+    router.refresh();
+    return true;
+  }
+
+  function addTag() {
+    const t = tagInput.trim();
+    if (!t || localTags.includes(t)) {
+      setTagInput("");
+      return;
+    }
+    const next = [...localTags, t];
+    setLocalTags(next);
+    setTagInput("");
+    save({ tags: next });
+  }
+  function removeTag(t: string) {
+    const next = localTags.filter((x) => x !== t);
+    setLocalTags(next);
+    save({ tags: next });
+  }
+  function toggleMain(pid: string) {
+    const base = isAllMain ? skus.map((s) => s.product_id) : mainSet!;
+    const next = base.includes(pid) ? base.filter((x) => x !== pid) : [...base, pid];
+    setMainSet(next);
+  }
+  function applyMain() {
+    // 전체 선택과 같으면 null(=전체)로 저장
+    const all = skus.map((s) => s.product_id).sort().join(",");
+    const sel = (mainSet ?? []).slice().sort().join(",");
+    save({ main_product_ids: isAllMain || sel === all ? null : mainSet });
+  }
+
+  return (
+    <section className="mt-5 rounded-2xl card-soft p-5">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold text-neutral-700">
+          함께 구매 추정 · 추천{" "}
+          <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700">
+            프로토타입
+          </span>
+        </h3>
+        <span className="text-[11px] text-ink-4">
+          유사 캠페인 {related.length}건 기준{" "}
+          {avgRatio != null && (
+            <>
+              · 평균 함께구매 비율 <strong className="text-brand-700">{pct(avgRatio, 0)}</strong>
+            </>
+          )}
+        </span>
+      </div>
+
+      {/* 태그 */}
+      <div className="mt-3">
+        <div className="text-[11px] font-medium text-ink-3">캠페인 성격 태그 (유사 캠페인 그룹핑)</div>
+        <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+          {localTags.map((t) => (
+            <span
+              key={t}
+              className="inline-flex items-center gap-1 rounded-full bg-brand-50 px-2 py-0.5 text-[11px] text-brand-700"
+            >
+              {t}
+              <button onClick={() => removeTag(t)} disabled={busy} className="text-brand-400 hover:text-brand-700">
+                ×
+              </button>
+            </span>
+          ))}
+          <input
+            value={tagInput}
+            onChange={(e) => setTagInput(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && (e.preventDefault(), addTag())}
+            placeholder="태그 추가 (예: 입문/구독, 벌크업)…"
+            className="min-w-[160px] flex-1 rounded-lg border border-line bg-card px-2.5 py-1 text-xs focus:outline-none"
+          />
+        </div>
+      </div>
+
+      {/* 추정 카드 */}
+      {avgRatio == null ? (
+        <p className="mt-4 rounded-xl bg-soft px-4 py-3 text-xs text-ink-4">
+          비교할 과거 캠페인(확정+실적)이 아직 없어 추정을 낼 수 없습니다. 캠페인이 쌓이면 유사 태그 그룹의 평균으로 추천합니다.
+        </p>
+      ) : (
+        <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <div className="rounded-xl bg-brand-50 p-4">
+            <div className="text-xs text-ink-3">메인 기대매출 → 예상 전체 매출</div>
+            <div className="mt-1 text-xl font-semibold text-ink">
+              {wonShort(mainExpected)} <span className="text-ink-4">→</span> {wonShort(projectedTotal)}
+            </div>
+            <div className="mt-0.5 text-[11px] text-ink-4">
+              메인 × (1 + 함께구매 {pct(avgRatio, 0)})
+            </div>
+          </div>
+          <div className="rounded-xl card-soft p-4">
+            <div className="text-xs text-ink-3">목표 {wonShort(planTarget)} 달성에 필요한 메인 기대매출</div>
+            <div className="mt-1 text-xl font-semibold text-ink">{wonShort(requiredMain)}</div>
+            <div className="mt-0.5 text-[11px] text-ink-4">
+              목표 ÷ (1 + 함께구매 {pct(avgRatio, 0)}) — 메인을 이만큼만 계획해도 함께구매로 목표 도달 기대
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 메인 제품 지정 */}
+      {skus.length > 0 && (
+        <div className="mt-4">
+          <div className="flex items-center justify-between">
+            <div className="text-[11px] font-medium text-ink-3">
+              메인 제품 지정 {isAllMain && <span className="text-ink-4">(미지정 = 플랜 SKU 전체)</span>}
+            </div>
+            <button
+              onClick={applyMain}
+              disabled={busy}
+              className="rounded-lg bg-brand-500 px-3 py-1 text-[11px] font-semibold text-white hover:bg-brand-600 disabled:opacity-40"
+            >
+              메인 적용
+            </button>
+          </div>
+          <div className="mt-1.5 flex flex-wrap gap-1.5">
+            {skus.map((s) => {
+              const on = mainIds.includes(s.product_id);
+              return (
+                <button
+                  key={s.product_id}
+                  onClick={() => toggleMain(s.product_id)}
+                  className={`rounded-full px-2.5 py-1 text-[11px] ${on ? "bg-brand-100 text-brand-700" : "bg-soft text-ink-4"}`}
+                >
+                  {on ? "✓ " : ""}
+                  {s.base_name}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* 벤치마크 표 */}
+      {related.length > 0 && (
+        <div className="mt-4 overflow-x-auto">
+          <table className="w-full min-w-[480px] text-left text-xs">
+            <thead className="text-ink-4">
+              <tr>
+                <th className="py-1.5 pr-3 font-medium">캠페인</th>
+                <th className="py-1.5 pr-3 font-medium">시즌</th>
+                <th className="py-1.5 pr-3 font-medium">태그</th>
+                <th className="py-1.5 pr-3 text-right font-medium">함께구매 비율</th>
+                <th className="py-1.5 text-right font-medium">전체 달성</th>
+              </tr>
+            </thead>
+            <tbody>
+              {related.map((b) => (
+                <tr key={b.promotion_id} className="border-t border-line/60">
+                  <td className="py-1.5 pr-3 text-ink-2">{b.name}</td>
+                  <td className="py-1.5 pr-3 text-ink-4">{b.season ?? "—"}</td>
+                  <td className="py-1.5 pr-3 text-ink-4">{b.tags.join(", ") || "—"}</td>
+                  <td className="py-1.5 pr-3 text-right font-medium text-brand-700">
+                    {b.halo_ratio != null ? pct(b.halo_ratio, 0) : "—"}
+                  </td>
+                  <td className="py-1.5 text-right text-ink-3">
+                    {b.revenue_ach_total != null ? pct(b.revenue_ach_total, 0) : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/promo-analytics/app/(dash)/promotions/[id]/plan/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/page.tsx
@@ -12,6 +12,7 @@ import PlanEditor, {
   type ProductEcon,
   type QtyHint,
 } from "./PlanEditor";
+import HaloRecommendPanel, { type Bench } from "./HaloRecommendPanel";
 
 export const dynamic = "force-dynamic";
 
@@ -139,6 +140,24 @@ export default async function PlanPage({
     qtyHint = { main: m.v, sub: s.v, mainN: m.n, subN: s.n };
   }
 
+  // N8 P3: 함께 구매 벤치마크 + 추천 패널 데이터
+  const { data: benchData } = plan
+    ? await supabase.rpc("halo_benchmarks")
+    : { data: [] };
+  const benchmarks = (benchData ?? []) as Bench[];
+  const planSkuMap = new Map<string, string>();
+  for (const o of options) for (const it of o.items) planSkuMap.set(it.product_id, it.base_name);
+  const planSkus = [...planSkuMap].map(([product_id, base_name]) => ({ product_id, base_name }));
+  const planOptionsForHalo = options.map((o) => ({
+    expected_revenue: Number(o.frozen?.expected_revenue ?? 0),
+    product_ids: o.items.map((i) => i.product_id),
+  }));
+  const planTarget = planOptionsForHalo.reduce((s, o) => s + o.expected_revenue, 0);
+  const planMeta = plan as unknown as {
+    tags?: string[] | null;
+    main_product_ids?: string[] | null;
+  } | null;
+
   return (
     <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
       <div className="mb-1 text-sm text-neutral-400">
@@ -163,6 +182,18 @@ export default async function PlanPage({
         rateCard={(rc as RateCard) ?? null}
         qtyHint={qtyHint}
       />
+
+      {plan && (
+        <HaloRecommendPanel
+          promotionId={id}
+          benchmarks={benchmarks}
+          tags={planMeta?.tags ?? []}
+          mainProductIds={planMeta?.main_product_ids ?? null}
+          skus={planSkus}
+          options={planOptionsForHalo}
+          planTarget={planTarget}
+        />
+      )}
     </div>
   );
 }

--- a/promo-analytics/app/api/promotions/[id]/plan/meta/route.ts
+++ b/promo-analytics/app/api/promotions/[id]/plan/meta/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export const runtime = "nodejs";
+
+// N8 P3: 플랜 메타(자유 태그 · 메인 제품 지정) 수정.
+// 사후 분석/추천용 메타데이터이므로 confirmed 플랜이어도 허용.
+// main_product_ids 변경은 메인/함께구매 분해에 영향 → 롤업 강제 갱신.
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const body = (await req.json()) as {
+      tags?: unknown;
+      main_product_ids?: unknown;
+    };
+    const supabase = await createClient();
+
+    // 이 캠페인의 현재 플랜
+    const { data: plan } = await supabase
+      .from("campaign_plans")
+      .select("id")
+      .eq("promotion_id", id)
+      .eq("is_current", true)
+      .order("version", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (!plan)
+      return NextResponse.json({ error: "플랜을 찾을 수 없습니다" }, { status: 404 });
+
+    const patch: Record<string, unknown> = { updated_at: new Date().toISOString() };
+
+    if (Array.isArray(body.tags)) {
+      patch.tags = [
+        ...new Set(
+          body.tags.map((s) => String(s).trim()).filter((s) => s.length > 0),
+        ),
+      ];
+    }
+
+    let mainChanged = false;
+    if (body.main_product_ids === null) {
+      patch.main_product_ids = null; // null = 플랜 SKU 전체가 메인
+      mainChanged = true;
+    } else if (Array.isArray(body.main_product_ids)) {
+      patch.main_product_ids = [
+        ...new Set(body.main_product_ids.map((s) => String(s))),
+      ];
+      mainChanged = true;
+    }
+
+    const { error } = await supabase
+      .from("campaign_plans")
+      .update(patch)
+      .eq("id", plan.id);
+    if (error) throw error;
+
+    // 메인 지정이 바뀌면 메인/함께구매 분해가 달라짐 → 사전계산 갱신
+    if (mainChanged) {
+      await supabase.rpc("refresh_rollups", { p_force: true });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : "저장 실패" },
+      { status: 500 },
+    );
+  }
+}

--- a/promo-analytics/supabase/migrations/0035_n8_halo_benchmarks.sql
+++ b/promo-analytics/supabase/migrations/0035_n8_halo_benchmarks.sql
@@ -1,0 +1,51 @@
+-- 0035: N8 P3 — 캠페인 자유 태그 + 함께 구매 벤치마크(추천 프로토타입 토대)
+--
+-- 방향: 캠페인별 '메인 → 함께 구매' 비율을 누적해, 유사 성격(자유 태그)·시즌의 캠페인끼리
+--   평균을 내면 메인·예상수량만 정해도 전체 매출을 역추정/추천 가능.
+--   (운영 데이터에서 비율 편차가 큼: 벌크UP 8% vs Better Habits 199% → 태그별 그룹핑 필수)
+--
+-- 비파괴: 컬럼 추가 + 신규 함수.
+
+alter table promo.campaign_plans
+  add column if not exists tags text[] default '{}';
+
+-- 확정 플랜+실적 보유 캠페인의 함께 구매 벤치마크 (plan_vs_actual_summary 재사용)
+create or replace function promo.halo_benchmarks()
+returns table(
+  promotion_id uuid,
+  name text,
+  season text,
+  tags text[],
+  main_revenue numeric,
+  halo_revenue numeric,
+  halo_ratio numeric,
+  total_revenue numeric,
+  target_revenue numeric,
+  revenue_ach_total numeric
+)
+language sql
+stable
+set search_path = ''
+as $$
+  select
+    p.id,
+    coalesce(cp.name, p.name),
+    to_char(cp.start_date, 'YYYY-MM'),
+    coalesce(cp.tags, '{}'),
+    s.main_revenue,
+    s.halo_revenue,
+    case when coalesce(s.main_revenue, 0) > 0 then s.halo_revenue / s.main_revenue else null end,
+    s.campaign_revenue_total,
+    s.expected_revenue_total,
+    s.revenue_ach_total
+  from promo.promotions p
+  join promo.campaign_plans cp
+    on cp.promotion_id = p.id and cp.is_current and cp.status = 'confirmed'
+  cross join lateral promo.plan_vs_actual_summary(p.id) s
+  where s.has_confirmed_plan
+  order by cp.start_date nulls last;
+$$;
+
+grant execute on all functions in schema promo to authenticated;
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## N8 P3 — 함께 구매 벤치마크 + 추천 프로토타입

목표: 캠페인별 "메인 → 함께 구매" 비율을 누적해, **메인 제품·예상수량만 정하면 전체 매출을 역추정·추천**.

### 변경
- **자유 태그**(`campaign_plans.tags`) + **메인 제품 명시 지정**(`main_product_ids`) UI를 **플랜 편집 화면**에 추가.
- `promo.halo_benchmarks()` — 확정+실적 캠페인의 메인 매출·함께구매 매출·**비율**을 누적(시즌·태그 포함).
- **`HaloRecommendPanel`** (플랜 편집 화면):
  - 유사 태그 그룹의 **평균 함께구매 비율** 사용 (태그 없으면 전체).
  - **메인 기대매출 → 예상 전체 매출** = 메인 × (1 + 비율).
  - **목표 → 필요한 메인 기대매출**(역추정) = 목표 ÷ (1 + 비율) — "메인을 이만큼만 계획해도 함께구매로 목표 도달".
  - 과거 캠페인 벤치마크 표.
- `/api/promotions/[id]/plan/meta` (PATCH) — 태그·메인 저장(메인 변경 시 `refresh_rollups`).

### 운영 검증 (왜 태그 그룹핑이 필요한가)
`halo_benchmarks`: **벌크UP 8% vs Better Habits 199%** — 성격에 따라 함께구매 비율 편차가 극단적 → 전사 평균은 무의미, 유사 태그/시즌 그룹별 평균이 정답. (자유 태그로 이 그룹핑을 사용자가 직접)

### 한계 (명시)
현재 확정+실적 캠페인이 **2건**뿐 → 추정은 **프로토타입**(패널에 표기). 캠페인이 쌓이고 태그가 붙을수록 추천이 정교해지는 **메커니즘을 먼저 구축**.

### 검증
- `tsc --noEmit` 0 에러, `next build` 통과. `halo_benchmarks` 정상.

이로써 N8 P1~P3(매출 중심 달성 + 메인 수량 + 추천 프로토타입) 완료.

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_