### PR TITLE
N9: 화면 정리 + 옵션 매칭 SKU 폴백 (벌크UP 0% 해결)

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/Achievement.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/Achievement.tsx
@@ -142,31 +142,17 @@ export default function Achievement({
             매출 달성은 위 카드의 <strong>캠페인 전체(함께 구매 포함)</strong> 기준입니다. 여기 SKU 표는 <strong>메인 제품이 예상수량만큼 팔렸는지</strong>를 봅니다 — 품목 코드·정규화 이름으로 자동 매칭, 빗나간 것만 아래에서 보정하세요.
           </p>
 
-          {/* 메인 제품 예상 vs 실제 수량 — 막대 + 부족분 강조 (한눈에) */}
-          {hasConfirmed && planRows.length > 0 && (
-            <div className="mb-3 rounded-2xl card-soft p-4">
-              <div className="mb-2.5 text-xs font-medium text-ink-2">메인 제품 수량: 예상 vs 실제</div>
-              <ul className="space-y-2.5">
-                {planRows.map((r) => (
-                  <QtyBar key={r.product_id} row={r} />
-                ))}
-              </ul>
-            </div>
-          )}
-
-          {/* SKU 단위 가이드 vs 실적 */}
+          {/* SKU 단위: 매출 + 수량(예상 vs 실제) 한 표에 통합 */}
           {hasConfirmed && (
             <div className="overflow-x-auto rounded-2xl card-soft">
-              <table className="w-full min-w-[720px] text-sm">
+              <table className="w-full min-w-[680px] text-sm">
                 <thead className="bg-neutral-50 text-left text-xs text-neutral-500">
                   <tr>
-                    <th className="px-3 py-2.5 font-medium">SKU</th>
+                    <th className="px-3 py-2.5 font-medium">메인 SKU</th>
                     <th className="px-3 py-2.5 text-right font-medium">기대 매출</th>
                     <th className="px-3 py-2.5 text-right font-medium">실 매출</th>
                     <th className="px-3 py-2.5 text-right font-medium">매출 달성</th>
-                    <th className="px-3 py-2.5 text-right font-medium">기대 수량</th>
-                    <th className="px-3 py-2.5 text-right font-medium">실 수량</th>
-                    <th className="px-3 py-2.5 text-right font-medium">공헌 달성</th>
+                    <th className="px-3 py-2.5 font-medium">수량 (예상 → 실제)</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-neutral-100">
@@ -185,16 +171,14 @@ export default function Achievement({
                       <td className="px-3 py-2.5 text-right">
                         <AchPct v={r.ach_revenue} />
                       </td>
-                      <td className="px-3 py-2.5 text-right text-neutral-500">{num(r.expected_qty)}</td>
-                      <td className="px-3 py-2.5 text-right">{num(r.actual_qty)}</td>
-                      <td className="px-3 py-2.5 text-right">
-                        <AchPct v={r.ach_contribution} />
+                      <td className="px-3 py-2.5">
+                        <QtyMini row={r} />
                       </td>
                     </tr>
                   ))}
                   {planRows.length === 0 && (
                     <tr>
-                      <td colSpan={7} className="px-3 py-4 text-center text-xs text-neutral-400">
+                      <td colSpan={5} className="px-3 py-4 text-center text-xs text-neutral-400">
                         계획된 SKU가 없습니다.
                       </td>
                     </tr>
@@ -204,9 +188,17 @@ export default function Achievement({
             </div>
           )}
 
-          {/* SKU 매칭 패널 (이전 '연동 센터'에서 흡수) */}
+          {/* SKU 매칭 보정 — 기본 접힘 (요약 우선) */}
           {hasMatchData && (
-            <SkuMatchPanel promotionId={promotionId} rows={diagnosticRows} mappings={skuMappings} />
+            <details className="mt-3 rounded-xl card-soft">
+              <summary className="cursor-pointer px-4 py-3 text-xs font-semibold text-ink-2">
+                SKU 매칭 보정{unmatched > 0 ? ` · 미매칭 ${unmatched}` : ""}
+                <span className="ml-1 font-normal text-ink-4">(자동 매칭이 빗나간 경우에만)</span>
+              </summary>
+              <div className="border-t border-line/70 px-4 pb-2">
+                <SkuMatchPanel promotionId={promotionId} rows={diagnosticRows} mappings={skuMappings} />
+              </div>
+            </details>
           )}
 
           {/* 계획 외 판매 */}
@@ -245,8 +237,7 @@ export default function Achievement({
       ) : (
         <div className="mt-3">
           <p className="mb-2 text-[11px] text-neutral-400">
-            옵션(묶음) 달성은 <strong>구성·묶음수 기반 best-effort</strong> 입니다 — 실적 옵션정보가 자유 텍스트라 완전 매칭은 불가하며,
-            같은 구성의 중복 옵션엔 매출을 분배해 보여줍니다. 신뢰 기준은 위 SKU 탭입니다.
+            옵션(묶음) 달성은 <strong>best-effort</strong> 입니다 — 개입(묶음수)이 맞으면 정확 매칭, 안 맞으면(예: 8개입 계획인데 1·2·4개로 판매) <strong>SKU 실적으로 폴백</strong>해 표시합니다. 신뢰 기준은 위 SKU 탭입니다.
           </p>
           <div className="space-y-2">
             {options.map((o) => (
@@ -305,8 +296,8 @@ function AchCard({
   );
 }
 
-// 메인 제품 예상 vs 실제 수량 막대 — 달성률·부족분 강조
-function QtyBar({ row }: { row: PlanVsActualRow }) {
+// 표 셀용 컴팩트 수량 막대 — 예상 vs 실제, 달성률·부족분 강조
+function QtyMini({ row }: { row: PlanVsActualRow }) {
   const exp = row.expected_qty ?? 0;
   const act = row.actual_qty ?? 0;
   const ratio = exp > 0 ? act / exp : null;
@@ -314,32 +305,27 @@ function QtyBar({ row }: { row: PlanVsActualRow }) {
   const over = ratio != null && ratio >= 1;
   const short = exp - act;
   return (
-    <li>
+    <div className="min-w-[180px]">
       <div className="flex items-center justify-between gap-2 text-xs">
-        <span className="min-w-0 truncate text-ink-2" title={row.base_name}>
-          {row.base_name}
+        <span className="tabular-nums text-ink-3">
+          {num(exp)} <span className="text-ink-4">→</span> {num(act)}
         </span>
-        <span className="shrink-0 tabular-nums text-ink-3">
-          {num(act)} / {num(exp)}
-          {ratio != null && (
-            <span className={`ml-1.5 font-semibold ${over ? "text-green-600" : "text-amber-600"}`}>
-              {pct(ratio, 0)}
-            </span>
-          )}
-        </span>
+        {ratio != null && (
+          <span className={`font-semibold ${over ? "text-green-600" : "text-amber-600"}`}>
+            {pct(ratio, 0)}
+          </span>
+        )}
       </div>
-      <div className="mt-1 h-2 w-full overflow-hidden rounded-full bg-neutral-100">
+      <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-neutral-100">
         <div
           className={`h-full rounded-full ${over ? "bg-green-500" : "bg-amber-400"}`}
           style={{ width: `${fill}%` }}
         />
       </div>
       {!over && exp > 0 && short > 0 && (
-        <div className="mt-0.5 text-[10px] font-medium text-amber-600">
-          예상 대비 {num(short)}개 부족
-        </div>
+        <div className="mt-0.5 text-[10px] font-medium text-amber-600">{num(short)}개 부족</div>
       )}
-    </li>
+    </div>
   );
 }
 
@@ -355,6 +341,12 @@ function SourceBadge({ src }: { src: PlanVsActualOption["match_source"] }) {
     return (
       <span className="rounded bg-green-100 px-1.5 py-0.5 text-[10px] font-medium text-green-700">
         자동 (구성·묶음)
+      </span>
+    );
+  if (src === "sku")
+    return (
+      <span className="rounded bg-sky-100 px-1.5 py-0.5 text-[10px] font-medium text-sky-700">
+        SKU 실적 (개입 무관)
       </span>
     );
   if (src === "manual")

--- a/promo-analytics/lib/types.ts
+++ b/promo-analytics/lib/types.ts
@@ -249,7 +249,7 @@ export type PlanVsActualOption = {
   match_patterns: string[];
   matched: boolean;
   // N7 P2: 'routed'(구성·묶음 자동 라우팅) | 'manual'(수동 패턴) | 'none'(미매칭/저신뢰)
-  match_source: "routed" | "manual" | "none";
+  match_source: "routed" | "sku" | "manual" | "none";
   actual_revenue: number;
   actual_qty: number;
   ach_revenue: number | null;

--- a/promo-analytics/supabase/migrations/0036_n9_option_sku_fallback.sql
+++ b/promo-analytics/supabase/migrations/0036_n9_option_sku_fallback.sql
@@ -1,0 +1,144 @@
+-- 0036: N9 — 옵션 달성 매칭에 SKU 실적 폴백 (정확 개입 우선, 없으면 SKU 합으로)
+--
+-- 문제(벌크UP e4f9e870): 플랜은 모든 모래를 '8개입' 세트로 짰는데 실제 고객은 1·2·4개로만 구매
+--   → (SKU, 개입=8) 정확일치 라우팅이 한 건도 안 걸려 옵션 10개 전부 0%/미매칭(노이즈).
+--   현실에 없는 묶음 단위로 매칭을 시도한 것이 원인.
+--
+-- 해결(설계 §8.1 'SKU가 1차 진실'과 정합): 2단계 라우팅.
+--   1) 정확: 매출행의 (정규화SKU, pack_size)와 일치하는 옵션에 분배 (기존 동작 유지 — 2개입/6개입 등).
+--   2) 폴백: 정확 매칭된 옵션이 없는 매출행은 '같은 SKU의 모든 옵션'에 균등 분배(개입 무시).
+--   → 옵션의 실적 합 = 그 SKU 실적 합과 정합. 8개입처럼 비현실 단위도 SKU 실수치로 표시.
+--   match_source: 정확 기여 있으면 'routed', 폴백만이면 'sku', 수동 'manual', 없으면 'none'.
+-- 반환 시그니처 동일 → CREATE OR REPLACE. 적용 후 refresh_rollups(true) 필요.
+
+create or replace function promo.plan_vs_actual_options(p_id uuid)
+returns table(
+  option_id uuid,
+  option_label text,
+  display_label text,
+  option_signature text,
+  expected_option_qty numeric,
+  expected_revenue numeric,
+  expected_contribution numeric,
+  match_patterns text[],
+  matched boolean,
+  match_source text,
+  actual_revenue numeric,
+  actual_qty numeric,
+  ach_revenue numeric
+)
+language sql
+stable
+set search_path = ''
+as $$
+  with plan as (
+    select id, coalesce(actual_promotion_id, promotion_id) as actual_pid
+    from promo.campaign_plans
+    where promotion_id = p_id and is_current and status = 'confirmed'
+    limit 1
+  ),
+  opt as (
+    select o.id as option_id, o.option_label, o.display_label, o.option_signature,
+      o.expected_option_qty, o.expected_revenue, o.expected_contribution,
+      o.match_patterns, o.sort,
+      count(i.id) as n_items,
+      (array_agg(promo.normalize_sku_name(i.base_name)))[1] as solo_key,
+      (array_agg(i.sku_qty_per_option))[1] as solo_pack,
+      (o.match_patterns is distinct from array[o.option_label]) as manual_patterns
+    from promo.campaign_plan_options o
+    left join promo.campaign_plan_option_items i on i.campaign_plan_option_id = o.id
+    where o.campaign_plan_id = (select id from plan)
+    group by o.id, o.option_label, o.display_label, o.option_signature,
+      o.expected_option_qty, o.expected_revenue, o.expected_contribution,
+      o.match_patterns, o.sort
+  ),
+  sales as (
+    select ps.id,
+      promo.normalize_sku_name(pr.base_name) as skey,
+      coalesce(ps.pack_size, 1) as pack,
+      ps.revenue, ps.quantity, ps.option_info
+    from promo.promotion_sales ps
+    left join promo.promotion_sku_mappings mp
+      on mp.promotion_id = ps.promotion_id and mp.actual_product_id = ps.product_id
+    left join promo.products pr on pr.id = coalesce(mp.plan_product_id, ps.product_id)
+    where ps.promotion_id = (select actual_pid from plan)
+  ),
+  -- 1) 정확: (SKU, 개입) 일치 옵션
+  exact as (
+    select s.id as sale_id, o.option_id, s.revenue, s.quantity
+    from sales s
+    join opt o on o.n_items = 1 and not o.manual_patterns
+              and o.solo_key = s.skey and o.solo_pack = s.pack
+  ),
+  exact_n as (select sale_id, count(*) as n from exact group by sale_id),
+  -- 2) 폴백: 정확 매칭 없는 매출행 → 같은 SKU의 모든 단일구성 옵션
+  fb as (
+    select s.id as sale_id, o.option_id, s.revenue, s.quantity
+    from sales s
+    join opt o on o.n_items = 1 and not o.manual_patterns and o.solo_key = s.skey
+    where s.id not in (select sale_id from exact_n)
+  ),
+  fb_n as (select sale_id, count(*) as n from fb group by sale_id),
+  routed as (
+    select e.option_id,
+      sum(e.revenue::numeric / en.n) as ar, sum(e.quantity::numeric / en.n) as aq,
+      count(*) as n, true as is_exact
+    from exact e join exact_n en on en.sale_id = e.sale_id
+    group by e.option_id
+    union all
+    select f.option_id,
+      sum(f.revenue::numeric / fn.n), sum(f.quantity::numeric / fn.n),
+      count(*), false
+    from fb f join fb_n fn on fn.sale_id = f.sale_id
+    group by f.option_id
+  ),
+  routed_agg as (
+    select option_id,
+      sum(ar) as actual_revenue, sum(aq) as actual_qty, sum(n) as n,
+      bool_or(is_exact) as has_exact
+    from routed group by option_id
+  ),
+  manual as (
+    select o.option_id,
+      sum(s.revenue) as actual_revenue, sum(s.quantity) as actual_qty, count(*) as n
+    from opt o
+    join sales s on o.manual_patterns and exists (
+      select 1 from unnest(o.match_patterns) pat
+      where length(btrim(pat)) > 0
+        and position(
+          lower(regexp_replace(pat, '\s', '', 'g'))
+          in lower(regexp_replace(coalesce(s.option_info, ''), '\s', '', 'g'))
+        ) > 0
+    )
+    group by o.option_id
+  ),
+  acc as (
+    select option_id, actual_revenue, actual_qty, n,
+      case when has_exact then 'routed' else 'sku' end as src
+    from routed_agg
+    union all
+    select option_id, actual_revenue, actual_qty, n, 'manual' as src
+    from manual
+  ),
+  acc2 as (
+    select option_id, max(src) as src,
+      sum(actual_revenue) as actual_revenue, sum(actual_qty) as actual_qty, sum(n) as n
+    from acc group by option_id
+  )
+  select o.option_id, o.option_label, o.display_label, o.option_signature,
+    o.expected_option_qty, o.expected_revenue, o.expected_contribution,
+    o.match_patterns,
+    coalesce(a.n, 0) > 0 as matched,
+    coalesce(a.src, case when o.manual_patterns then 'manual' else 'none' end) as match_source,
+    coalesce(a.actual_revenue, 0) as actual_revenue,
+    coalesce(a.actual_qty, 0) as actual_qty,
+    case when coalesce(o.expected_revenue, 0) > 0
+      then coalesce(a.actual_revenue, 0) / o.expected_revenue else null end as ach_revenue
+  from opt o
+  left join acc2 a on a.option_id = o.option_id
+  order by o.sort;
+$$;
+
+grant execute on all functions in schema promo to authenticated;
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## N9 — 화면 정리 + 옵션 매칭 SKU 폴백

벌크UP 캠페인 피드백 반영: "쓸데없는 데이터 많고, 옵션 매칭 전부 0%, 중복·과밀."

### 1) 옵션 매칭 SKU 폴백 (`migration 0036`) — 0% 문제 해결
- 원인: 플랜이 모든 모래를 **8개입 세트**로 짰는데 실제는 **1·2·4개**로만 판매 → `(SKU, 개입=8)` 정확일치가 한 건도 안 걸려 옵션 10개 **전부 0%**.
- 수정: **2단계 라우팅** — 개입 정확 매칭 우선, 없으면 **같은 SKU의 옵션에 SKU 실적 폴백**(`match_source='sku'`). 옵션 합 = SKU 합으로 정합.
- 결과(벌크UP): 0% → **하드볼 56%·마스터 44%·원티드 43%…** 실수치. Better Habits 회귀 없음(개입 정확 매칭 유지).

### 2) 화면 정리 (요약 중심·나머지 접기)
- **중복 제거**: '메인 수량 막대 10개'와 '아래 SKU 표'가 같은 데이터였음 → **한 표로 통합**(표의 '수량' 칸에 예상→실제 막대·부족분 내장). 표 컬럼도 5개로 슬림.
- **SKU 매칭 보정 패널 기본 접힘**(`<details>`) — 미매칭 N건은 펼쳐야 보임(평소엔 노이즈 제거).
- 옵션 `match_source='sku'` 배지(**SKU 실적·개입 무관**) 추가, 옵션 탭 설명 갱신.

### 검증
- `tsc` 0 에러, `next build` 통과. 벌크UP/Better Habits 옵션 합 = SKU 합 확인.

> 이 PR은 **벌크UP 화면을 직접 보고 평가**하시도록 자동 머지 보류했습니다. 프리뷰 확인 후 "머지"라고 하시면 반영하겠습니다.

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_