### PR TITLE
N14: 정기구독 식별을 상품 플래그로 일원화 (Codex 리뷰)

### DIFF
--- a/promo-analytics/supabase/migrations/0038_n11_subscription_product_only.sql
+++ b/promo-analytics/supabase/migrations/0038_n11_subscription_product_only.sql
@@ -1,0 +1,100 @@
+-- 0038: N11 후속 — 정기구독 식별을 '상품 플래그'로 일원화 (텍스트 폴백 제거)
+--
+-- 배경: 0037은 구독 판정 = products.is_subscription OR option_info 텍스트('정기배송/구독').
+--   그런데 화면의 SKU 진단표/함께구매 목록은 products.is_subscription만 사용 → 텍스트로만
+--   잡힌 구독이 요약(제외)과 목록(노출)에서 엇갈림(불일치).
+-- 사용자 결정은 '상품(품목)으로 식별' → 텍스트 폴백을 제거해 전 구간(요약·진단·함께구매)이
+--   products.is_subscription 하나로 일관되게 동작하도록 통일.
+-- (반환 시그니처 0037과 동일 — 본문 is_sub 판정만 product flag로 축소)
+
+create or replace function promo.plan_vs_actual_summary(p_id uuid)
+returns table(
+  has_confirmed_plan boolean,
+  expected_revenue_total numeric, actual_revenue_total numeric, ach_revenue numeric,
+  expected_qty_total numeric, actual_qty_total numeric, ach_qty numeric,
+  expected_contribution_total numeric, actual_contribution_total numeric, ach_contribution numeric,
+  unplanned_revenue numeric, unplanned_qty numeric, unplanned_contribution numeric,
+  matched_sku_count integer, unsold_sku_count integer, unplanned_sku_count integer,
+  quantity_reliable boolean, snapshot_mult numeric,
+  subscription_revenue numeric, main_revenue numeric, halo_revenue numeric,
+  campaign_revenue_total numeric, revenue_ach_total numeric,
+  contribution_total numeric, contribution_ach_total numeric
+)
+language plpgsql stable set search_path to ''
+as $function$
+declare
+  v_has boolean; v_mult numeric; v_plan_id uuid; v_actual_pid uuid; v_main uuid[];
+begin
+  select true, (rate_card_snapshot->>'mult')::numeric, id,
+         coalesce(actual_promotion_id, promotion_id), main_product_ids
+    into v_has, v_mult, v_plan_id, v_actual_pid, v_main
+  from promo.campaign_plans
+  where promotion_id = p_id and is_current and status = 'confirmed' limit 1;
+
+  if not coalesce(v_has, false) then
+    return query select false,
+      null::numeric, null::numeric, null::numeric, null::numeric, null::numeric, null::numeric,
+      null::numeric, null::numeric, null::numeric, null::numeric, null::numeric, null::numeric,
+      null::int, null::int, null::int, null::boolean, null::numeric,
+      null::numeric, null::numeric, null::numeric, null::numeric, null::numeric, null::numeric, null::numeric;
+    return;
+  end if;
+
+  return query
+  with rows as (select * from promo.plan_vs_actual(p_id)),
+  exp_rows as (select * from rows where status in ('matched','unsold')),
+  unp_rows as (select * from rows where status = 'unplanned'),
+  main_keys as (
+    select distinct promo.normalize_sku_name(pr.base_name) as k
+    from promo.campaign_plan_option_items i
+    join promo.campaign_plan_options o on o.id = i.campaign_plan_option_id
+    join promo.products pr on pr.id = i.product_id
+    where o.campaign_plan_id = v_plan_id and (v_main is null or i.product_id = any(v_main))
+  ),
+  sales as (
+    select ps.revenue, coalesce(ps.cost,0) as cost,
+      coalesce(pr.is_subscription, false) as is_sub,
+      (promo.normalize_sku_name(pr.base_name) in (select k from main_keys)) as is_main
+    from promo.promotion_sales ps
+    left join promo.products pr on pr.id = ps.product_id
+    where ps.promotion_id = v_actual_pid
+  ),
+  agg as (
+    select
+      coalesce(sum(revenue) filter (where is_sub), 0) as sub_rev,
+      coalesce(sum(revenue) filter (where is_main and not is_sub), 0) as main_rev,
+      coalesce(sum(revenue) filter (where not is_main and not is_sub), 0) as halo_rev,
+      coalesce(sum(revenue) filter (where not is_sub), 0) as total_rev,
+      coalesce(sum(cost) filter (where not is_sub), 0) as total_cost
+    from sales
+  ),
+  e as (
+    select coalesce(sum(expected_revenue),0) exp_rev, coalesce(sum(actual_revenue),0) act_rev,
+      coalesce(sum(expected_qty),0) exp_qty, coalesce(sum(actual_qty),0) act_qty,
+      coalesce(sum(expected_contribution),0) exp_contrib, coalesce(sum(actual_contribution),0) act_contrib
+    from exp_rows
+  )
+  select true,
+    e.exp_rev, e.act_rev,
+    case when e.exp_rev > 0 then e.act_rev/e.exp_rev else null end,
+    e.exp_qty, e.act_qty,
+    case when e.exp_qty > 0 then e.act_qty/e.exp_qty else null end,
+    e.exp_contrib, e.act_contrib,
+    case when e.exp_contrib > 0 then e.act_contrib/e.exp_contrib else null end,
+    (select coalesce(sum(actual_revenue),0) from unp_rows),
+    (select coalesce(sum(actual_qty),0) from unp_rows),
+    (select coalesce(sum(actual_contribution),0) from unp_rows),
+    (select count(*)::int from rows where status = 'matched'),
+    (select count(*)::int from rows where status = 'unsold'),
+    (select count(*)::int from unp_rows),
+    (e.act_qty > 0), v_mult,
+    a.sub_rev, a.main_rev, a.halo_rev, a.total_rev,
+    case when e.exp_rev > 0 then a.total_rev/e.exp_rev else null end,
+    (a.total_rev * v_mult - a.total_cost),
+    case when e.exp_contrib > 0 then (a.total_rev * v_mult - a.total_cost)/e.exp_contrib else null end
+  from e, agg a;
+end;
+$function$;
+
+grant execute on all functions in schema promo to authenticated;
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## N14 — 정기구독 식별 일원화 (텍스트 폴백 제거) · Codex 리뷰 반영

PR #88에 대한 Codex 리뷰: `plan_vs_actual_summary`는 구독 = `products.is_subscription` **OR** `option_info` 텍스트('정기배송/구독')로 보지만, 화면(진단표·함께구매 목록)은 **상품 플래그만** 사용 → 텍스트로만 잡힌 구독이 **요약(제외) vs 목록(노출)에서 엇갈림**.

### 수정 (`migration 0038`)
- 사용자 결정("**상품으로 식별**")에 맞춰 summary의 구독 판정에서 **텍스트 폴백 제거** → `products.is_subscription` 단일 기준.
- 이제 **요약 · SKU 진단표 · 함께 구매 목록**이 모두 같은 기준 → 완전 일관.
- 운영 DB 적용 + `refresh_rollups`.

### 영향
- 텍스트로만 잡히던 일부 구독 매출(타 캠페인 ~6.26M)은 해당 품목을 '구독 지정'하기 전까진 일반/함께구매로 집계 — 의도된 상품 기반 모델과 일치. (Better Habits 영향 0)

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_