### PR TITLE
PR2: 캠페인 상세 정보구조 개편 (워크플로 바 + 요약→조치→분석 탭)

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/Achievement.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/Achievement.tsx
@@ -23,6 +23,7 @@ export default function Achievement({
   optionInfos,
   diagnosticRows,
   skuMappings,
+  hideSummaryCards,
 }: {
   promotionId: string;
   summary: PlanVsActualSummary | null;
@@ -31,6 +32,7 @@ export default function Achievement({
   optionInfos: string[];
   diagnosticRows: DiagnosticRow[];
   skuMappings: SkuMapping[];
+  hideSummaryCards?: boolean; // Layer A 히어로 KPI와 중복 방지
 }) {
   const [tab, setTab] = useState<"sku" | "option">("sku");
 
@@ -78,34 +80,36 @@ export default function Achievement({
       {/* 달성 카드 (N8 매출 중심): 매출은 전체 실적/목표, 수량은 메인 제품 */}
       {hasConfirmed ? (
         <>
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-            <AchCard
-              label="캠페인 매출 달성 (전체)"
-              ach={summary!.revenue_ach_total}
-              actual={summary!.campaign_revenue_total}
-              expected={summary!.expected_revenue_total}
-              primary
-            />
-            <AchCard
-              label="메인 제품 수량 달성"
-              ach={summary!.ach_qty}
-              actual={summary!.actual_qty_total}
-              expected={summary!.expected_qty_total}
-              isQty
-              lowData={summary!.quantity_reliable === false}
-            />
-            <AchCard
-              label="공헌이익 달성 (전체)"
-              ach={summary!.contribution_ach_total}
-              actual={summary!.contribution_total}
-              expected={summary!.expected_contribution_total}
-              note={
-                (summary!.expected_contribution_total ?? 0) <= 0
-                  ? "기대 공헌이 0 이하 — 플랜 원가/판매가 확인 필요"
-                  : undefined
-              }
-            />
-          </div>
+          {!hideSummaryCards && (
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+              <AchCard
+                label="캠페인 매출 달성 (전체)"
+                ach={summary!.revenue_ach_total}
+                actual={summary!.campaign_revenue_total}
+                expected={summary!.expected_revenue_total}
+                primary
+              />
+              <AchCard
+                label="메인 제품 수량 달성"
+                ach={summary!.ach_qty}
+                actual={summary!.actual_qty_total}
+                expected={summary!.expected_qty_total}
+                isQty
+                lowData={summary!.quantity_reliable === false}
+              />
+              <AchCard
+                label="공헌이익 달성 (전체)"
+                ach={summary!.contribution_ach_total}
+                actual={summary!.contribution_total}
+                expected={summary!.expected_contribution_total}
+                note={
+                  (summary!.expected_contribution_total ?? 0) <= 0
+                    ? "기대 공헌이 0 이하 — 플랜 원가/판매가 확인 필요"
+                    : undefined
+                }
+              />
+            </div>
+          )}
           {/* 매출 구성: 메인 + 함께 구매 (구독 제외) */}
           <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 rounded-xl bg-soft px-4 py-2.5 text-[11px] text-ink-3">
             <span>

--- a/promo-analytics/app/(dash)/promotions/[id]/ActionPanel.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/ActionPanel.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+import { InlineAlert } from "@/components/ui";
+import type { ActionItem } from "@/lib/campaign-workflow";
+
+// Layer B — 문제 있는 항목만. 각 조치에 바로가기 CTA.
+export function ActionPanel({ actions, basePath }: { actions: ActionItem[]; basePath: string }) {
+  if (actions.length === 0) {
+    return (
+      <InlineAlert tone="success" title="지금 필요한 조치가 없습니다">
+        달성 결과를 검토하고 회고를 남겨보세요.
+      </InlineAlert>
+    );
+  }
+  return (
+    <div className="space-y-2">
+      {actions.map((a) => {
+        const href = a.href ?? (a.view ? `${basePath}?view=${a.view}` : undefined);
+        return (
+          <InlineAlert
+            key={a.id}
+            tone={a.tone}
+            title={a.title}
+            action={
+              a.actionLabel && href ? (
+                <Link
+                  href={href}
+                  scroll={false}
+                  className="rounded-lg bg-card/70 px-2.5 py-1 text-[11px] font-semibold text-ink-2 hover:bg-card focus-visible:outline-none"
+                >
+                  {a.actionLabel} →
+                </Link>
+              ) : undefined
+            }
+          >
+            {a.body}
+          </InlineAlert>
+        );
+      })}
+    </div>
+  );
+}

--- a/promo-analytics/app/(dash)/promotions/[id]/CampaignWorkflowBar.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/CampaignWorkflowBar.tsx
@@ -1,0 +1,67 @@
+import Link from "next/link";
+import { cn } from "@/lib/cn";
+import { WORKFLOW_TONE, TONE_CLASSES } from "@/lib/status";
+import type { WorkflowStep } from "@/lib/campaign-workflow";
+
+// 생애주기 워크플로 바 — 현재 단계 하나만 강조, 완료=체크, 경고/차단=아이콘+색.
+// 클릭 시 해당 상세 탭으로 이동(URL). 모바일은 가로 스크롤.
+const GLYPH = {
+  complete: "✓",
+  current: "●",
+  warning: "⚠",
+  blocked: "✕",
+  pending: "○",
+} as const;
+
+export function CampaignWorkflowBar({
+  steps,
+  basePath,
+}: {
+  steps: WorkflowStep[];
+  basePath: string; // 예: /promotions/[id]
+}) {
+  return (
+    <nav aria-label="캠페인 진행 단계" className="mb-5">
+      <ol className="flex items-stretch gap-1 overflow-x-auto rounded-2xl card-soft p-1.5">
+        {steps.map((s) => {
+          const tone = WORKFLOW_TONE[s.status];
+          const active = s.status === "current" || s.status === "warning" || s.status === "blocked";
+          const href = s.view ? `${basePath}?view=${s.view}` : undefined;
+          const inner = (
+            <div
+              className={cn(
+                "flex min-w-[7.5rem] flex-col gap-0.5 rounded-xl px-3 py-2 transition-colors",
+                "[transition-duration:var(--duration-fast)]",
+                active ? TONE_CLASSES[tone].soft : "text-ink-4 hover:bg-soft",
+              )}
+              aria-current={s.status === "current" ? "step" : undefined}
+            >
+              <div className="flex items-center gap-1.5">
+                <span aria-hidden className={cn("text-[11px] leading-none", active ? "" : "text-ink-4")}>
+                  {GLYPH[s.status]}
+                </span>
+                <span className={cn("text-xs font-semibold", active ? "" : "text-ink-3")}>{s.label}</span>
+              </div>
+              {s.description && (active || s.status === "complete") && (
+                <span className={cn("truncate text-[10px]", active ? "opacity-90" : "text-ink-4")}>
+                  {s.description}
+                </span>
+              )}
+            </div>
+          );
+          return (
+            <li key={s.id} className="shrink-0">
+              {href ? (
+                <Link href={href} scroll={false} className="block focus-visible:outline-none">
+                  {inner}
+                </Link>
+              ) : (
+                inner
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/promo-analytics/app/(dash)/promotions/[id]/DetailTabsNav.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/DetailTabsNav.tsx
@@ -1,0 +1,54 @@
+import Link from "next/link";
+import { cn } from "@/lib/cn";
+
+// 상세 심층분석 탭 — URL(?view=)로 보존, 선택 탭만 서버 렌더(lazy). 네비게이션 기반(공유·뒤로가기 정상).
+export type DetailView = "overview" | "skus" | "trend" | "purpose" | "sources";
+
+export const DETAIL_VIEWS: { id: DetailView; label: string }[] = [
+  { id: "overview", label: "성과 개요" },
+  { id: "skus", label: "SKU·옵션" },
+  { id: "trend", label: "매출 흐름" },
+  { id: "purpose", label: "목적 분석" },
+  { id: "sources", label: "데이터·회고" },
+];
+
+export function DetailTabsNav({
+  active,
+  basePath,
+  badges,
+}: {
+  active: DetailView;
+  basePath: string;
+  badges?: Partial<Record<DetailView, number>>;
+}) {
+  return (
+    <div className="sticky top-0 z-10 -mx-1 mb-4 bg-canvas/80 px-1 py-2 backdrop-blur">
+      <nav aria-label="상세 분석 보기" className="flex items-center gap-1 overflow-x-auto">
+        {DETAIL_VIEWS.map((v) => {
+          const on = v.id === active;
+          const badge = badges?.[v.id];
+          return (
+            <Link
+              key={v.id}
+              href={`${basePath}?view=${v.id}`}
+              scroll={false}
+              aria-current={on ? "page" : undefined}
+              className={cn(
+                "inline-flex shrink-0 items-center gap-1.5 rounded-xl px-3.5 py-1.5 text-sm font-medium transition-colors",
+                "[transition-duration:var(--duration-fast)] focus-visible:outline-none",
+                on ? "bg-card text-ink shadow-sm card-soft" : "text-ink-3 hover:bg-soft hover:text-ink-2",
+              )}
+            >
+              {v.label}
+              {badge ? (
+                <span className="rounded-full bg-warning-soft px-1.5 py-0.5 text-[10px] font-semibold text-warning">
+                  {badge}
+                </span>
+              ) : null}
+            </Link>
+          );
+        })}
+      </nav>
+    </div>
+  );
+}

--- a/promo-analytics/app/(dash)/promotions/[id]/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/page.tsx
@@ -10,7 +10,10 @@ import type {
   PlanVsActualSummary,
   PlanVsActualOption,
 } from "@/lib/types";
-import { won, wonShort, pct, daysBetween } from "@/lib/format";
+import { won, wonShort, pct, num, daysBetween } from "@/lib/format";
+import { InlineAlert } from "@/components/ui";
+import { ProgressMetric } from "@/components/ui/ProgressMetric";
+import { deriveWorkflow, deriveActions } from "@/lib/campaign-workflow";
 import UpliftChart from "./UpliftChart";
 import Notes from "./Notes";
 import Achievement from "./Achievement";
@@ -18,6 +21,9 @@ import PurposeBlock, { type PurposeMetricRow } from "./PurposeBlock";
 import { type DiagnosticRow, type SkuMapping } from "./SkuMatchPanel";
 import ActualsLink, { type ActualsCandidate } from "./ActualsLink";
 import CampaignTrend, { type DailyPoint } from "./CampaignTrend";
+import { CampaignWorkflowBar } from "./CampaignWorkflowBar";
+import { ActionPanel } from "./ActionPanel";
+import { DetailTabsNav, type DetailView } from "./DetailTabsNav";
 
 export const dynamic = "force-dynamic";
 
@@ -60,19 +66,26 @@ type UploadSource = {
   created_at: string;
 };
 
+const VALID_VIEWS: DetailView[] = ["overview", "skus", "trend", "purpose", "sources"];
+
 export default async function PromotionDetail({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{ view?: string }>;
 }) {
   const { id } = await params;
+  const sp = await searchParams;
+  const view: DetailView = VALID_VIEWS.includes(sp.view as DetailView)
+    ? (sp.view as DetailView)
+    : "overview";
   const supabase = await createClient();
 
   const { data: bundleData, error: bundleError } = await supabase.rpc(
     "promotion_detail_bundle",
     { p_id: id },
   );
-  // RPC 실패(타임아웃 등)는 '캠페인 없음'이 아니다 — 404 대신 에러 바운더리로.
   if (bundleError) {
     throw new Error(`분석 데이터를 불러오지 못했습니다: ${bundleError.message}`);
   }
@@ -104,7 +117,7 @@ export default async function PromotionDetail({
   const skuMappings = bundle?.mappings ?? [];
   const sources = bundle?.sources ?? [];
 
-  // 목적별 핵심 지표 (S5.4): 유효 가중치 × 측정·달성률·구매건수
+  // 목적별 핵심 지표 (S5.4)
   const ewData = bundle?.weights ?? [];
   const orderCount = Number(bundle?.order_count) || 0;
   const upliftPct =
@@ -137,367 +150,389 @@ export default async function PromotionDetail({
   const chartData = rows
     .filter((r) => Math.abs(r.uplift_revenue) > 0)
     .slice(0, 10)
-    .map((r) => ({
-      name: r.base_name,
-      uplift: r.uplift_revenue,
-      isMain: r.is_main,
-    }));
+    .map((r) => ({ name: r.base_name, uplift: r.uplift_revenue, isMain: r.is_main }));
 
   const suggested = buildQuestions(rows, summary);
   const hasBaseline = rows.some((r) => r.baseline_daily_revenue > 0);
 
+  // ── 생애주기 워크플로 + 즉시 조치 (Layer A/B) ────────────────
+  const today = new Date().toISOString().slice(0, 10);
+  const unmatchedCount = diagnosticRows.filter(
+    (r) => r.side !== "both" && !r.is_mapped && !r.is_subscription,
+  ).length;
+  const wfInput = {
+    hasPlan: !!plan,
+    planConfirmed: plan?.status === "confirmed",
+    hasActualLink: !!plan?.actual_promotion_id,
+    hasActualData: !!achSummary?.has_confirmed_plan,
+    unmatchedCount,
+    expectedContribution:
+      achSummary?.expected_contribution_total ?? plan?.expected_contribution_total ?? null,
+    hasBaseline,
+    notesCount: notes.length,
+    isEnded: !!promo.end_date && promo.end_date < today,
+  };
+  const workflow = deriveWorkflow(wfInput);
+  const actions = deriveActions(wfInput, { promotionId: id });
+  const basePath = `/promotions/${id}`;
+  const qtyShort =
+    achSummary && (achSummary.expected_qty_total ?? 0) - (achSummary.actual_qty_total ?? 0) > 0
+      ? `${num((achSummary.expected_qty_total ?? 0) - (achSummary.actual_qty_total ?? 0))}개 부족`
+      : undefined;
+
   return (
     <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
-      <div className="mb-1 text-sm text-neutral-400">
+      <div className="mb-1 text-sm text-ink-4">
         <Link href="/" className="hover:underline">
           대시보드
         </Link>{" "}
         / 캠페인
       </div>
-      <header className="mb-6 flex items-start justify-between gap-4">
+      <header className="mb-4 flex items-start justify-between gap-4">
         <div>
           <h1 className="text-xl font-semibold">{promo.name}</h1>
-          <p className="mt-1 text-sm text-neutral-500">
-            {promo.start_date} ~ {promo.end_date} (
-            {daysBetween(promo.start_date, promo.end_date)}일)
+          <p className="mt-1 text-sm text-ink-3">
+            {promo.start_date} ~ {promo.end_date} ({daysBetween(promo.start_date, promo.end_date)}일)
             {promo.season_tag && ` · ${promo.season_tag}`}
             {promo.promo_type && ` · ${promo.promo_type}`}
           </p>
         </div>
         <Link
           href={`/promotions/${id}/edit`}
-          className="shrink-0 rounded-xl border border-neutral-200 px-4 py-2 text-sm font-medium hover:bg-neutral-50"
+          className="shrink-0 rounded-xl border border-line px-4 py-2 text-sm font-medium hover:bg-soft"
         >
           메타·메인상품 편집
         </Link>
       </header>
 
-      {/* 역링크 (N6): 이 캠페인의 실적을 비교 대상으로 쓰는 플랜 안내 —
-          "플랜은 저쪽 캠페인에 있다"를 명시해 어디서 매칭할지 혼란 제거 */}
       {linkedPlans.length > 0 && (
-        <div className="mb-5 rounded-xl border border-brand-200 bg-brand-50/60 px-4 py-3 text-sm text-ink-2">
+        <div className="mb-4 rounded-xl border border-brand-200 bg-brand-50/60 px-4 py-2.5 text-sm text-ink-2">
           이 캠페인의 실적은{" "}
           {linkedPlans.map((lp, i) => (
             <span key={lp.plan_id}>
               {i > 0 && ", "}
-              {lp.promotion_id ? (
-                <Link
-                  href={`/promotions/${lp.promotion_id}`}
-                  className="font-semibold text-brand-700 hover:underline"
-                >
-                  {lp.name ?? lp.code} 플랜
-                </Link>
-              ) : (
-                <Link href="/plans" className="font-semibold text-brand-700 hover:underline">
-                  {lp.name ?? lp.code} 플랜
-                </Link>
-              )}
+              <Link
+                href={lp.promotion_id ? `/promotions/${lp.promotion_id}` : "/plans"}
+                className="font-semibold text-brand-700 hover:underline"
+              >
+                {lp.name ?? lp.code} 플랜
+              </Link>
             </span>
           ))}
-          의 비교 대상입니다. <strong>플랜 vs 실적 비교·SKU 매칭은 플랜이 있는 캠페인에서</strong>{" "}
-          진행하세요.
+          의 비교 대상입니다. <strong>플랜 vs 실적 비교·SKU 매칭은 플랜이 있는 캠페인에서</strong> 진행하세요.
         </div>
       )}
 
-      {!hasBaseline && (
-        <div className="mb-5 rounded-lg bg-amber-50 px-4 py-3 text-sm text-amber-800">
-          직전 8주 baseline 데이터가 부족합니다. <strong>일별 매출 추이</strong>를
-          충분히 업로드하면 증분이 정확해집니다.
-        </div>
-      )}
+      {/* Layer A — 생애주기 + 핵심 결과 + 즉시 조치 */}
+      <CampaignWorkflowBar steps={workflow} basePath={basePath} />
 
-      {/* 측정 v2: 보정 적용 안내 */}
-      <MeasurementBanner summary={summary} rows={rows} />
-
-      {/* 요약 카드 */}
-      <div className="grid grid-cols-2 gap-3 md:grid-cols-5">
-        <Stat label="캠페인 총 매출" value={won(summary?.actual_revenue)} primary />
-        <Stat
-          label="총 기여 매출"
-          value={won(summary?.total_uplift)}
-          sub={summary?.uplift_ci ? `±${wonShort(summary.uplift_ci)} (95% CI)` : undefined}
-        />
-        <Stat label="메인 상품 직접 매출" value={wonShort(summary?.direct_uplift)} />
-        <Stat
-          label="간접 매출"
-          value={wonShort(summary?.halo_uplift)}
-          sub={summary?.halo_share != null ? `비중 ${pct(summary.halo_share)}` : undefined}
-        />
-        <Stat
-          label="공헌이익"
-          value={wonShort(summary?.contribution)}
-          sub={
-            summary?.contribution_rate != null
-              ? `이익률 ${pct(summary.contribution_rate)}`
-              : undefined
-          }
-        />
-      </div>
-
-      {/* 일별 매출 시계열 (N6 R2.2) — 평시 8주 맥락 + 캠페인 강조 + 브러시 줌 */}
-      <CampaignTrend
-        data={bundle?.rollup?.daily ?? []}
-        baselineDaily={
-          bundle?.rollup?.features?.baseline_daily != null
-            ? Number(bundle.rollup.features.baseline_daily)
-            : null
-        }
-      />
-
-      {/* 가격 가이드(플랜) 요약 + CTA */}
-      <div className="mt-6 rounded-2xl card-soft p-5">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <h2 className="text-sm font-semibold text-neutral-700">가격 가이드(플랜)</h2>
-            {plan ? (
-              <p className="mt-1 text-sm text-neutral-500">
-                v{plan.version} ·{" "}
-                <span
-                  className={
-                    plan.status === "confirmed" ? "text-green-600" : "text-amber-600"
-                  }
-                >
-                  {plan.status === "confirmed" ? "확정됨" : "draft"}
-                </span>{" "}
-                · 예상 매출 {won(plan.expected_revenue_total)} · 예상 공헌이익{" "}
-                {won(plan.expected_contribution_total)}
-              </p>
-            ) : null}
-            {plan && plan.status !== "confirmed" && (
-              <p className="mt-1 text-xs text-amber-700">
-                draft 상태 — 플랜을 <strong>확정</strong>해야 달성률 집계와 홈 페이싱
-                알림에 포함됩니다. (플랜 편집 → 확정)
-              </p>
-            )}
-            {!plan && (
-              <p className="mt-1 text-sm text-neutral-500">
-                아직 플랜이 없습니다. 옵션(다중 SKU 묶음)·예상 세트수로 예상 성과를 미리
-                계산하세요.
-              </p>
-            )}
-          </div>
-          <Link
-            href={`/promotions/${id}/plan`}
-            className="shrink-0 rounded-xl bg-brand-500 px-4 py-2 text-sm font-medium text-white hover:bg-brand-600"
-          >
-            {plan ? "플랜 편집" : "플랜 만들기"}
-          </Link>
-        </div>
-      </div>
-
-      {/* 비교 대상 연동 — 어떤 실적 캠페인과 비교할지 선택 (SKU 매칭은 아래 달성 블록으로 통합) */}
-      {plan && (
-        <section className="mt-6 rounded-2xl card-soft p-5">
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <div className="flex items-center gap-2">
-              <h2 className="text-sm font-semibold text-neutral-700">비교 대상 연동</h2>
-              {!plan.actual_promotion_id && (
-                <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-700">
-                  비교 대상 미지정
-                </span>
-              )}
-            </div>
-            <Link
-              href={`/promotions/${id}/edit`}
-              className="text-xs text-neutral-400 hover:text-brand-600 hover:underline"
-            >
-              중복 캠페인이 있나요? 병합 도구 →
-            </Link>
-          </div>
-          {linkedActualName ? (
-            <p className="mt-1 text-xs text-ink-3">
-              비교 구도: <strong className="text-ink">이 캠페인의 플랜</strong> ↔{" "}
-              <strong className="text-brand-700">{linkedActualName}</strong> 실적 —
-              아래 달성 블록이 이 구도 기준으로 계산됩니다.
-            </p>
-          ) : (
-            <p className="mt-1 text-xs text-neutral-400">
-              비교할 실적 캠페인을 지정하면 아래 달성 블록이 자동으로 채워집니다. SKU·옵션 매칭은 달성 블록에서 보정하세요.
-            </p>
-          )}
-          <ActualsLink
-            promotionId={id}
-            currentLinkId={plan.actual_promotion_id}
-            candidates={candidates}
+      {wfInput.hasActualData && achSummary ? (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <ProgressMetric
+            label="캠페인 매출 달성 (전체)"
+            ratio={achSummary.revenue_ach_total}
+            valueLabel={wonShort(achSummary.campaign_revenue_total)}
+            targetLabel={wonShort(achSummary.expected_revenue_total)}
+            caption="메인 + 함께 구매, 구독 제외"
+            primary
+            action={
+              <Link href={`${basePath}?view=skus`} scroll={false} className="text-[11px] font-semibold text-brand-700 hover:underline">
+                SKU·옵션 분석 →
+              </Link>
+            }
           />
-        </section>
+          <ProgressMetric
+            label="메인 제품 수량 달성"
+            ratio={achSummary.ach_qty}
+            valueLabel={num(achSummary.actual_qty_total)}
+            targetLabel={num(achSummary.expected_qty_total)}
+            caption="메인 제품만 (예상수량 대비)"
+            delta={qtyShort}
+          />
+          <ProgressMetric
+            label="공헌이익 달성 (전체)"
+            ratio={achSummary.contribution_ach_total}
+            valueLabel={wonShort(achSummary.contribution_total)}
+            targetLabel={wonShort(achSummary.expected_contribution_total)}
+            caption="전체 실적 기준"
+            note={
+              (achSummary.expected_contribution_total ?? 0) <= 0
+                ? "원가/판매가 확인 필요"
+                : undefined
+            }
+          />
+        </div>
+      ) : (
+        <InlineAlert
+          tone="info"
+          title="확정 플랜 + 실적 연결 시 달성 KPI가 표시됩니다"
+          action={
+            <Link href={`${basePath}/plan`} className="rounded-lg bg-card/70 px-2.5 py-1 text-[11px] font-semibold text-ink-2 hover:bg-card">
+              {plan ? "플랜 편집" : "플랜 만들기"} →
+            </Link>
+          }
+        >
+          {plan
+            ? `플랜 v${plan.version} · ${plan.status === "confirmed" ? "확정됨" : "draft"} · 예상 매출 ${won(plan.expected_revenue_total)}`
+            : "옵션·예상 세트수로 예상 성과를 미리 계산하세요."}
+        </InlineAlert>
       )}
 
-      {/* 달성 & 매칭 (S3 + N7 P3 통합) */}
-      <Achievement
-        promotionId={id}
-        summary={achSummary}
-        rows={achRows}
-        options={achOptions}
-        optionInfos={optionInfos}
-        diagnosticRows={diagnosticRows}
-        skuMappings={skuMappings}
-      />
-
-      {/* 목적별 핵심 지표 (S5.4) */}
-      <PurposeBlock rows={purposeRows} />
-
-      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-5">
-        {/* 측정 테이블 */}
-        <section className="lg:col-span-3">
-          <h2 className="mb-2 text-sm font-semibold text-neutral-700">
-            상품별 증분 측정
-          </h2>
-          <div className="overflow-x-auto rounded-2xl card-soft">
-            <table className="w-full min-w-[760px] text-sm">
-              <thead className="bg-neutral-50 text-left text-xs text-neutral-500">
-                <tr>
-                  <th className="px-3 py-2.5 font-medium">상품</th>
-                  <th className="px-3 py-2.5 text-right font-medium">baseline/일</th>
-                  <th className="px-3 py-2.5 text-right font-medium">실적</th>
-                  <th className="px-3 py-2.5 text-right font-medium">기대</th>
-                  <th className="px-3 py-2.5 text-right font-medium">증분 ±95% CI</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-neutral-100">
-                {rows.map((r) => {
-                  const significant =
-                    r.uplift_ci > 0 && Math.abs(r.uplift_revenue) > r.uplift_ci;
-                  return (
-                    <tr key={r.product_id} className="hover:bg-neutral-50">
-                      <td className="px-3 py-2.5">
-                        <span className="text-neutral-800">{r.base_name}</span>
-                        {r.is_main && (
-                          <span className="ml-1.5 rounded bg-brand-500 px-1.5 py-0.5 text-[10px] font-medium text-white">
-                            메인
-                          </span>
-                        )}
-                        {r.cold_start && (
-                          <span
-                            className="ml-1.5 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700"
-                            title={`baseline 관측 ${r.observed_baseline_days}일 (14일 미만) — 측정 신뢰도 낮음`}
-                          >
-                            신상품
-                          </span>
-                        )}
-                      </td>
-                      <td className="px-3 py-2.5 text-right text-neutral-500">
-                        {wonShort(r.baseline_daily_revenue)}
-                        {!r.cold_start && r.observed_baseline_days > 0 && (
-                          <span className="ml-1 text-[10px] text-neutral-400">
-                            ({r.observed_baseline_days}일)
-                          </span>
-                        )}
-                      </td>
-                      <td className="px-3 py-2.5 text-right text-neutral-600">
-                        {wonShort(r.actual_revenue)}
-                      </td>
-                      <td className="px-3 py-2.5 text-right text-neutral-400">
-                        {wonShort(r.expected_revenue)}
-                      </td>
-                      <td
-                        className={`px-3 py-2.5 text-right font-semibold ${
-                          r.uplift_revenue < 0 ? "text-red-600" : "text-neutral-900"
-                        }`}
-                      >
-                        <div className="flex items-center justify-end gap-1">
-                          <span>{wonShort(r.uplift_revenue)}</span>
-                          {!significant && r.uplift_ci > 0 && !r.cold_start && (
-                            <span
-                              className="text-[10px] text-neutral-400"
-                              title="증분이 baseline 변동성 범위 안 — 통계적으로 유의하지 않음"
-                            >
-                              n.s.
-                            </span>
-                          )}
-                        </div>
-                        {r.uplift_ci > 0 && !r.cold_start && (
-                          <div className="text-[10px] font-normal text-neutral-400">
-                            ±{wonShort(r.uplift_ci)}
-                          </div>
-                        )}
-                      </td>
-                    </tr>
-                  );
-                })}
-                {rows.length === 0 && (
-                  <tr>
-                    <td colSpan={5} className="px-3 py-8 text-center text-neutral-400">
-                      캠페인 기간의 판매 데이터가 없습니다.
-                    </td>
-                  </tr>
-                )}
-              </tbody>
-            </table>
-          </div>
-          <p className="mt-2 text-[11px] text-neutral-400">
-            baseline = 직전 8주 비캠페인 일자의 요일별 평균 (±2σ 트림). 추세 보정 적용. 95% CI는 baseline 변동성 기준.
-          </p>
-        </section>
-
-        {/* 차트 */}
-        <section className="lg:col-span-2">
-          <h2 className="mb-2 text-sm font-semibold text-neutral-700">
-            증분 Top 10 (검정=메인 · 회색=후광)
-          </h2>
-          <div className="rounded-2xl card-soft p-4">
-            <UpliftChart data={chartData} />
-          </div>
-
-          <div className="mt-4 rounded-2xl card-soft p-4">
-            <div className="text-xs text-neutral-500">메인 상품</div>
-            {mains.length > 0 ? (
-              <ul className="mt-1.5 space-y-1 text-sm">
-                {mains.map((m) => (
-                  <li key={m.product_id} className="flex justify-between">
-                    <span className="truncate text-neutral-700">{m.base_name}</span>
-                    <span className="ml-2 shrink-0 text-neutral-500">
-                      증분 {wonShort(m.uplift_revenue)}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <p className="mt-1 text-sm text-neutral-400">
-                아직 메인 상품이 지정되지 않았습니다.{" "}
-                <Link href={`/promotions/${id}/edit`} className="underline">
-                  지정하기
-                </Link>
-              </p>
-            )}
-          </div>
-
-          {/* 데이터 출처 (N6 R1.3) — 이 캠페인을 만들거나 갱신한 업로드 파일 */}
-          {sources.length > 0 && (
-            <div className="mt-4 rounded-2xl card-soft p-4">
-              <div className="text-xs text-neutral-500">데이터 출처 (업로드 파일)</div>
-              <ul className="mt-1.5 space-y-1.5 text-sm">
-                {sources.slice(0, 5).map((s) => (
-                  <li key={s.id} className="flex items-baseline justify-between gap-2">
-                    <span className="min-w-0 truncate text-neutral-700" title={s.source_file}>
-                      {s.source_file}
-                    </span>
-                    <span className="shrink-0 text-[11px] text-neutral-400">
-                      {s.kind === "plan_guide" ? "플랜" : s.kind === "promotion" ? "실적" : s.kind}
-                      {" · "}
-                      {new Date(s.created_at).toLocaleDateString("ko-KR", {
-                        month: "2-digit",
-                        day: "2-digit",
-                      })}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </section>
+      <div className="mt-4">
+        <ActionPanel actions={actions} basePath={basePath} />
       </div>
 
-      {/* 정성 메모 */}
-      <section className="mt-8 max-w-3xl">
-        <h2 className="mb-1 text-sm font-semibold text-neutral-700">
-          성과의 원인 — 집요하게 묻기
-        </h2>
-        <p className="mb-3 text-xs text-neutral-400">
-          여기 쌓인 원인·가설이 예측 정확도를 높입니다.
-        </p>
-        <Notes promotionId={id} notes={notes} suggested={suggested} />
-      </section>
+      {/* Layer C — 심층 분석 (탭, URL 보존, 선택 탭만 렌더) */}
+      <div className="mt-6">
+        <DetailTabsNav active={view} basePath={basePath} badges={{ skus: unmatchedCount || undefined }} />
+
+        {view === "overview" && (
+          <div>
+            {!hasBaseline && (
+              <div className="mb-4 rounded-lg bg-warning-soft px-4 py-3 text-sm text-warning">
+                직전 8주 baseline 데이터가 부족합니다. <strong>일별 매출 추이</strong>를 충분히 업로드하면 증분이 정확해집니다.
+              </div>
+            )}
+            <MeasurementBanner summary={summary} rows={rows} />
+            <div className="grid grid-cols-2 gap-3 md:grid-cols-5">
+              <Stat label="캠페인 총 매출" value={won(summary?.actual_revenue)} primary />
+              <Stat
+                label="총 기여 매출"
+                value={won(summary?.total_uplift)}
+                sub={summary?.uplift_ci ? `±${wonShort(summary.uplift_ci)} (95% CI)` : undefined}
+              />
+              <Stat label="메인 상품 직접 매출" value={wonShort(summary?.direct_uplift)} />
+              <Stat
+                label="간접 매출"
+                value={wonShort(summary?.halo_uplift)}
+                sub={summary?.halo_share != null ? `비중 ${pct(summary.halo_share)}` : undefined}
+              />
+              <Stat
+                label="공헌이익"
+                value={wonShort(summary?.contribution)}
+                sub={summary?.contribution_rate != null ? `이익률 ${pct(summary.contribution_rate)}` : undefined}
+              />
+            </div>
+
+            <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-5">
+              <section className="lg:col-span-3">
+                <h2 className="mb-2 text-sm font-semibold text-ink-2">상품별 증분 측정</h2>
+                <div className="overflow-x-auto rounded-2xl card-soft">
+                  <table className="w-full min-w-[760px] text-sm">
+                    <thead className="bg-soft/60 text-left text-xs text-ink-3">
+                      <tr>
+                        <th className="px-3 py-2.5 font-medium">상품</th>
+                        <th className="px-3 py-2.5 text-right font-medium">baseline/일</th>
+                        <th className="px-3 py-2.5 text-right font-medium">실적</th>
+                        <th className="px-3 py-2.5 text-right font-medium">기대</th>
+                        <th className="px-3 py-2.5 text-right font-medium">증분 ±95% CI</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-line/70">
+                      {rows.map((r) => {
+                        const significant = r.uplift_ci > 0 && Math.abs(r.uplift_revenue) > r.uplift_ci;
+                        return (
+                          <tr key={r.product_id} className="hover:bg-soft/50">
+                            <td className="px-3 py-2.5">
+                              <span className="text-ink">{r.base_name}</span>
+                              {r.is_main && (
+                                <span className="ml-1.5 rounded bg-brand-500 px-1.5 py-0.5 text-[10px] font-medium text-white">
+                                  메인
+                                </span>
+                              )}
+                              {r.cold_start && (
+                                <span
+                                  className="ml-1.5 rounded bg-warning-soft px-1.5 py-0.5 text-[10px] font-medium text-warning"
+                                  title={`baseline 관측 ${r.observed_baseline_days}일 (14일 미만) — 측정 신뢰도 낮음`}
+                                >
+                                  신상품
+                                </span>
+                              )}
+                            </td>
+                            <td className="px-3 py-2.5 text-right text-ink-3">
+                              {wonShort(r.baseline_daily_revenue)}
+                              {!r.cold_start && r.observed_baseline_days > 0 && (
+                                <span className="ml-1 text-[10px] text-ink-4">({r.observed_baseline_days}일)</span>
+                              )}
+                            </td>
+                            <td className="px-3 py-2.5 text-right text-ink-2">{wonShort(r.actual_revenue)}</td>
+                            <td className="px-3 py-2.5 text-right text-ink-4">{wonShort(r.expected_revenue)}</td>
+                            <td className={`px-3 py-2.5 text-right font-semibold ${r.uplift_revenue < 0 ? "text-danger" : "text-ink"}`}>
+                              <div className="flex items-center justify-end gap-1">
+                                <span>{wonShort(r.uplift_revenue)}</span>
+                                {!significant && r.uplift_ci > 0 && !r.cold_start && (
+                                  <span className="text-[10px] text-ink-4" title="증분이 baseline 변동성 범위 안 — 통계적으로 유의하지 않음">
+                                    n.s.
+                                  </span>
+                                )}
+                              </div>
+                              {r.uplift_ci > 0 && !r.cold_start && (
+                                <div className="text-[10px] font-normal text-ink-4">±{wonShort(r.uplift_ci)}</div>
+                              )}
+                            </td>
+                          </tr>
+                        );
+                      })}
+                      {rows.length === 0 && (
+                        <tr>
+                          <td colSpan={5} className="px-3 py-8 text-center text-ink-4">
+                            캠페인 기간의 판매 데이터가 없습니다.
+                          </td>
+                        </tr>
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+                <p className="mt-2 text-[11px] text-ink-4">
+                  baseline = 직전 8주 비캠페인 일자의 요일별 평균 (±2σ 트림). 추세 보정 적용. 95% CI는 baseline 변동성 기준.
+                </p>
+              </section>
+
+              <section className="lg:col-span-2">
+                <h2 className="mb-2 text-sm font-semibold text-ink-2">증분 Top 10 (검정=메인 · 회색=후광)</h2>
+                <div className="rounded-2xl card-soft p-4">
+                  <UpliftChart data={chartData} />
+                </div>
+                <div className="mt-4 rounded-2xl card-soft p-4">
+                  <div className="text-xs text-ink-3">메인 상품</div>
+                  {mains.length > 0 ? (
+                    <ul className="mt-1.5 space-y-1 text-sm">
+                      {mains.map((m) => (
+                        <li key={m.product_id} className="flex justify-between">
+                          <span className="truncate text-ink-2">{m.base_name}</span>
+                          <span className="ml-2 shrink-0 text-ink-3">증분 {wonShort(m.uplift_revenue)}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="mt-1 text-sm text-ink-4">
+                      아직 메인 상품이 지정되지 않았습니다.{" "}
+                      <Link href={`/promotions/${id}/edit`} className="underline">
+                        지정하기
+                      </Link>
+                    </p>
+                  )}
+                </div>
+              </section>
+            </div>
+          </div>
+        )}
+
+        {view === "skus" && (
+          <div>
+            <div className="mb-4 rounded-2xl card-soft p-5">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <h2 className="text-sm font-semibold text-ink-2">가격 가이드(플랜)</h2>
+                  {plan ? (
+                    <p className="mt-1 text-sm text-ink-3">
+                      v{plan.version} ·{" "}
+                      <span className={plan.status === "confirmed" ? "text-success" : "text-warning"}>
+                        {plan.status === "confirmed" ? "확정됨" : "draft"}
+                      </span>{" "}
+                      · 예상 매출 {won(plan.expected_revenue_total)} · 예상 공헌이익 {won(plan.expected_contribution_total)}
+                    </p>
+                  ) : (
+                    <p className="mt-1 text-sm text-ink-3">
+                      아직 플랜이 없습니다. 옵션·예상 세트수로 예상 성과를 미리 계산하세요.
+                    </p>
+                  )}
+                </div>
+                <Link
+                  href={`/promotions/${id}/plan`}
+                  className="shrink-0 rounded-xl bg-brand-500 px-4 py-2 text-sm font-medium text-white hover:bg-brand-600"
+                >
+                  {plan ? "플랜 편집" : "플랜 만들기"}
+                </Link>
+              </div>
+            </div>
+
+            {plan && (
+              <section className="mb-4 rounded-2xl card-soft p-5">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="flex items-center gap-2">
+                    <h2 className="text-sm font-semibold text-ink-2">비교 대상 연결</h2>
+                    {!plan.actual_promotion_id && (
+                      <span className="rounded-full bg-warning-soft px-2 py-0.5 text-[11px] font-medium text-warning">
+                        비교 대상 미지정
+                      </span>
+                    )}
+                  </div>
+                  <Link href={`/promotions/${id}/edit`} className="text-xs text-ink-4 hover:text-brand-600 hover:underline">
+                    중복 캠페인이 있나요? 병합 도구 →
+                  </Link>
+                </div>
+                {linkedActualName ? (
+                  <p className="mt-1 text-xs text-ink-3">
+                    비교 구도: <strong className="text-ink">이 캠페인의 플랜</strong> ↔{" "}
+                    <strong className="text-brand-700">{linkedActualName}</strong> 실적.
+                  </p>
+                ) : (
+                  <p className="mt-1 text-xs text-ink-4">
+                    비교할 실적 캠페인을 지정하면 아래 달성 블록이 자동으로 채워집니다.
+                  </p>
+                )}
+                <ActualsLink promotionId={id} currentLinkId={plan.actual_promotion_id} candidates={candidates} />
+              </section>
+            )}
+
+            <Achievement
+              promotionId={id}
+              summary={achSummary}
+              rows={achRows}
+              options={achOptions}
+              optionInfos={optionInfos}
+              diagnosticRows={diagnosticRows}
+              skuMappings={skuMappings}
+              hideSummaryCards
+            />
+          </div>
+        )}
+
+        {view === "trend" && (
+          <CampaignTrend
+            data={bundle?.rollup?.daily ?? []}
+            baselineDaily={
+              bundle?.rollup?.features?.baseline_daily != null
+                ? Number(bundle.rollup.features.baseline_daily)
+                : null
+            }
+          />
+        )}
+
+        {view === "purpose" && <PurposeBlock rows={purposeRows} />}
+
+        {view === "sources" && (
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-5">
+            <section className="lg:col-span-2">
+              <h2 className="mb-2 text-sm font-semibold text-ink-2">데이터 출처 (업로드 파일)</h2>
+              {sources.length > 0 ? (
+                <ul className="space-y-1.5 rounded-2xl card-soft p-4 text-sm">
+                  {sources.slice(0, 8).map((s) => (
+                    <li key={s.id} className="flex items-baseline justify-between gap-2">
+                      <span className="min-w-0 truncate text-ink-2" title={s.source_file}>
+                        {s.source_file}
+                      </span>
+                      <span className="shrink-0 text-[11px] text-ink-4">
+                        {s.kind === "plan_guide" ? "플랜" : s.kind === "promotion" ? "실적" : s.kind}
+                        {" · "}
+                        {new Date(s.created_at).toLocaleDateString("ko-KR", { month: "2-digit", day: "2-digit" })}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="rounded-2xl card-soft p-4 text-sm text-ink-4">출처 기록이 없습니다.</p>
+              )}
+            </section>
+            <section className="lg:col-span-3">
+              <h2 className="mb-1 text-sm font-semibold text-ink-2">성과의 원인 — 집요하게 묻기</h2>
+              <p className="mb-3 text-xs text-ink-4">여기 쌓인 원인·가설이 예측 정확도를 높입니다.</p>
+              <Notes promotionId={id} notes={notes} suggested={suggested} />
+            </section>
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -513,45 +548,36 @@ function MeasurementBanner({
   const cold = summary.cold_start_count;
   const trend = summary.trend_factor;
   const trendPct = (trend - 1) * 100;
-  const significant =
-    summary.uplift_ci > 0 && Math.abs(summary.total_uplift) > summary.uplift_ci;
+  const significant = summary.uplift_ci > 0 && Math.abs(summary.total_uplift) > summary.uplift_ci;
 
   const chips: { label: string; tone: "neutral" | "warn" | "ok" }[] = [];
   if (Math.abs(trendPct) >= 1) {
-    chips.push({
-      label: `추세 보정 ${trendPct > 0 ? "+" : ""}${trendPct.toFixed(1)}%`,
-      tone: "neutral",
-    });
+    chips.push({ label: `추세 보정 ${trendPct > 0 ? "+" : ""}${trendPct.toFixed(1)}%`, tone: "neutral" });
   }
-  if (cold > 0) {
-    chips.push({ label: `신상품 ${cold}건`, tone: "warn" });
-  }
+  if (cold > 0) chips.push({ label: `신상품 ${cold}건`, tone: "warn" });
   if (summary.uplift_ci > 0) {
-    chips.push({
-      label: significant ? "통계적 유의" : "유의성 낮음",
-      tone: significant ? "ok" : "warn",
-    });
+    chips.push({ label: significant ? "통계적 유의" : "유의성 낮음", tone: significant ? "ok" : "warn" });
   }
   if (chips.length === 0) return null;
 
   return (
     <div className="mb-5 flex flex-wrap items-center gap-2 rounded-xl card-soft px-4 py-3">
-      <span className="text-xs font-medium text-neutral-500">측정 보정</span>
+      <span className="text-xs font-medium text-ink-3">측정 보정</span>
       {chips.map((c) => (
         <span
           key={c.label}
           className={`rounded-full px-2.5 py-1 text-[11px] font-medium ${
             c.tone === "ok"
-              ? "bg-emerald-50 text-emerald-700"
+              ? "bg-success-soft text-success"
               : c.tone === "warn"
-              ? "bg-amber-50 text-amber-700"
-              : "bg-neutral-100 text-neutral-600"
+                ? "bg-warning-soft text-warning"
+                : "bg-soft text-ink-3"
           }`}
         >
           {c.label}
         </span>
       ))}
-      <span className="text-[11px] text-neutral-400">
+      <span className="text-[11px] text-ink-4">
         요일 보정·±2σ 트림 적용 / baseline은 직전 8주, 추세는 8주 대비 16주 평균
       </span>
     </div>
@@ -570,30 +596,15 @@ function Stat({
   primary?: boolean;
 }) {
   return (
-    <div
-      className={`rounded-xl border p-4 ${
-        primary
-          ? "border-neutral-900 bg-brand-500 text-white"
-          : "border-neutral-200 bg-white"
-      }`}
-    >
-      <div className={`text-xs ${primary ? "text-neutral-300" : "text-neutral-500"}`}>
-        {label}
-      </div>
+    <div className={`rounded-xl border p-4 ${primary ? "border-transparent bg-brand-500 text-white" : "border-line bg-card"}`}>
+      <div className={`text-xs ${primary ? "text-white/70" : "text-ink-3"}`}>{label}</div>
       <div className="mt-1 text-lg font-semibold">{value}</div>
-      {sub && (
-        <div className={`mt-0.5 text-xs ${primary ? "text-neutral-300" : "text-neutral-400"}`}>
-          {sub}
-        </div>
-      )}
+      {sub && <div className={`mt-0.5 text-xs ${primary ? "text-white/70" : "text-ink-4"}`}>{sub}</div>}
     </div>
   );
 }
 
-function buildQuestions(
-  rows: MeasurementRow[],
-  summary: PromotionSummary | null,
-): string[] {
+function buildQuestions(rows: MeasurementRow[], summary: PromotionSummary | null): string[] {
   const qs: string[] = [];
   const topMain = rows.filter((r) => r.is_main)[0];
   const topHalo = rows.filter((r) => !r.is_main)[0];

--- a/promo-analytics/components/ui/ProgressMetric.tsx
+++ b/promo-analytics/components/ui/ProgressMetric.tsx
@@ -1,0 +1,56 @@
+import { cn } from "@/lib/cn";
+
+// 달성 KPI — 진행바 + 값/목표 + 부족·초과 + 일관된 캡션. (지시서 P0-3)
+export function ProgressMetric({
+  label,
+  ratio,
+  valueLabel,
+  targetLabel,
+  caption,
+  delta,
+  note,
+  action,
+  primary,
+}: {
+  label: string;
+  ratio: number | null; // 0..n (1=100%)
+  valueLabel: string;
+  targetLabel: string;
+  caption?: string;
+  delta?: string; // 부족/초과 설명
+  note?: string; // 경고 안내 (예: 계산 불가)
+  action?: React.ReactNode;
+  primary?: boolean;
+}) {
+  const over = ratio != null && ratio >= 1;
+  const fill = ratio == null ? 0 : Math.min(100, Math.max(0, ratio * 100));
+  const pctText = ratio == null ? "—" : `${Math.round(ratio * 100)}%`;
+  return (
+    <div className={cn("rounded-2xl p-4", primary ? "bg-brand-50" : "card-soft")}>
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-xs text-ink-3">{label}</span>
+        {delta && <span className="text-[11px] text-ink-4">{delta}</span>}
+      </div>
+      <div className="mt-1 flex items-baseline gap-2">
+        <span className={cn("text-2xl font-semibold tabular-nums", note && ratio == null && "text-warning")}>
+          {note && ratio == null ? "계산 불가" : pctText}
+        </span>
+        <span className="text-xs text-ink-4">
+          {valueLabel} <span className="text-ink-4/70">/ {targetLabel}</span>
+        </span>
+      </div>
+      <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-soft">
+        <div
+          className={cn(
+            "h-full rounded-full [transition:width_var(--duration-slow)_var(--ease-standard)]",
+            over ? "bg-success" : ratio == null ? "bg-transparent" : "bg-brand-400",
+          )}
+          style={{ width: `${fill}%` }}
+        />
+      </div>
+      {caption && <div className="mt-1.5 text-[10px] leading-tight text-ink-4">{caption}</div>}
+      {note && <div className="mt-1 text-[10px] leading-tight text-warning">{note}</div>}
+      {action && <div className="mt-2">{action}</div>}
+    </div>
+  );
+}

--- a/promo-analytics/lib/__tests__/campaign-workflow.test.ts
+++ b/promo-analytics/lib/__tests__/campaign-workflow.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { deriveWorkflow, deriveActions, type WorkflowInput } from "@/lib/campaign-workflow";
+
+const base: WorkflowInput = {
+  hasPlan: false,
+  planConfirmed: false,
+  hasActualLink: false,
+  hasActualData: false,
+  unmatchedCount: 0,
+  expectedContribution: 1000,
+  hasBaseline: true,
+  notesCount: 0,
+  isEnded: false,
+};
+
+function step(input: WorkflowInput, id: string) {
+  return deriveWorkflow(input).find((s) => s.id === id)!;
+}
+
+describe("deriveWorkflow", () => {
+  it("플랜 없음 → '플랜 작성'이 current", () => {
+    const s = step(base, "plan");
+    expect(s.status).toBe("current");
+  });
+  it("draft 플랜 → '플랜 확정'이 warning", () => {
+    const s = step({ ...base, hasPlan: true }, "confirm");
+    expect(s.status).toBe("warning");
+  });
+  it("확정 + 실적 미연결 → '실적 연결'이 blocked", () => {
+    const s = step({ ...base, hasPlan: true, planConfirmed: true }, "link");
+    expect(s.status).toBe("blocked");
+  });
+  it("실적 연결 + 미매칭 존재 → '매칭 검증'이 warning", () => {
+    const s = step(
+      { ...base, hasPlan: true, planConfirmed: true, hasActualLink: true, hasActualData: true, unmatchedCount: 3 },
+      "match",
+    );
+    expect(s.status).toBe("warning");
+  });
+  it("모든 매칭 정상 → '매칭 검증'이 complete, '결과 검토'가 current", () => {
+    const w = deriveWorkflow({
+      ...base, hasPlan: true, planConfirmed: true, hasActualLink: true, hasActualData: true, unmatchedCount: 0,
+    });
+    expect(w.find((s) => s.id === "match")!.status).toBe("complete");
+    expect(w.find((s) => s.id === "review")!.status).toBe("current");
+  });
+  it("정확히 하나의 활성(current) 단계만 존재", () => {
+    const w = deriveWorkflow({ ...base, hasPlan: true });
+    expect(w.filter((s) => s.status === "current").length).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("deriveActions", () => {
+  it("기대공헌 0 이하면 danger 조치 노출", () => {
+    const acts = deriveActions(
+      { ...base, hasPlan: true, planConfirmed: true, hasActualLink: true, hasActualData: true, expectedContribution: -100 },
+      { promotionId: "p1" },
+    );
+    expect(acts.some((a) => a.id === "contrib" && a.tone === "danger")).toBe(true);
+  });
+  it("문제 없으면 조치 비어있음(또는 baseline만)", () => {
+    const acts = deriveActions(
+      { ...base, hasPlan: true, planConfirmed: true, hasActualLink: true, hasActualData: true, unmatchedCount: 0 },
+      { promotionId: "p1" },
+    );
+    expect(acts.length).toBe(0);
+  });
+});

--- a/promo-analytics/lib/campaign-workflow.ts
+++ b/promo-analytics/lib/campaign-workflow.ts
@@ -1,0 +1,163 @@
+// PR2: 캠페인 생애주기 상태 머신 + 조치 도출 (순수 함수 — 테스트 대상).
+// 데이터 준비 → 플랜 작성 → 플랜 확정 → 실적 연결 → 매칭 검증 → 결과 검토 → 회고 완료
+import type { WorkflowStatus } from "@/lib/status";
+
+export type StepId = "data" | "plan" | "confirm" | "link" | "match" | "review" | "retro";
+
+export type WorkflowInput = {
+  hasPlan: boolean;
+  planConfirmed: boolean;
+  hasActualLink: boolean; // 비교 대상(실적) 지정됨
+  hasActualData: boolean; // 확정 플랜 + 실적 매칭 결과 존재
+  unmatchedCount: number; // 미매칭 SKU 수
+  expectedContribution: number | null;
+  hasBaseline: boolean;
+  notesCount: number;
+  isEnded: boolean; // 캠페인 종료일 경과
+};
+
+export type WorkflowStep = {
+  id: StepId;
+  label: string;
+  status: WorkflowStatus;
+  description: string;
+  view?: string; // 상세 탭으로 이동
+  actionLabel?: string;
+};
+
+const ORDER: { id: StepId; label: string; view?: string }[] = [
+  { id: "data", label: "데이터 준비", view: "overview" },
+  { id: "plan", label: "플랜 작성" },
+  { id: "confirm", label: "플랜 확정" },
+  { id: "link", label: "실적 연결", view: "skus" },
+  { id: "match", label: "매칭 검증", view: "skus" },
+  { id: "review", label: "결과 검토", view: "overview" },
+  { id: "retro", label: "회고 완료", view: "sources" },
+];
+
+export function deriveWorkflow(i: WorkflowInput): WorkflowStep[] {
+  const done: Record<StepId, boolean> = {
+    data: i.hasBaseline,
+    plan: i.hasPlan,
+    confirm: i.planConfirmed,
+    link: i.hasActualLink,
+    match: i.hasActualData && i.unmatchedCount === 0,
+    review: i.notesCount > 0, // 검토는 회고로 완료 처리
+    retro: i.notesCount > 0,
+  };
+
+  // 활성(current) 단계 = 완료되지 않은 첫 단계. 그 앞 단계가 안 되어 있으면 blocked.
+  let currentAssigned = false;
+
+  return ORDER.map((s, idx) => {
+    const prev = ORDER[idx - 1];
+    const prevDone = idx === 0 ? true : done[prev.id];
+    let status: WorkflowStatus;
+    let description = "";
+    let actionLabel: string | undefined;
+
+    if (done[s.id]) {
+      status = "complete";
+      description = COMPLETE_DESC[s.id];
+    } else if (!currentAssigned) {
+      currentAssigned = true;
+      // 활성 단계 — 문제성이면 warning/blocked, 아니면 current
+      if (s.id === "data") {
+        status = "warning";
+        description = "직전 8주 baseline이 부족합니다. 일별 매출을 더 올리면 증분이 정확해집니다.";
+        actionLabel = "일별 매출 업로드";
+      } else if (s.id === "confirm" && i.hasPlan) {
+        status = "warning";
+        description = "draft 플랜입니다. 확정해야 달성률 집계에 포함됩니다.";
+        actionLabel = "플랜 확정";
+      } else if (s.id === "link" && !prevDone) {
+        status = "blocked";
+        description = "플랜을 먼저 확정하세요.";
+      } else if (s.id === "link") {
+        status = "blocked";
+        description = "비교할 실적 캠페인이 연결되지 않았습니다.";
+        actionLabel = "실적 연결";
+      } else if (s.id === "match" && i.hasActualData && i.unmatchedCount > 0) {
+        status = "warning";
+        description = `미매칭 SKU ${i.unmatchedCount}개 — 보정이 필요합니다.`;
+        actionLabel = "매칭 보정";
+      } else if (!prevDone) {
+        status = "blocked";
+        description = "이전 단계를 먼저 완료하세요.";
+      } else {
+        status = "current";
+        description = CURRENT_DESC[s.id];
+        actionLabel = CURRENT_ACTION[s.id];
+      }
+    } else {
+      status = "pending";
+      description = "";
+    }
+    return { id: s.id, label: s.label, status, description, view: s.view, actionLabel };
+  });
+}
+
+const COMPLETE_DESC: Record<StepId, string> = {
+  data: "측정 데이터 준비됨",
+  plan: "플랜 작성됨",
+  confirm: "플랜 확정됨",
+  link: "실적 연결됨",
+  match: "모든 SKU 매칭 정상",
+  review: "결과 검토 완료",
+  retro: "회고 메모 작성됨",
+};
+const CURRENT_DESC: Record<StepId, string> = {
+  data: "측정 데이터 확인",
+  plan: "옵션·예상 세트수로 플랜을 작성하세요.",
+  confirm: "플랜을 확정하세요.",
+  link: "비교할 실적 캠페인을 연결하세요.",
+  match: "SKU·옵션 매칭을 검증하세요.",
+  review: "달성 결과를 검토하세요.",
+  retro: "성과 원인·회고를 남기세요.",
+};
+const CURRENT_ACTION: Record<StepId, string> = {
+  data: "데이터 보기",
+  plan: "플랜 만들기",
+  confirm: "플랜 확정",
+  link: "실적 연결",
+  match: "매칭 검증",
+  review: "결과 보기",
+  retro: "회고 작성",
+};
+
+// ── 즉시 조치 (Layer B) — 문제 있는 것만 ──────────────────────────
+export type Tone2 = "warning" | "danger" | "info";
+export type ActionItem = {
+  id: string;
+  tone: Tone2;
+  title: string;
+  body?: string;
+  actionLabel?: string;
+  view?: string;
+  href?: string;
+};
+
+export function deriveActions(
+  i: WorkflowInput,
+  ctx: { promotionId: string },
+): ActionItem[] {
+  const a: ActionItem[] = [];
+  if (!i.hasPlan) {
+    a.push({ id: "no-plan", tone: "info", title: "플랜이 없습니다", body: "옵션·예상 세트수로 예상 성과를 미리 계산하세요.", actionLabel: "플랜 만들기", href: `/promotions/${ctx.promotionId}/plan` });
+  } else if (!i.planConfirmed) {
+    a.push({ id: "draft", tone: "warning", title: "draft 플랜 — 확정 필요", body: "확정해야 달성률 집계·홈 페이싱 알림에 포함됩니다.", actionLabel: "플랜 편집", href: `/promotions/${ctx.promotionId}/plan` });
+  }
+  if (i.planConfirmed && !i.hasActualLink) {
+    a.push({ id: "no-link", tone: "warning", title: "실적 연결 필요", body: "비교할 실적 캠페인을 지정하면 달성률이 채워집니다.", actionLabel: "실적 연결", view: "skus" });
+  }
+  if (i.hasActualData && i.unmatchedCount > 0) {
+    a.push({ id: "unmatched", tone: "warning", title: `미매칭 SKU ${i.unmatchedCount}개`, body: "자동 매칭이 빗나간 항목을 보정하세요.", actionLabel: "매칭 보정", view: "skus" });
+  }
+  if (i.hasActualData && i.expectedContribution != null && i.expectedContribution <= 0) {
+    a.push({ id: "contrib", tone: "danger", title: "기대 공헌이익이 0 이하", body: "플랜의 원가·판매가(세트가) 적재를 확인하세요.", actionLabel: "플랜 확인", href: `/promotions/${ctx.promotionId}/plan` });
+  }
+  if (!i.hasBaseline) {
+    a.push({ id: "baseline", tone: "info", title: "baseline 데이터 부족", body: "일별 매출을 더 올리면 증분 측정이 정확해집니다.", actionLabel: "데이터 업로드", href: `/upload` });
+  }
+  return a;
+}


### PR DESCRIPTION
## PR2 — 캠페인 상세 정보구조 개편 (워크플로 바 + 요약→조치→분석 탭)

개발지시서 §3 **P0-1**(생애주기 상태머신) · **P0-2**(요약→조치→심층분석 3레이어).

### 핵심
- **생애주기 상태머신** (`lib/campaign-workflow.ts`, 순수함수·유닛테스트 8건): 데이터준비→플랜작성→확정→실적연결→매칭검증→결과검토→회고. 정확히 하나의 `current`, 문제는 `warning/blocked`.
- **CampaignWorkflowBar**: 현재 단계만 강조, 완료=체크, 경고/차단=아이콘+색(색만 의존 X), 클릭 시 해당 상세 탭으로.
- **Layer A (요약)**: 워크플로 바 + **핵심 KPI 3개**(`ProgressMetric` — 진행바·부족분·일관 캡션·CTA): 캠페인 매출 달성(전체)/메인 수량/공헌(전체).
- **Layer B (조치)**: `ActionPanel` — **문제 있는 것만** (플랜확정·실적연결·미매칭·기대공헌≤0·baseline부족) InlineAlert+바로가기 CTA.
- **Layer C (심층분석)**: `DetailTabsNav` — `?view=overview|skus|trend|purpose|sources` **URL 보존**, sticky, **선택 탭만 서버 렌더(lazy)**, 미매칭 배지. 뒤로가기·링크공유 정상.
- 12개 누적 섹션 → 5개 탭 재배치. `Achievement`에 `hideSummaryCards`(히어로 중복 제거).
- **Server Component 경계 유지** — 거대 클라이언트 컴포넌트화 없이 전부 서버 렌더, 탭은 Link 네비게이션.

### 완료 조건 (지시서)
캠페인 상세 진입 후 5초 내 **상태(워크플로)·달성(히어로 KPI)·문제(조치 패널)·다음 액션(현재 단계 CTA)** 파악 가능.

### 게이트
`tsc` 0 · `vitest` 15/15 · `next build` 통과.

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_