### PR TITLE
PR3: 매칭 인터랙션 개선 (optimistic·undo·자동펼침·신뢰도)

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/Achievement.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/Achievement.tsx
@@ -38,6 +38,9 @@ export default function Achievement({
 
   const hasConfirmed = !!summary?.has_confirmed_plan;
   const hasMatchData = diagnosticRows.length > 0 || skuMappings.length > 0;
+  const unmatched = diagnosticRows.filter((r) => r.side !== "both" && !r.is_mapped).length;
+  // 미매칭 있으면 매칭 보정 패널 자동 펼침 (지시서 §3) — 이후 사용자 토글 가능
+  const [matchOpen, setMatchOpen] = useState(unmatched > 0);
 
   if (!hasConfirmed && !hasMatchData && options.length === 0) {
     return (
@@ -71,7 +74,6 @@ export default function Achievement({
   const haloRest = haloSorted.slice(HALO_TOP);
   const haloRestRev = haloRest.reduce((s, r) => s + (r.actual_revenue ?? 0), 0);
   const haloRestQty = haloRest.reduce((s, r) => s + (r.actual_qty ?? 0), 0);
-  const unmatched = diagnosticRows.filter((r) => r.side !== "both" && !r.is_mapped).length;
 
   return (
     <section className="mt-6">
@@ -221,9 +223,13 @@ export default function Achievement({
             </div>
           )}
 
-          {/* SKU 매칭 보정 — 기본 접힘 (요약 우선) */}
+          {/* SKU 매칭 보정 — 미매칭 있으면 자동 펼침, 없으면 접힘 (사용자 토글 가능) */}
           {hasMatchData && (
-            <details className="mt-3 rounded-xl card-soft">
+            <details
+              open={matchOpen}
+              onToggle={(e) => setMatchOpen(e.currentTarget.open)}
+              className="mt-3 rounded-xl card-soft"
+            >
               <summary className="cursor-pointer px-4 py-3 text-xs font-semibold text-ink-2">
                 SKU 매칭 보정{unmatched > 0 ? ` · 미매칭 ${unmatched}` : ""}
                 <span className="ml-1 font-normal text-ink-4">(자동 매칭이 빗나간 경우에만)</span>

--- a/promo-analytics/app/(dash)/promotions/[id]/SkuMatchPanel.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/SkuMatchPanel.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
-import { toast } from "sonner";
+import { useEffect, useMemo, useState } from "react";
 import { won, wonShort, num } from "@/lib/format";
+import { cn } from "@/lib/cn";
+import { StatusBadge } from "@/components/ui";
+import { useOptimisticMutation } from "@/hooks/useOptimisticMutation";
 
 // promo.sku_match_diagnostic() 반환 행
 export type DiagnosticRow = {
@@ -19,22 +20,16 @@ export type DiagnosticRow = {
   is_subscription: boolean;
 };
 
-export type SkuMapping = {
-  plan_product_id: string;
-  actual_product_id: string;
-};
+export type SkuMapping = { plan_product_id: string; actual_product_id: string };
 
-// SQL promo.normalize_sku_name(0018) 의 클라이언트 미러 — 추천 정렬용(표시 전용).
-// 실제 매칭 판정은 항상 서버가 한다.
+// SQL normalize_sku_name 의 클라이언트 미러 — 추천 정렬·신뢰도 표시용. 판정은 서버가.
 function normalize(name: string): string {
   return name
     .replace(/\([^)]*\)|\[[^\]]*\]/g, "")
-    .replace(/닥터펠리스/g, "")
+    .replace(/(닥터펠리스|세븐플러스)/g, "")
     .replace(/[\s\-_·.,/+]/g, "")
     .toLowerCase();
 }
-
-// 추천 점수: 정규화 동일 > 포함 > 공통 prefix 길이
 function similarity(a: string, b: string): number {
   const na = normalize(a);
   const nb = normalize(b);
@@ -45,11 +40,14 @@ function similarity(a: string, b: string): number {
   while (i < Math.min(na.length, nb.length) && na[i] === nb[i]) i++;
   return i;
 }
+// 신뢰도 라벨 (지시서 §3: 정확/추천/미매칭)
+function confidence(score: number): { label: string; tone: "success" | "info" | "neutral" } | null {
+  if (score >= 1000) return { label: "정확 추천", tone: "success" };
+  if (score >= 500) return { label: "유사 추천", tone: "info" };
+  if (score > 0) return { label: "약한 후보", tone: "neutral" };
+  return null;
+}
 
-// 플랜 ↔ 실적 SKU 매칭 패널 (N6 비교 UX 개편판).
-// - 미매칭 플랜 SKU 마다 행 안에서 바로 실적 SKU 를 골라 연동 (왕복 제거)
-// - 실적 후보는 이름 유사도순 정렬, 최상위 후보 '추천' 표기
-// - 요약은 카드 대신 칩 한 줄, 진단 표는 검색 필터 지원
 export default function SkuMatchPanel({
   promotionId,
   rows,
@@ -59,143 +57,155 @@ export default function SkuMatchPanel({
   rows: DiagnosticRow[];
   mappings: SkuMapping[];
 }) {
-  const router = useRouter();
-  const [busyKey, setBusyKey] = useState<string | null>(null);
-  const [picks, setPicks] = useState<Record<string, string>>({}); // plan pid → actual pid
+  const { run, pending } = useOptimisticMutation();
+  // optimistic 로컬 상태 — 서버 reconcile(props 변경) 시 재동기화
+  const [localRows, setLocalRows] = useState(rows);
+  const [localMaps, setLocalMaps] = useState(mappings);
+  const [picks, setPicks] = useState<Record<string, string>>({});
   const [query, setQuery] = useState("");
   const [showAll, setShowAll] = useState(false);
+  const [flash, setFlash] = useState<string | null>(null);
 
-  const matched = rows.filter((r) => r.side === "both");
-  const planOnly = rows.filter((r) => r.side === "plan" && !r.is_mapped);
-  const actualOnly = rows.filter((r) => r.side === "actual" && !r.is_mapped);
+  useEffect(() => setLocalRows(rows), [rows]);
+  useEffect(() => setLocalMaps(mappings), [mappings]);
+
+  const matched = localRows.filter((r) => r.side === "both" || r.is_mapped);
+  const planOnly = localRows.filter((r) => r.side === "plan" && !r.is_mapped);
+  const actualOnly = localRows.filter((r) => r.side === "actual" && !r.is_mapped);
   const nameOf = useMemo(() => {
-    const m = new Map(rows.map((r) => [r.product_id, r.base_name]));
+    const m = new Map(localRows.map((r) => [r.product_id, r.base_name]));
     return (pid: string) => m.get(pid) ?? `${pid.slice(0, 8)}…`;
-  }, [rows]);
+  }, [localRows]);
 
-  async function addMapping(planPid: string, actualPid: string) {
+  const setMapped = (pids: string[], val: boolean) =>
+    setLocalRows((rs) => rs.map((r) => (pids.includes(r.product_id) ? { ...r, is_mapped: val } : r)));
+
+  function addMapping(planPid: string, actualPid: string) {
     if (!actualPid) return;
-    setBusyKey(planPid);
-    const res = await fetch(`/api/promotions/${promotionId}/sku-mappings`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ plan_product_id: planPid, actual_product_id: actualPid }),
+    const snapRows = localRows;
+    const snapMaps = localMaps;
+    run({
+      key: `add:${planPid}`,
+      apply: () => {
+        setMapped([planPid, actualPid], true);
+        setLocalMaps((m) => [...m, { plan_product_id: planPid, actual_product_id: actualPid }]);
+        setFlash(planPid);
+        setTimeout(() => setFlash((f) => (f === planPid ? null : f)), 600);
+      },
+      rollback: () => {
+        setLocalRows(snapRows);
+        setLocalMaps(snapMaps);
+      },
+      request: () =>
+        fetch(`/api/promotions/${promotionId}/sku-mappings`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ plan_product_id: planPid, actual_product_id: actualPid }),
+        }),
+      successMessage: `${nameOf(planPid)} 연동됨`,
+      errorMessage: "연동 실패",
+      undo: () => removeMapping(planPid, actualPid),
     });
-    setBusyKey(null);
-    if (!res.ok) {
-      const j = await res.json().catch(() => ({}));
-      toast.error(j.error ?? "연동 실패", {
-        action: { label: "다시 시도", onClick: () => addMapping(planPid, actualPid) },
-      });
-      return;
-    }
-    toast.success(`${nameOf(planPid)} 연동됨`);
-    router.refresh();
   }
 
-  async function toggleSubscription(productId: string, next: boolean) {
-    setBusyKey(productId);
-    const res = await fetch(`/api/products/subscription`, {
-      method: "PATCH",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ product_id: productId, is_subscription: next }),
+  function removeMapping(planPid: string, actualPid: string) {
+    const snapRows = localRows;
+    const snapMaps = localMaps;
+    run({
+      key: `rm:${planPid}`,
+      apply: () => {
+        setMapped([planPid, actualPid], false);
+        setLocalMaps((m) =>
+          m.filter((x) => !(x.plan_product_id === planPid && x.actual_product_id === actualPid)),
+        );
+      },
+      rollback: () => {
+        setLocalRows(snapRows);
+        setLocalMaps(snapMaps);
+      },
+      request: () =>
+        fetch(`/api/promotions/${promotionId}/sku-mappings`, {
+          method: "DELETE",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ plan_product_id: planPid, actual_product_id: actualPid }),
+        }),
+      successMessage: "연동 해제됨",
+      errorMessage: "해제 실패",
     });
-    setBusyKey(null);
-    if (!res.ok) {
-      const j = await res.json().catch(() => ({}));
-      toast.error(j.error ?? "구독 지정 실패");
-      return;
-    }
-    toast.success(next ? "정기구독으로 지정됨" : "정기구독 해제됨");
-    router.refresh();
   }
 
-  async function removeMapping(plan_product_id: string, actual_product_id: string) {
-    setBusyKey(plan_product_id);
-    const res = await fetch(`/api/promotions/${promotionId}/sku-mappings`, {
-      method: "DELETE",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ plan_product_id, actual_product_id }),
+  function toggleSubscription(pid: string, next: boolean) {
+    const snap = localRows;
+    run({
+      key: `sub:${pid}`,
+      apply: () => setLocalRows((rs) => rs.map((r) => (r.product_id === pid ? { ...r, is_subscription: next } : r))),
+      rollback: () => setLocalRows(snap),
+      request: () =>
+        fetch(`/api/products/subscription`, {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ product_id: pid, is_subscription: next }),
+        }),
+      successMessage: next ? "정기구독으로 지정됨" : "정기구독 해제됨",
+      errorMessage: "구독 지정 실패",
     });
-    setBusyKey(null);
-    if (!res.ok) {
-      const j = await res.json().catch(() => ({}));
-      toast.error(j.error ?? "해제 실패");
-      return;
-    }
-    router.refresh();
   }
 
   const filtered = query.trim()
-    ? rows.filter(
-        (r) =>
-          r.base_name.includes(query.trim()) ||
-          (r.dr_code ?? "").includes(query.trim()),
+    ? localRows.filter(
+        (r) => r.base_name.includes(query.trim()) || (r.dr_code ?? "").includes(query.trim()),
       )
-    : rows;
+    : localRows;
 
   return (
     <section className="mt-5">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <h3 className="text-sm font-semibold text-ink-2">SKU 매칭</h3>
-        {/* 요약 칩 한 줄 — 큰 카드 3개 대체 */}
         <div className="flex flex-wrap items-center gap-1.5 text-[11px] font-medium">
-          <span className="rounded-full bg-emerald-50 px-2 py-0.5 text-emerald-700">
+          <span className="rounded-full bg-success-soft px-2 py-0.5 text-success">
             자동 {matched.filter((r) => !r.is_mapped).length}
           </span>
-          <span className="rounded-full bg-brand-50 px-2 py-0.5 text-brand-700">
-            수동 {mappings.length}
-          </span>
+          <span className="rounded-full bg-brand-50 px-2 py-0.5 text-brand-700">수동 {localMaps.length}</span>
           {planOnly.length > 0 && (
-            <span className="rounded-full bg-amber-50 px-2 py-0.5 text-amber-700">
-              플랜 미매칭 {planOnly.length}
-            </span>
+            <span className="rounded-full bg-warning-soft px-2 py-0.5 text-warning">플랜 미매칭 {planOnly.length}</span>
           )}
           {actualOnly.length > 0 && (
-            <span className="rounded-full bg-soft px-2 py-0.5 text-ink-3">
-              실적 미매칭 {actualOnly.length}
-            </span>
+            <span className="rounded-full bg-soft px-2 py-0.5 text-ink-3">실적 미매칭 {actualOnly.length}</span>
           )}
         </div>
       </div>
 
-      {/* 미매칭 플랜 SKU — 행 안에서 바로 연동 */}
+      {/* 미매칭 플랜 SKU — 행 안에서 바로 연동 (optimistic) */}
       {planOnly.length > 0 && (
         <div className="mt-3 overflow-hidden rounded-xl card-soft">
-          <div className="border-b border-line bg-amber-50/50 px-4 py-2.5 text-xs font-medium text-amber-800">
-            플랜에 있는데 실적과 매칭 안 된 SKU {planOnly.length}개 — 행에서 바로
-            실적 SKU를 골라 연동하세요 (추천순 정렬)
+          <div className="border-b border-line bg-warning-soft/60 px-4 py-2.5 text-xs font-medium text-warning">
+            플랜에 있는데 실적과 매칭 안 된 SKU {planOnly.length}개 — 추천순으로 골라 바로 연동하세요.
           </div>
           <ul className="divide-y divide-line/70">
             {planOnly.map((p) => {
               const candidates = [...actualOnly].sort(
-                (a, b) =>
-                  similarity(p.base_name, b.base_name) -
-                  similarity(p.base_name, a.base_name),
+                (a, b) => similarity(p.base_name, b.base_name) - similarity(p.base_name, a.base_name),
               );
               const best = candidates[0];
               const bestScore = best ? similarity(p.base_name, best.base_name) : 0;
               const pick = picks[p.product_id] ?? (bestScore >= 500 ? best.product_id : "");
+              const conf = pick ? confidence(similarity(p.base_name, nameOf(pick))) : null;
+              const busy = pending === `add:${p.product_id}`;
               return (
-                <li
-                  key={p.product_id}
-                  className="flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center"
-                >
+                <li key={p.product_id} className="flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center">
                   <div className="min-w-0 sm:w-2/5">
                     <div className="truncate text-sm text-ink" title={p.base_name}>
                       {p.base_name}
                     </div>
                     <div className="text-[10px] text-ink-4">
-                      {p.dr_code ?? "코드 없음"} · 기대 {num(p.expected_qty)}개 ·{" "}
-                      {wonShort(p.expected_revenue)}
+                      {p.dr_code ?? "코드 없음"} · 기대 {num(p.expected_qty)}개 · {wonShort(p.expected_revenue)}
                     </div>
                   </div>
                   <div className="flex min-w-0 flex-1 items-center gap-2">
                     <select
                       value={pick}
-                      onChange={(e) =>
-                        setPicks((s) => ({ ...s, [p.product_id]: e.target.value }))
-                      }
+                      aria-label={`${p.base_name}에 연결할 실적 SKU`}
+                      onChange={(e) => setPicks((s) => ({ ...s, [p.product_id]: e.target.value }))}
                       className="w-full min-w-0 flex-1 truncate rounded-xl border border-line bg-card px-3 py-2 text-sm text-ink-2 focus:outline-none"
                     >
                       <option value="">실적 SKU 선택…</option>
@@ -206,12 +216,13 @@ export default function SkuMatchPanel({
                         </option>
                       ))}
                     </select>
+                    {conf && <StatusBadge tone={conf.tone} label={conf.label} />}
                     <button
                       onClick={() => addMapping(p.product_id, pick)}
-                      disabled={!pick || busyKey === p.product_id}
+                      disabled={!pick || busy}
                       className="shrink-0 rounded-full bg-brand-500 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-600 disabled:opacity-40"
                     >
-                      {busyKey === p.product_id ? "…" : "연동"}
+                      {busy ? "…" : "연동"}
                     </button>
                   </div>
                 </li>
@@ -222,22 +233,24 @@ export default function SkuMatchPanel({
       )}
 
       {/* 수동 매핑 현황 */}
-      {mappings.length > 0 && (
+      {localMaps.length > 0 && (
         <div className="mt-3 rounded-xl card-soft px-4 py-3">
-          <h4 className="text-xs font-semibold text-ink-2">수동 연동 {mappings.length}건</h4>
+          <h4 className="text-xs font-semibold text-ink-2">수동 연동 {localMaps.length}건</h4>
           <ul className="mt-1.5 space-y-1 text-xs">
-            {mappings.map((m) => (
+            {localMaps.map((m) => (
               <li
                 key={`${m.plan_product_id}-${m.actual_product_id}`}
-                className="flex items-center justify-between gap-2"
+                className={cn(
+                  "flex items-center justify-between gap-2 rounded-md px-1",
+                  flash === m.plan_product_id && "row-success-flash",
+                )}
               >
                 <span className="min-w-0 truncate text-ink-2">
-                  {nameOf(m.plan_product_id)}{" "}
-                  <span className="text-ink-4">↔ {nameOf(m.actual_product_id)}</span>
+                  {nameOf(m.plan_product_id)} <span className="text-ink-4">↔ {nameOf(m.actual_product_id)}</span>
                 </span>
                 <button
                   onClick={() => removeMapping(m.plan_product_id, m.actual_product_id)}
-                  disabled={busyKey != null}
+                  disabled={pending === `rm:${m.plan_product_id}`}
                   className="shrink-0 text-[11px] text-ink-4 hover:text-brand-700"
                 >
                   해제
@@ -252,9 +265,10 @@ export default function SkuMatchPanel({
       <div className="mt-3 rounded-xl card-soft">
         <button
           onClick={() => setShowAll((v) => !v)}
+          aria-expanded={showAll}
           className="flex w-full items-center justify-between px-4 py-3 text-left text-xs font-semibold text-ink-2"
         >
-          전체 SKU 진단 표 ({rows.length})
+          전체 SKU 진단 표 ({localRows.length})
           <span className="text-ink-4">{showAll ? "접기 ▴" : "펼치기 ▾"}</span>
         </button>
         {showAll && (
@@ -263,6 +277,7 @@ export default function SkuMatchPanel({
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder="SKU 이름·코드 검색…"
+              aria-label="SKU 검색"
               className="mt-3 w-full rounded-xl border border-line bg-card px-3 py-2 text-sm focus:outline-none sm:max-w-xs"
             />
             <div className="mt-3 overflow-x-auto">
@@ -286,32 +301,22 @@ export default function SkuMatchPanel({
                       </td>
                       <td className="px-2 py-2">
                         <div className="text-ink">{r.base_name}</div>
-                        {r.dr_code && (
-                          <div className="text-[10px] text-ink-4">{r.dr_code}</div>
-                        )}
+                        {r.dr_code && <div className="text-[10px] text-ink-4">{r.dr_code}</div>}
                       </td>
-                      <td className="px-2 py-2 text-right text-ink-3">
-                        {r.expected_qty ? num(r.expected_qty) : "—"}
-                      </td>
-                      <td className="px-2 py-2 text-right text-ink-3">
-                        {r.expected_revenue ? wonShort(r.expected_revenue) : "—"}
-                      </td>
-                      <td className="px-2 py-2 text-right text-ink-3">
-                        {r.actual_qty ? num(r.actual_qty) : "—"}
-                      </td>
-                      <td className="px-2 py-2 text-right text-ink-3">
-                        {r.actual_revenue ? won(r.actual_revenue) : "—"}
-                      </td>
+                      <td className="px-2 py-2 text-right text-ink-3">{r.expected_qty ? num(r.expected_qty) : "—"}</td>
+                      <td className="px-2 py-2 text-right text-ink-3">{r.expected_revenue ? wonShort(r.expected_revenue) : "—"}</td>
+                      <td className="px-2 py-2 text-right text-ink-3">{r.actual_qty ? num(r.actual_qty) : "—"}</td>
+                      <td className="px-2 py-2 text-right text-ink-3">{r.actual_revenue ? won(r.actual_revenue) : "—"}</td>
                       <td className="px-2 py-2 text-center">
                         <button
                           onClick={() => toggleSubscription(r.product_id, !r.is_subscription)}
-                          disabled={busyKey === r.product_id}
+                          disabled={pending === `sub:${r.product_id}`}
+                          aria-pressed={r.is_subscription}
                           title="정기구독 상품으로 지정하면 달성률에서 제외되고 별도 표기됩니다"
-                          className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${
-                            r.is_subscription
-                              ? "bg-violet-100 text-violet-700"
-                              : "bg-soft text-ink-4 hover:text-ink-2"
-                          }`}
+                          className={cn(
+                            "rounded-full px-2 py-0.5 text-[10px] font-medium",
+                            r.is_subscription ? "bg-subscription-soft text-subscription" : "bg-soft text-ink-4 hover:text-ink-2",
+                          )}
                         >
                           {r.is_subscription ? "✓ 구독" : "구독 지정"}
                         </button>
@@ -335,30 +340,8 @@ export default function SkuMatchPanel({
   );
 }
 
-function SideBadge({
-  side,
-  isMapped,
-}: {
-  side: DiagnosticRow["side"];
-  isMapped: boolean;
-}) {
-  if (side === "both" || isMapped) {
-    return (
-      <span className="inline-flex items-center rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] font-semibold text-emerald-700">
-        {isMapped ? "수동 연동" : "자동 매칭"}
-      </span>
-    );
-  }
-  if (side === "plan") {
-    return (
-      <span className="inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-semibold text-amber-700">
-        플랜만
-      </span>
-    );
-  }
-  return (
-    <span className="inline-flex items-center rounded-full bg-soft px-2 py-0.5 text-[10px] font-semibold text-ink-3">
-      실적만
-    </span>
-  );
+function SideBadge({ side, isMapped }: { side: DiagnosticRow["side"]; isMapped: boolean }) {
+  if (side === "both" || isMapped) return <StatusBadge tone="success" label={isMapped ? "수동 연동" : "자동 매칭"} />;
+  if (side === "plan") return <StatusBadge tone="warning" label="플랜만" />;
+  return <StatusBadge tone="neutral" label="실적만" />;
 }

--- a/promo-analytics/hooks/__tests__/useOptimisticMutation.test.tsx
+++ b/promo-analytics/hooks/__tests__/useOptimisticMutation.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+const refresh = vi.fn();
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh }) }));
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...a: unknown[]) => toastSuccess(...a),
+    error: (...a: unknown[]) => toastError(...a),
+  },
+}));
+
+import { useOptimisticMutation } from "@/hooks/useOptimisticMutation";
+
+describe("useOptimisticMutation", () => {
+  beforeEach(() => {
+    refresh.mockClear();
+    toastSuccess.mockClear();
+    toastError.mockClear();
+  });
+
+  it("성공: optimistic apply + 성공 토스트 + reconcile refresh, rollback 없음", async () => {
+    const apply = vi.fn();
+    const rollback = vi.fn();
+    const { result } = renderHook(() => useOptimisticMutation());
+    await act(async () => {
+      const ok = await result.current.run({
+        key: "k",
+        apply,
+        rollback,
+        request: async () => new Response(null, { status: 200 }),
+        successMessage: "ok",
+      });
+      expect(ok).toBe(true);
+    });
+    expect(apply).toHaveBeenCalledTimes(1);
+    expect(rollback).not.toHaveBeenCalled();
+    expect(toastSuccess).toHaveBeenCalled();
+    expect(refresh).toHaveBeenCalled();
+  });
+
+  it("실패: rollback + error 토스트, reconcile 안함", async () => {
+    const apply = vi.fn();
+    const rollback = vi.fn();
+    const { result } = renderHook(() => useOptimisticMutation());
+    await act(async () => {
+      const ok = await result.current.run({
+        key: "k",
+        apply,
+        rollback,
+        request: async () => new Response(JSON.stringify({ error: "x" }), { status: 500 }),
+      });
+      expect(ok).toBe(false);
+    });
+    expect(rollback).toHaveBeenCalledTimes(1);
+    expect(toastError).toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+});

--- a/promo-analytics/hooks/useOptimisticMutation.ts
+++ b/promo-analytics/hooks/useOptimisticMutation.ts
@@ -1,0 +1,59 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+// 지시서 P0-6: 작은 변경은 즉시 optimistic 반영, 서버 성공 시 확정/실패 시 rollback+재시도.
+// 전체 router.refresh()는 성공 후 reconcile 용도로만(블로킹 아님).
+export type MutationOpts = {
+  key: string;
+  apply: () => void; // optimistic 즉시 반영
+  rollback: () => void; // 실패 시 원복
+  request: () => Promise<Response>;
+  successMessage?: string;
+  errorMessage?: string;
+  undo?: () => void; // toast '실행 취소'
+  reconcile?: boolean; // 성공 후 router.refresh (기본 true)
+};
+
+export function useOptimisticMutation() {
+  const router = useRouter();
+  const [pending, setPending] = useState<string | null>(null);
+
+  const run = useCallback(
+    async (opts: MutationOpts): Promise<boolean> => {
+      const { key, apply, rollback, request, successMessage, errorMessage, undo, reconcile = true } = opts;
+      apply();
+      setPending(key);
+      let res: Response;
+      try {
+        res = await request();
+      } catch {
+        rollback();
+        setPending(null);
+        toast.error(errorMessage ?? "네트워크 오류", {
+          action: { label: "다시 시도", onClick: () => run(opts) },
+        });
+        return false;
+      }
+      setPending(null);
+      if (!res.ok) {
+        rollback();
+        const j = (await res.json().catch(() => ({}))) as { error?: string };
+        toast.error(j.error ?? errorMessage ?? "처리 실패", {
+          action: { label: "다시 시도", onClick: () => run(opts) },
+        });
+        return false;
+      }
+      if (successMessage) {
+        toast.success(successMessage, undo ? { action: { label: "실행 취소", onClick: undo } } : undefined);
+      }
+      if (reconcile) router.refresh(); // 성공 상태를 먼저 보여준 뒤 reconcile
+      return true;
+    },
+    [router],
+  );
+
+  return { run, pending };
+}


### PR DESCRIPTION
## PR3 — 매칭 인터랙션 개선 (optimistic · undo · 자동펼침 · 신뢰도)

개발지시서 §3 P0-3 + §10 P0-6.

### 변경
- **`hooks/useOptimisticMutation`** — 작은 변경 **즉시 optimistic 반영**, 실패 시 **rollback + 재시도 토스트**, **undo** 액션, 성공 후 **background reconcile**(`router.refresh`, 블로킹 아님). 유닛테스트 2건.
- **`SkuMatchPanel` 재작성** (로컬 optimistic 상태):
  - 연동/해제/구독지정이 **즉시 반영** — **전체 페이지 깜빡임 없음**, **미매칭 수 즉시 갱신**.
  - 매칭 완료 시 toast **'실행 취소'(undo)** + 새 매핑 행 **성공 flash**.
  - 추천 후보 **신뢰도 배지**(정확/유사/약한 후보).
  - 접근성: `aria-label`·`aria-pressed`·`aria-expanded`, 의미 토큰·`StatusBadge` 적용.
- **`Achievement`**: 미매칭 ≥ 1이면 매칭 보정 패널 **자동 펼침**(이후 사용자 토글 가능).

### 완료 조건 (지시서)
- SKU 하나 연결 시 전체 페이지 깜빡임 없음 ✓ (optimistic)
- 잘못 연결한 매핑 즉시 되돌리기 ✓ (toast undo + 해제)
- 미매칭 수 즉시 갱신 ✓

### 게이트
`tsc` 0 · `vitest` 17/17 · `next build` 통과.

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_