### PR TITLE
PR4: 업로드 안전성 — 원자적 교체 RPC + 교체 검토 dialog

### DIFF
--- a/promo-analytics/app/(dash)/upload/page.tsx
+++ b/promo-analytics/app/(dash)/upload/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { won, pct } from "@/lib/format";
 import type { ParsedPriceConfig } from "@/lib/parse";
+import { useReplaceConfirm } from "./useReplaceConfirm";
 
 // 업로드 이력 기록 — 연동 파일명·시간·종류·행수를 남긴다(업데이트 참고용).
 // 실패해도 업로드 자체를 막지 않는다(best-effort).
@@ -205,6 +206,7 @@ type Progress = {
 function UploadCard({ def }: { def: CardDef }) {
   const router = useRouter();
   const [p, setP] = useState<Progress>({ phase: "idle", message: "" });
+  const { confirm, element: replaceDialog } = useReplaceConfirm();
 
   async function handleFile(file: File) {
     try {
@@ -257,9 +259,8 @@ function UploadCard({ def }: { def: CardDef }) {
           .in("base_name", baseNamesList);
         if (cntErr) throw cntErr;
 
+        let oldRevenue = 0;
         if (oldCount && oldCount > 0) {
-          // 기존 총매출 합산(페이지네이션) — 불변식(총매출 동일) 확인용
-          let oldRevenue = 0;
           const size = 1000;
           for (let from = 0; from < oldCount; from += size) {
             const { data, error } = await supabase
@@ -272,44 +273,14 @@ function UploadCard({ def }: { def: CardDef }) {
             if (error) throw error;
             for (const r of data ?? []) oldRevenue += Number(r.revenue) || 0;
           }
-          const delta = newRevenue - oldRevenue;
-          const deltaPct =
-            oldRevenue > 0 ? (delta / oldRevenue) * 100 : newRevenue > 0 ? 100 : 0;
-
-          // 교환·환불·취소가 나중에 잡히면 동기간 총매출이 정당하게 바뀜 → 최신 파일로 교체.
-          // (구) 하드 차단 폐기 — 큰 변동(±5% 초과)은 확인창에 경고만 띄우고 진행은 사용자가 결정.
-          const bigDelta = Math.abs(deltaPct) > 5;
-          const ok = window.confirm(
-            `백필(소스 교체) — 기간 ${minDate} ~ ${maxDate}\n` +
-              `기존 ${oldCount.toLocaleString()}건 · 총매출 ₩${Math.round(oldRevenue).toLocaleString()}\n` +
-              `신규 ${rows.length.toLocaleString()}건 · 총매출 ₩${Math.round(newRevenue).toLocaleString()}\n` +
-              `매출 차이 ₩${Math.round(delta).toLocaleString()} (${deltaPct.toFixed(1)}%)` +
-              (bigDelta ? `  ⚠️ 변동이 큽니다 — 파일·기간이 맞는지 확인` : ``) +
-              `\n\n교환·환불·취소는 나중에 반영되어 동기간 매출이 달라질 수 있습니다 — 최신 파일이 기준입니다.\n` +
-              `이 기간·상품의 기존 행을 모두 삭제하고 최신 파일로 교체합니다 (누적 아님). 진행할까요?`,
-          );
-          if (!ok) {
-            setP({ phase: "idle", message: "취소됨" });
-            return;
-          }
-
-          setP({ phase: "uploading", message: `기존 ${oldCount.toLocaleString()}행 삭제 중…` });
-          const { error: delErr } = await supabase
-            .from("daily_sales")
-            .delete()
-            .gte("sale_date", minDate)
-            .lte("sale_date", maxDate)
-            .in("base_name", baseNamesList);
-          if (delErr) throw delErr;
         }
 
+        // 상품 매칭 + 레코드 빌드 (DB 변경 전 — 미리보기에 매칭 통계 포함)
         setP({ phase: "uploading", message: `상품 매칭 중… (${rows.length}행)` });
         const productMap = await products.ensureProducts(
           supabase,
           rows.map((r) => r.base_name),
         );
-
-        // 파일 내부 동일 키(일자·상품·옵션) 합산 — 한 배치에 중복 키가 있으면 upsert가 실패하므로 방어.
         const dedup = new Map<
           string,
           { sale_date: string; product_id: string | null; base_name: string; option_info: string; revenue: number; quantity: number; source_file: string }
@@ -329,21 +300,40 @@ function UploadCard({ def }: { def: CardDef }) {
         }
         const records = [...dedup.values()];
 
-        const batches = products.chunk(records, 1000);
-        let done = 0;
-        for (const [i, batch] of batches.entries()) {
-          setP({
-            phase: "uploading",
-            message: `${i + 1}/${batches.length} 배치 적재 중…`,
-            done,
-            total: records.length,
+        // 교체 검토 (DB 변경 전 영향 확인) — window.confirm 대신 앱 내부 dialog
+        if (oldCount && oldCount > 0) {
+          const ok = await confirm({
+            title: "일별 매출 — 같은 기간·상품 교체",
+            period: `${minDate} ~ ${maxDate}`,
+            oldCount,
+            oldRevenue,
+            newCount: records.length,
+            newRevenue,
+            matchedSkus: productMap.size,
+            totalSkus: baseNamesList.length,
+            note: "교환·환불·취소 반영 — 최신 파일을 기준으로 같은 기간·상품을 교체합니다(누적 아님). 삭제+삽입이 한 번에(원자적) 처리되어 부분 반영이 없습니다.",
           });
-          const { error } = await supabase
-            .from("daily_sales")
-            .upsert(batch, { onConflict: "sale_date,base_name,option_info" });
-          if (error) throw error;
-          done += batch.length;
+          if (!ok) {
+            setP({ phase: "idle", message: "취소됨" });
+            return;
+          }
         }
+
+        // 원자적 교체 (삭제+삽입 한 트랜잭션 — 부분 반영 불가)
+        setP({
+          phase: "uploading",
+          message: `최신 파일로 교체 중… (${records.length}행)`,
+          done: 0,
+          total: records.length,
+        });
+        const { data: inserted, error: rpcErr } = await supabase.rpc("replace_daily_sales", {
+          p_min: minDate,
+          p_max: maxDate,
+          p_base_names: baseNamesList,
+          p_rows: records,
+        });
+        if (rpcErr) throw rpcErr;
+        const done = Number(inserted) || records.length;
 
         const dates = rows.map((r) => r.sale_date).sort();
         await logUpload(supabase, {
@@ -420,53 +410,44 @@ function UploadCard({ def }: { def: CardDef }) {
           (s, r) => s + (Number(r.revenue) || 0),
           0,
         );
-        const delta = newRevenue - oldRevenue;
-        const deltaPct =
-          oldRevenue > 0 ? (delta / oldRevenue) * 100 : newRevenue > 0 ? 100 : 0;
-        // 교환·환불·취소 반영으로 실적 매출이 정당하게 바뀜 → 최신 파일로 교체(하드 차단 폐기).
-        const bigDelta = Math.abs(deltaPct) > 5;
-        const ok = window.confirm(
-          `백필(캠페인 실적 교체) — ${name}\n` +
-            `기존 ${oldCount.toLocaleString()}건 · 총매출 ₩${Math.round(oldRevenue).toLocaleString()}\n` +
-            `신규 ${parsed.rows.length.toLocaleString()}건 · 총매출 ₩${Math.round(newRevenue).toLocaleString()}\n` +
-            `매출 차이 ₩${Math.round(delta).toLocaleString()} (${deltaPct.toFixed(1)}%)` +
-            (bigDelta ? `  ⚠️ 변동이 큽니다 — 파일이 맞는지 확인` : ``) +
-            `\n\n교환·환불·취소는 나중에 반영되어 실적 매출이 달라질 수 있습니다 — 최신 파일이 기준입니다.\n` +
-            `이 캠페인의 기존 실적을 삭제하고 최신 파일로 교체합니다. 확정 플랜(frozen)은 그대로 보존됩니다.\n` +
-            `진행할까요? (취소 시 중단 — 중복 캠페인을 만들지 않습니다)`,
-        );
-        if (!ok) {
-          setP({ phase: "idle", message: "취소됨" });
-          return;
-        }
-
+        // 상품 매칭 + 레코드 빌드 (DB 변경 전 — 미리보기 매칭 통계)
         setP({ phase: "uploading", message: "상품 매칭 중…" });
         const productMap = await products.ensureProducts(
           supabase,
           parsed.rows.map((r) => r.base_name),
         );
-
-        setP({ phase: "uploading", message: `기존 실적 ${oldCount.toLocaleString()}행 삭제 중…` });
-        const { error: delErr } = await supabase
-          .from("promotion_sales")
-          .delete()
-          .eq("promotion_id", existing.id);
-        if (delErr) throw delErr;
-
         const records = buildRecords(existing.id, productMap);
-        const batches = products.chunk(records, 1000);
-        let done = 0;
-        for (const [i, batch] of batches.entries()) {
-          setP({
-            phase: "uploading",
-            message: `${i + 1}/${batches.length} 배치 적재 중…`,
-            done,
-            total: records.length,
-          });
-          const { error } = await supabase.from("promotion_sales").insert(batch);
-          if (error) throw error;
-          done += batch.length;
+        const totalSkus = new Set(parsed.rows.map((r) => r.base_name)).size;
+
+        // 교체 검토 (DB 변경 전) — window.confirm 대신 앱 내부 dialog
+        const ok = await confirm({
+          title: `캠페인 실적 교체 — ${name}`,
+          oldCount,
+          oldRevenue,
+          newCount: parsed.rows.length,
+          newRevenue,
+          matchedSkus: productMap.size,
+          totalSkus,
+          note: "이 캠페인의 기존 실적을 최신 파일로 교체합니다. 확정 플랜(frozen)·기대값은 보존됩니다. 삭제+삽입이 한 번에(원자적) 처리되어 부분 반영이 없습니다.",
+        });
+        if (!ok) {
+          setP({ phase: "idle", message: "취소됨" });
+          return;
         }
+
+        // 원자적 교체 (삭제+삽입 한 트랜잭션 — pack_size 트리거 자동 채움)
+        setP({
+          phase: "uploading",
+          message: `최신 파일로 교체 중… (${records.length}행)`,
+          done: 0,
+          total: records.length,
+        });
+        const { data: insertedN, error: rpcErr } = await supabase.rpc("replace_promotion_sales", {
+          p_promotion_id: existing.id,
+          p_rows: records,
+        });
+        if (rpcErr) throw rpcErr;
+        const done = Number(insertedN) || records.length;
 
         await logUpload(supabase, {
           kind: "promotion",
@@ -555,6 +536,7 @@ function UploadCard({ def }: { def: CardDef }) {
 
   return (
     <div className="rounded-2xl card-soft p-5">
+      {replaceDialog}
       <div className="flex items-start justify-between gap-4">
         <div>
           <h2 className="font-medium">{def.title}</h2>

--- a/promo-analytics/app/(dash)/upload/useReplaceConfirm.tsx
+++ b/promo-analytics/app/(dash)/upload/useReplaceConfirm.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogFooter, Button, InlineAlert } from "@/components/ui";
+import { wonShort, num } from "@/lib/format";
+
+// PR4: 교체 검토 — window.confirm 대신 앱 내부 dialog. DB 변경 전 영향을 명확히 보여주고 확인.
+// promise 기반: `const ok = await confirm({...})` 로 기존 흐름 거의 그대로 사용.
+export type ReplacePreview = {
+  title: string;
+  period?: string;
+  oldCount: number;
+  oldRevenue: number;
+  newCount: number;
+  newRevenue: number;
+  matchedSkus?: number;
+  totalSkus?: number;
+  note?: string;
+};
+
+export function useReplaceConfirm() {
+  const [preview, setPreview] = useState<ReplacePreview | null>(null);
+  const [typed, setTyped] = useState("");
+  const resolver = useRef<((v: boolean) => void) | null>(null);
+
+  const confirm = useCallback((p: ReplacePreview) => {
+    setTyped("");
+    setPreview(p);
+    return new Promise<boolean>((resolve) => {
+      resolver.current = resolve;
+    });
+  }, []);
+
+  const finish = useCallback((v: boolean) => {
+    resolver.current?.(v);
+    resolver.current = null;
+    setPreview(null);
+  }, []);
+
+  const delta = preview ? preview.newRevenue - preview.oldRevenue : 0;
+  const deltaPct = preview
+    ? preview.oldRevenue > 0
+      ? (delta / preview.oldRevenue) * 100
+      : preview.newRevenue > 0
+        ? 100
+        : 0
+    : 0;
+  const bigDelta = Math.abs(deltaPct) > 5;
+  const canConfirm = !bigDelta || typed.trim() === "교체";
+
+  const element = (
+    <Dialog open={!!preview} onOpenChange={(o) => !o && finish(false)}>
+      <DialogContent>
+        {preview && (
+          <>
+            <DialogHeader title={preview.title} description={preview.period} />
+            <dl className="space-y-1.5 text-sm">
+              <Row label="삭제 예정 (기존)" value={`${num(preview.oldCount)}건 · ${wonShort(preview.oldRevenue)}`} />
+              <Row label="삽입 예정 (신규)" value={`${num(preview.newCount)}건 · ${wonShort(preview.newRevenue)}`} strong />
+              <Row
+                label="매출 차이"
+                value={`${delta >= 0 ? "+" : ""}${wonShort(delta)} (${deltaPct.toFixed(1)}%)`}
+                tone={bigDelta ? "warn" : undefined}
+              />
+              {preview.matchedSkus != null && preview.totalSkus != null && (
+                <Row
+                  label="상품 매칭"
+                  value={`${num(preview.matchedSkus)} / ${num(preview.totalSkus)} 성공`}
+                  tone={preview.matchedSkus < preview.totalSkus ? "warn" : undefined}
+                />
+              )}
+            </dl>
+
+            {bigDelta && (
+              <div className="mt-3">
+                <InlineAlert tone="warning" title="총매출 변동이 큽니다">
+                  파일·기간이 맞는지 확인하세요. 진행하려면 아래에 <strong>교체</strong> 를 입력하세요.
+                </InlineAlert>
+                <input
+                  value={typed}
+                  onChange={(e) => setTyped(e.target.value)}
+                  aria-label="확인 문구 입력"
+                  placeholder="교체"
+                  className="mt-2 w-full rounded-xl border border-line bg-card px-3 py-2 text-sm focus:outline-none"
+                />
+              </div>
+            )}
+
+            {preview.note && <p className="mt-3 text-[11px] leading-relaxed text-ink-4">{preview.note}</p>}
+
+            <DialogFooter>
+              <Button variant="secondary" onClick={() => finish(false)}>
+                취소
+              </Button>
+              <Button variant={bigDelta ? "danger" : "primary"} disabled={!canConfirm} onClick={() => finish(true)}>
+                교체 진행
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+
+  return { confirm, element };
+}
+
+function Row({
+  label,
+  value,
+  strong,
+  tone,
+}: {
+  label: string;
+  value: string;
+  strong?: boolean;
+  tone?: "warn";
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <dt className="text-ink-3">{label}</dt>
+      <dd
+        className={`tabular-nums ${tone === "warn" ? "font-semibold text-warning" : strong ? "font-semibold text-ink" : "text-ink-2"}`}
+      >
+        {value}
+      </dd>
+    </div>
+  );
+}

--- a/promo-analytics/supabase/migrations/0039_pr4_atomic_replace.sql
+++ b/promo-analytics/supabase/migrations/0039_pr4_atomic_replace.sql
@@ -1,0 +1,79 @@
+-- 0039: PR4 — 업로드 백필을 원자적 교체(서버 RPC, 단일 트랜잭션)로
+--
+-- 기존: 클라이언트가 delete 후 insert를 별도로 수행 → 중간 실패 시 부분 반영(데이터 유실) 위험.
+-- 변경: 같은 기간/캠페인의 삭제 + 신규 삽입을 한 함수(=한 트랜잭션)로 처리 → 부분 반영 불가능.
+--   상품 매칭(ensureProducts)은 클라에서 미리 끝내고, 파괴 구간만 RPC로 원자화.
+
+-- 일별 매출: 같은 기간(min~max) × 같은 상품(base_names) 교체
+create or replace function promo.replace_daily_sales(
+  p_min date,
+  p_max date,
+  p_base_names text[],
+  p_rows jsonb
+)
+returns integer
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  n integer;
+begin
+  delete from promo.daily_sales
+   where sale_date between p_min and p_max
+     and base_name = any(p_base_names);
+
+  insert into promo.daily_sales (sale_date, product_id, base_name, option_info, revenue, quantity, source_file)
+  select (r->>'sale_date')::date,
+         nullif(r->>'product_id', '')::uuid,
+         r->>'base_name',
+         coalesce(r->>'option_info', ''),
+         coalesce((r->>'revenue')::numeric, 0),
+         coalesce((r->>'quantity')::numeric, 0),
+         r->>'source_file'
+  from jsonb_array_elements(coalesce(p_rows, '[]'::jsonb)) r;
+
+  get diagnostics n = row_count;
+  return n;
+end;
+$$;
+
+-- 캠페인 실적: 해당 캠페인의 실적 전체 교체 (확정 플랜/expected는 별도 테이블 — 영향 없음)
+-- pack_size는 promotion_sales BEFORE INSERT 트리거(0030)가 자동 채움.
+create or replace function promo.replace_promotion_sales(
+  p_promotion_id uuid,
+  p_rows jsonb
+)
+returns integer
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  n integer;
+begin
+  delete from promo.promotion_sales where promotion_id = p_promotion_id;
+
+  insert into promo.promotion_sales
+    (promotion_id, product_id, base_name, option_info, revenue, order_count, aov, fee, cost, quantity)
+  select p_promotion_id,
+         nullif(r->>'product_id', '')::uuid,
+         r->>'base_name',
+         r->>'option_info',
+         coalesce((r->>'revenue')::numeric, 0),
+         (r->>'order_count')::numeric,
+         (r->>'aov')::numeric,
+         (r->>'fee')::numeric,
+         (r->>'cost')::numeric,
+         (r->>'quantity')::numeric
+  from jsonb_array_elements(coalesce(p_rows, '[]'::jsonb)) r;
+
+  get diagnostics n = row_count;
+  return n;
+end;
+$$;
+
+grant execute on function promo.replace_daily_sales(date, date, text[], jsonb) to authenticated;
+grant execute on function promo.replace_promotion_sales(uuid, jsonb) to authenticated;
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## PR4 — 업로드 안전성 (원자적 교체 RPC + 교체 검토 dialog)

개발지시서 §5 P0-4. 결정대로 **서버 RPC 트랜잭션까지**.

### 데이터 안전 (핵심)
- **`migration 0039`**: `promo.replace_daily_sales` / `replace_promotion_sales` — 같은 기간·캠페인의 **삭제+삽입을 한 트랜잭션(함수)** 으로. 기존 클라 `delete→insert`의 **중간 실패 시 부분 반영(데이터 유실) 위험 제거**. `pack_size`는 기존 트리거가 자동.
- 스모크테스트: no-op 호출 0 반환(데이터 무변).

### 검토 UX
- **`window.confirm` 제거** → 앱 내부 **`ReviewReplaceDialog`**(Radix). **DB 변경 전** 삭제/삽입 건수·총매출·**매출 차이**·상품 매칭 성공수·위험 경고 표시. 큰 변동(±5% 초과)은 **'교체' 확인문구 입력** 요구.
- 일별 매출(②)·캠페인 실적(③) 백필: 파싱 → 상품매칭 → **검토 dialog** → **원자적 RPC 교체** → 성공·상세 이동.

### 완료 조건 (지시서)
- DB 변경 전 영향 명확히 확인 ✓ (dialog)
- 삭제 후 삽입 중 실패로 부분 반영 없음 ✓ (단일 트랜잭션 RPC)
- 업로드 성공 후 결과 화면 이동 ✓

### 게이트
`tsc` 0 · `vitest` 17/17 · `next build` 통과.

> 범위 메모: `DataReadinessOverview`·전체 다중검증 미리보기(미인식 헤더/중복 키 표)는 안전 코어 우선을 위해 **후속(PR4b)** 으로 분리.

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_