### PR TITLE
N11: 정기구독을 상품으로 식별 + 달성 제외 + 별도 표기

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/Achievement.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/Achievement.tsx
@@ -101,10 +101,19 @@ export default function Achievement({
             <span>
               전체 <strong className="text-ink">{wonShort(summary!.campaign_revenue_total)}</strong>
             </span>
-            {(summary!.subscription_revenue ?? 0) > 0 && (
-              <span className="text-ink-4">· 구독 {wonShort(summary!.subscription_revenue)} 제외</span>
-            )}
           </div>
+          {(summary!.subscription_revenue ?? 0) > 0 && (
+            <div className="mt-2 flex flex-wrap items-center gap-2 rounded-xl border border-violet-200 bg-violet-50/60 px-4 py-2.5 text-xs">
+              <span className="rounded bg-violet-100 px-1.5 py-0.5 text-[10px] font-medium text-violet-700">
+                정기구독
+              </span>
+              <span className="text-ink-2">
+                정기구독 매출{" "}
+                <strong className="text-violet-700">{wonShort(summary!.subscription_revenue)}</strong>
+              </span>
+              <span className="text-ink-4">— 달성률·함께 구매 계산에서 제외(별도 집계)</span>
+            </div>
+          )}
         </>
       ) : (
         <p className="rounded-xl card-soft px-4 py-3 text-xs text-neutral-500">

--- a/promo-analytics/app/(dash)/promotions/[id]/SkuMatchPanel.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/SkuMatchPanel.tsx
@@ -16,6 +16,7 @@ export type DiagnosticRow = {
   actual_qty: number | null;
   actual_revenue: number | null;
   is_mapped: boolean;
+  is_subscription: boolean;
 };
 
 export type SkuMapping = {
@@ -89,6 +90,23 @@ export default function SkuMatchPanel({
       return;
     }
     toast.success(`${nameOf(planPid)} 연동됨`);
+    router.refresh();
+  }
+
+  async function toggleSubscription(productId: string, next: boolean) {
+    setBusyKey(productId);
+    const res = await fetch(`/api/products/subscription`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ product_id: productId, is_subscription: next }),
+    });
+    setBusyKey(null);
+    if (!res.ok) {
+      const j = await res.json().catch(() => ({}));
+      toast.error(j.error ?? "구독 지정 실패");
+      return;
+    }
+    toast.success(next ? "정기구독으로 지정됨" : "정기구독 해제됨");
     router.refresh();
   }
 
@@ -257,6 +275,7 @@ export default function SkuMatchPanel({
                     <th className="px-2 py-2 text-right font-medium">기대매출</th>
                     <th className="px-2 py-2 text-right font-medium">실수량</th>
                     <th className="px-2 py-2 text-right font-medium">실매출</th>
+                    <th className="px-2 py-2 text-center font-medium">정기구독</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -283,11 +302,25 @@ export default function SkuMatchPanel({
                       <td className="px-2 py-2 text-right text-ink-3">
                         {r.actual_revenue ? won(r.actual_revenue) : "—"}
                       </td>
+                      <td className="px-2 py-2 text-center">
+                        <button
+                          onClick={() => toggleSubscription(r.product_id, !r.is_subscription)}
+                          disabled={busyKey === r.product_id}
+                          title="정기구독 상품으로 지정하면 달성률에서 제외되고 별도 표기됩니다"
+                          className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${
+                            r.is_subscription
+                              ? "bg-violet-100 text-violet-700"
+                              : "bg-soft text-ink-4 hover:text-ink-2"
+                          }`}
+                        >
+                          {r.is_subscription ? "✓ 구독" : "구독 지정"}
+                        </button>
+                      </td>
                     </tr>
                   ))}
                   {filtered.length === 0 && (
                     <tr>
-                      <td colSpan={6} className="px-2 py-6 text-center text-ink-4">
+                      <td colSpan={7} className="px-2 py-6 text-center text-ink-4">
                         {query ? "검색 결과가 없습니다." : "플랜·실적 모두 없습니다."}
                       </td>
                     </tr>

--- a/promo-analytics/app/api/products/subscription/route.ts
+++ b/promo-analytics/app/api/products/subscription/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export const runtime = "nodejs";
+
+// N11: 상품(품목)을 정기구독으로 지정/해제. 구독 매출은 달성률 계산에서 제외되고 별도 표기됨.
+// 전역 속성(모든 캠페인 공통) → 변경 시 사전계산(롤업) 갱신.
+export async function PATCH(req: Request) {
+  try {
+    const body = (await req.json()) as {
+      product_id?: unknown;
+      is_subscription?: unknown;
+    };
+    if (!body.product_id || typeof body.product_id !== "string") {
+      return NextResponse.json({ error: "product_id 필요" }, { status: 400 });
+    }
+    const supabase = await createClient();
+    const { error } = await supabase
+      .from("products")
+      .update({ is_subscription: !!body.is_subscription })
+      .eq("id", body.product_id);
+    if (error) throw error;
+
+    await supabase.rpc("refresh_rollups", { p_force: true });
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : "저장 실패" },
+      { status: 500 },
+    );
+  }
+}

--- a/promo-analytics/supabase/migrations/0037_n11_subscription_products.sql
+++ b/promo-analytics/supabase/migrations/0037_n11_subscription_products.sql
@@ -1,0 +1,179 @@
+-- 0037: N11 — 정기구독을 '상품(품목)' 단위로 식별 + 달성에서 제외(별도 표기 토대)
+--
+-- 사용자 결정: 구독은 option_info 텍스트가 아니라 '상품(품목)'으로 식별, 화면엔 제외 + 별도 섹션.
+-- (Better Habits는 텍스트로 0건 — 상품 플래그가 맞는 접근)
+--
+-- 비파괴: products에 플래그 컬럼 추가, 집계 함수는 그 플래그를 사용(텍스트는 폴백 유지).
+
+alter table promo.products
+  add column if not exists is_subscription boolean not null default false;
+
+-- ── plan_vs_actual_summary: 구독 식별 = 상품 플래그 or (폴백) 텍스트 ──────────
+-- (반환 시그니처 0034와 동일 — 본문의 is_sub 판정만 교체)
+create or replace function promo.plan_vs_actual_summary(p_id uuid)
+returns table(
+  has_confirmed_plan boolean,
+  expected_revenue_total numeric, actual_revenue_total numeric, ach_revenue numeric,
+  expected_qty_total numeric, actual_qty_total numeric, ach_qty numeric,
+  expected_contribution_total numeric, actual_contribution_total numeric, ach_contribution numeric,
+  unplanned_revenue numeric, unplanned_qty numeric, unplanned_contribution numeric,
+  matched_sku_count integer, unsold_sku_count integer, unplanned_sku_count integer,
+  quantity_reliable boolean, snapshot_mult numeric,
+  subscription_revenue numeric, main_revenue numeric, halo_revenue numeric,
+  campaign_revenue_total numeric, revenue_ach_total numeric,
+  contribution_total numeric, contribution_ach_total numeric
+)
+language plpgsql stable set search_path to ''
+as $function$
+declare
+  v_has boolean; v_mult numeric; v_plan_id uuid; v_actual_pid uuid; v_main uuid[];
+begin
+  select true, (rate_card_snapshot->>'mult')::numeric, id,
+         coalesce(actual_promotion_id, promotion_id), main_product_ids
+    into v_has, v_mult, v_plan_id, v_actual_pid, v_main
+  from promo.campaign_plans
+  where promotion_id = p_id and is_current and status = 'confirmed' limit 1;
+
+  if not coalesce(v_has, false) then
+    return query select false,
+      null::numeric, null::numeric, null::numeric, null::numeric, null::numeric, null::numeric,
+      null::numeric, null::numeric, null::numeric, null::numeric, null::numeric, null::numeric,
+      null::int, null::int, null::int, null::boolean, null::numeric,
+      null::numeric, null::numeric, null::numeric, null::numeric, null::numeric, null::numeric, null::numeric;
+    return;
+  end if;
+
+  return query
+  with rows as (select * from promo.plan_vs_actual(p_id)),
+  exp_rows as (select * from rows where status in ('matched','unsold')),
+  unp_rows as (select * from rows where status = 'unplanned'),
+  main_keys as (
+    select distinct promo.normalize_sku_name(pr.base_name) as k
+    from promo.campaign_plan_option_items i
+    join promo.campaign_plan_options o on o.id = i.campaign_plan_option_id
+    join promo.products pr on pr.id = i.product_id
+    where o.campaign_plan_id = v_plan_id and (v_main is null or i.product_id = any(v_main))
+  ),
+  sales as (
+    select ps.revenue, coalesce(ps.cost,0) as cost,
+      (coalesce(pr.is_subscription, false)
+        or ps.option_info ilike '%정기배송%' or ps.option_info ilike '%구독%') as is_sub,
+      (promo.normalize_sku_name(pr.base_name) in (select k from main_keys)) as is_main
+    from promo.promotion_sales ps
+    left join promo.products pr on pr.id = ps.product_id
+    where ps.promotion_id = v_actual_pid
+  ),
+  agg as (
+    select
+      coalesce(sum(revenue) filter (where is_sub), 0) as sub_rev,
+      coalesce(sum(revenue) filter (where is_main and not is_sub), 0) as main_rev,
+      coalesce(sum(revenue) filter (where not is_main and not is_sub), 0) as halo_rev,
+      coalesce(sum(revenue) filter (where not is_sub), 0) as total_rev,
+      coalesce(sum(cost) filter (where not is_sub), 0) as total_cost
+    from sales
+  ),
+  e as (
+    select coalesce(sum(expected_revenue),0) exp_rev, coalesce(sum(actual_revenue),0) act_rev,
+      coalesce(sum(expected_qty),0) exp_qty, coalesce(sum(actual_qty),0) act_qty,
+      coalesce(sum(expected_contribution),0) exp_contrib, coalesce(sum(actual_contribution),0) act_contrib
+    from exp_rows
+  )
+  select true,
+    e.exp_rev, e.act_rev,
+    case when e.exp_rev > 0 then e.act_rev/e.exp_rev else null end,
+    e.exp_qty, e.act_qty,
+    case when e.exp_qty > 0 then e.act_qty/e.exp_qty else null end,
+    e.exp_contrib, e.act_contrib,
+    case when e.exp_contrib > 0 then e.act_contrib/e.exp_contrib else null end,
+    (select coalesce(sum(actual_revenue),0) from unp_rows),
+    (select coalesce(sum(actual_qty),0) from unp_rows),
+    (select coalesce(sum(actual_contribution),0) from unp_rows),
+    (select count(*)::int from rows where status = 'matched'),
+    (select count(*)::int from rows where status = 'unsold'),
+    (select count(*)::int from unp_rows),
+    (e.act_qty > 0), v_mult,
+    a.sub_rev, a.main_rev, a.halo_rev, a.total_rev,
+    case when e.exp_rev > 0 then a.total_rev/e.exp_rev else null end,
+    (a.total_rev * v_mult - a.total_cost),
+    case when e.exp_contrib > 0 then (a.total_rev * v_mult - a.total_cost)/e.exp_contrib else null end
+  from e, agg a;
+end;
+$function$;
+
+-- ── sku_match_diagnostic: is_subscription 컬럼 추가 ──────────────────────────
+drop function if exists promo.sku_match_diagnostic(uuid);
+create function promo.sku_match_diagnostic(p_id uuid)
+returns table(side text, product_id uuid, base_name text, dr_code text,
+  expected_qty numeric, expected_revenue numeric, actual_qty numeric, actual_revenue numeric,
+  is_mapped boolean, is_subscription boolean)
+language sql stable set search_path to ''
+as $function$
+  with current_plan as (
+    select id, coalesce(actual_promotion_id, promotion_id) as actual_pid
+    from promo.campaign_plans where promotion_id = p_id and is_current
+    order by version desc limit 1
+  ),
+  plan_raw as (
+    select cpoi.product_id, pr.base_name, pr.dr_code,
+      promo.normalize_sku_name(pr.base_name) as match_key,
+      cpo.expected_option_qty * cpoi.sku_qty_per_option as q,
+      cpo.expected_option_qty * cpoi.sku_qty_per_option * cpoi.unit_sale_price as r
+    from promo.campaign_plan_options cpo
+    join promo.campaign_plan_option_items cpoi on cpoi.campaign_plan_option_id = cpo.id
+    left join promo.products pr on pr.id = cpoi.product_id
+    where cpo.campaign_plan_id = (select id from current_plan)
+  ),
+  plan_skus as (
+    select match_key,
+      (array_agg(product_id order by product_id))[1] as product_id,
+      (array_agg(base_name order by base_name))[1] as base_name,
+      (array_agg(dr_code order by dr_code) filter (where dr_code is not null))[1] as dr_code,
+      sum(q) as expected_qty, sum(r) as expected_revenue
+    from plan_raw group by match_key
+  ),
+  mapped_sales as (
+    select coalesce(m.plan_product_id, ps.product_id) as product_id,
+      (m.plan_product_id is not null) as is_mapped,
+      pr.base_name, pr.dr_code, promo.normalize_sku_name(pr.base_name) as match_key,
+      ps.quantity, ps.revenue
+    from promo.promotion_sales ps
+    left join promo.promotion_sku_mappings m
+      on m.promotion_id = ps.promotion_id and m.actual_product_id = ps.product_id
+    left join promo.products pr on pr.id = coalesce(m.plan_product_id, ps.product_id)
+    where ps.promotion_id = coalesce((select actual_pid from current_plan), p_id)
+      and ps.product_id is not null
+  ),
+  actual_skus as (
+    select match_key,
+      (array_agg(product_id order by product_id))[1] as product_id,
+      (array_agg(base_name order by base_name))[1] as base_name,
+      (array_agg(dr_code order by dr_code) filter (where dr_code is not null))[1] as dr_code,
+      bool_or(is_mapped) as is_mapped, sum(quantity) as actual_qty, sum(revenue) as actual_revenue
+    from mapped_sales group by match_key
+  ),
+  combined as (
+    select coalesce(p.product_id, a.product_id) as product_id,
+      coalesce(p.base_name, a.base_name) as base_name,
+      coalesce(p.dr_code, a.dr_code) as dr_code,
+      coalesce(p.expected_qty, 0) as expected_qty,
+      coalesce(p.expected_revenue, 0) as expected_revenue,
+      coalesce(a.actual_qty, 0) as actual_qty,
+      coalesce(a.actual_revenue, 0) as actual_revenue,
+      coalesce(a.is_mapped, false) as is_mapped,
+      case when p.match_key is not null and a.match_key is not null then 'both'
+        when p.match_key is not null then 'plan' else 'actual' end as side
+    from plan_skus p
+    full outer join actual_skus a on a.match_key = p.match_key
+  )
+  select c.side, c.product_id, c.base_name, c.dr_code,
+    c.expected_qty, c.expected_revenue, c.actual_qty, c.actual_revenue, c.is_mapped,
+    coalesce(sp.is_subscription, false) as is_subscription
+  from combined c
+  left join promo.products sp on sp.id = c.product_id
+  order by
+    case c.side when 'both' then 0 when 'plan' then 1 else 2 end,
+    coalesce(c.expected_revenue, 0) desc, coalesce(c.actual_revenue, 0) desc;
+$function$;
+
+grant execute on all functions in schema promo to authenticated;
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## N11 — 정기구독을 상품(품목)으로 식별 + 달성 제외 + 별도 표기

질문에 대한 답이자 수정: "정기구독 상품은 빠진거야? 별도 표기야?" → 이제 **상품(품목)으로 식별 → 달성률에서 제외 + 별도 섹션으로 표기**.

### 배경
- 기존 구독 식별은 `option_info` 텍스트('정기배송/구독')였는데, Better Habits는 텍스트로 **0건** → 구독이 잡히지 않았음.
- 사용자 결정: **상품(품목)으로 식별**, **제외 + 별도 섹션**.

### 변경 (`migration 0037`)
- `products.is_subscription` 플래그 추가(전역 속성).
- `plan_vs_actual_summary`: 구독 판정 = **상품 플래그** or (폴백) 텍스트. 구독 매출은 main/halo/전체매출/공헌 계산에서 **제외**.
- `sku_match_diagnostic`: `is_subscription` 노출.
- API `PATCH /api/products/subscription`: 품목 구독 지정/해제 + `refresh_rollups`.

### UI
- **진단표 각 행에 '구독 지정' 토글** + 구독 배지(보라색) — 여기서 구독 상품을 직접 지정.
- 캠페인 상세에 **"정기구독 매출 (별도)" 섹션** — `subscription_revenue>0`일 때, "달성률·함께 구매에서 제외(별도 집계)" 명시.

### 검증
- 프로바이오틱스를 임시로 구독 지정 → 구독 ₩2.27M 분리, halo 57.9M→55.7M, 전체 달성 160%→156% 확인 후 원복.
- `tsc` 0 에러, `next build` 통과. (현재 지정된 구독 상품 0개 → 기존 화면 변화 없음, 지정 시 반영)

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_