### PR TITLE
PR5: 플랜 빌더 — 저장 상태·이탈 경고·인라인 검증·확정 검토 dialog

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
@@ -14,6 +14,8 @@ import {
   type PlanItemInput,
 } from "@/lib/plan";
 import { won, pct, num } from "@/lib/format";
+import { validatePlan } from "@/lib/plan-validation";
+import { InlineAlert, Dialog, DialogContent, DialogHeader, DialogFooter, Button } from "@/components/ui";
 
 export type EditorItem = {
   product_id: string;
@@ -94,6 +96,19 @@ export default function PlanEditor({
   const [options, setOptions] = useState<OptState[]>(() => toState(initialOptions));
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState<{ kind: "err" | "ok"; text: string } | null>(null);
+  const [dirty, setDirty] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  // 저장되지 않은 변경이 있으면 이탈 경고
+  useEffect(() => {
+    if (!dirty) return;
+    const h = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", h);
+    return () => window.removeEventListener("beforeunload", h);
+  }, [dirty]);
 
   const confirmed = plan?.status === "confirmed";
   const mult = confirmed
@@ -143,12 +158,20 @@ export default function PlanEditor({
     })),
   );
 
+  // ── 인라인 검증 (확정 전 오류 발견) ──────────
+  const validation = validatePlan(options, mult);
+
   // ── 상태 변경 헬퍼 ───────────────────────────
-  const patchOption = (key: string, patch: Partial<OptState>) =>
+  const patchOption = (key: string, patch: Partial<OptState>) => {
+    setDirty(true);
     setOptions((prev) => prev.map((o) => (o.key === key ? { ...o, ...patch } : o)));
-  const removeOption = (key: string) =>
+  };
+  const removeOption = (key: string) => {
+    setDirty(true);
     setOptions((prev) => prev.filter((o) => o.key !== key));
-  const addOption = () =>
+  };
+  const addOption = () => {
+    setDirty(true);
     setOptions((prev) => [
       ...prev,
       {
@@ -160,7 +183,9 @@ export default function PlanEditor({
         items: [],
       },
     ]);
-  const patchItem = (optKey: string, itemKey: string, patch: Partial<ItemState>) =>
+  };
+  const patchItem = (optKey: string, itemKey: string, patch: Partial<ItemState>) => {
+    setDirty(true);
     setOptions((prev) =>
       prev.map((o) =>
         o.key === optKey
@@ -168,14 +193,18 @@ export default function PlanEditor({
           : o,
       ),
     );
-  const removeItem = (optKey: string, itemKey: string) =>
+  };
+  const removeItem = (optKey: string, itemKey: string) => {
+    setDirty(true);
     setOptions((prev) =>
       prev.map((o) =>
         o.key === optKey ? { ...o, items: o.items.filter((it) => it.key !== itemKey) } : o,
       ),
     );
+  };
 
   function addItem(optKey: string, it: ItemState) {
+    setDirty(true);
     setOptions((prev) =>
       prev.map((o) => (o.key === optKey ? { ...o, items: [...o.items, it] } : o)),
     );
@@ -220,26 +249,23 @@ export default function PlanEditor({
     setMsg(null);
     const ok = await save();
     if (ok) {
+      setDirty(false);
       setMsg({ kind: "ok", text: "draft 저장 완료" });
       router.refresh();
     }
     setBusy(false);
   }
 
-  async function onConfirm() {
-    if (
-      !window.confirm(
-        "확정하면 rate card·가격·원가가 동결되고 수정이 잠깁니다.\n" +
-          "확정 후 수정은 '새 버전'으로만 가능합니다. 확정할까요?",
-      )
-    )
-      return;
+  // 확정 검토 dialog에서 호출 (window.confirm 대체)
+  async function doConfirm() {
+    setConfirmOpen(false);
     setBusy(true);
     setMsg(null);
     if (!(await save())) {
       setBusy(false);
       return;
     }
+    setDirty(false);
     const res = await fetch(`/api/promotions/${promotionId}/plan/confirm`, {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -290,6 +316,21 @@ export default function PlanEditor({
           공헌이익 승수 mult = {mult.toFixed(3)}
           {confirmed && plan.confirmed_at ? " · 동결됨" : " · 라이브"}
         </span>
+        {!confirmed && (
+          <span
+            className={`ml-auto rounded-full px-2.5 py-0.5 text-xs font-medium ${
+              msg?.kind === "err"
+                ? "bg-danger-soft text-danger"
+                : busy
+                  ? "bg-soft text-ink-3"
+                  : dirty
+                    ? "bg-warning-soft text-warning"
+                    : "bg-success-soft text-success"
+            }`}
+          >
+            {msg?.kind === "err" ? "저장 실패" : busy ? "저장 중…" : dirty ? "저장되지 않은 변경" : "저장됨"}
+          </span>
+        )}
       </div>
 
       {/* 플랜 합계 */}
@@ -303,23 +344,59 @@ export default function PlanEditor({
         />
       </div>
 
+      {/* 검증 요약 (확정 전 오류 발견) */}
+      {!confirmed && (validation.errorCount > 0 || validation.warnCount > 0) && (
+        <div className="mt-4">
+          <InlineAlert
+            tone={validation.errorCount > 0 ? "danger" : "warning"}
+            title={`검증 — 오류 ${validation.errorCount} · 경고 ${validation.warnCount}`}
+          >
+            {validation.errorCount > 0
+              ? "오류를 해결해야 확정할 수 있습니다."
+              : "경고가 있어도 확정은 가능하나 확인을 권장합니다."}
+            {validation.plan.map((p, j) => (
+              <span key={j} className="mt-0.5 block">
+                · {p.message}
+              </span>
+            ))}
+          </InlineAlert>
+        </div>
+      )}
+
       {/* 옵션들 */}
       <div className="mt-5 space-y-4">
-        {options.map((o, i) => (
-          <OptionCard
-            key={o.key}
-            opt={o}
-            totals={optionResults[i]}
-            mult={mult}
-            qtyHint={qtyHint}
-            readOnly={confirmed}
-            onPatch={(patch) => patchOption(o.key, patch)}
-            onRemove={() => removeOption(o.key)}
-            onAddItem={(it) => addItem(o.key, it)}
-            onPatchItem={(itemKey, patch) => patchItem(o.key, itemKey, patch)}
-            onRemoveItem={(itemKey) => removeItem(o.key, itemKey)}
-          />
-        ))}
+        {options.map((o, i) => {
+          const issues = validation.byOption[o.key] ?? [];
+          return (
+            <div key={o.key}>
+              <OptionCard
+                opt={o}
+                totals={optionResults[i]}
+                mult={mult}
+                qtyHint={qtyHint}
+                readOnly={confirmed}
+                invalid={issues.some((x) => x.level === "error")}
+                onPatch={(patch) => patchOption(o.key, patch)}
+                onRemove={() => removeOption(o.key)}
+                onAddItem={(it) => addItem(o.key, it)}
+                onPatchItem={(itemKey, patch) => patchItem(o.key, itemKey, patch)}
+                onRemoveItem={(itemKey) => removeItem(o.key, itemKey)}
+              />
+              {issues.length > 0 && (
+                <ul className="mt-1 space-y-0.5 px-1">
+                  {issues.map((iss, j) => (
+                    <li
+                      key={j}
+                      className={`text-[11px] ${iss.level === "error" ? "text-danger" : "text-warning"}`}
+                    >
+                      {iss.level === "error" ? "✕" : "⚠"} {iss.message}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          );
+        })}
       </div>
 
       {!confirmed && (
@@ -377,8 +454,9 @@ export default function PlanEditor({
               draft 저장
             </button>
             <button
-              onClick={onConfirm}
-              disabled={busy}
+              onClick={() => setConfirmOpen(true)}
+              disabled={busy || validation.errorCount > 0}
+              title={validation.errorCount > 0 ? "오류를 먼저 해결하세요" : undefined}
               className="rounded-xl bg-brand-500 px-4 py-2 text-sm font-medium text-white hover:bg-brand-600 disabled:opacity-50"
             >
               확정
@@ -388,12 +466,57 @@ export default function PlanEditor({
       </div>
 
       {msg && (
-        <p
-          className={`mt-3 text-sm ${msg.kind === "err" ? "text-red-600" : "text-green-600"}`}
-        >
+        <p className={`mt-3 text-sm ${msg.kind === "err" ? "text-danger" : "text-success"}`}>
           {msg.text}
         </p>
       )}
+
+      {/* 확정 검토 dialog */}
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent>
+          <DialogHeader
+            title="플랜 확정"
+            description="확정하면 rate card·가격·원가가 동결되고 수정이 잠깁니다. 이후 수정은 '새 버전'으로만 가능합니다."
+          />
+          <dl className="space-y-1.5 text-sm">
+            <div className="flex justify-between gap-3">
+              <dt className="text-ink-3">목표 매출</dt>
+              <dd className="font-semibold tabular-nums text-ink">{won(planTotals.expected_revenue_total)}</dd>
+            </div>
+            <div className="flex justify-between gap-3">
+              <dt className="text-ink-3">목표 공헌이익</dt>
+              <dd className="font-semibold tabular-nums text-ink">{won(planTotals.expected_contribution_total)}</dd>
+            </div>
+            <div className="flex justify-between gap-3">
+              <dt className="text-ink-3">옵션 수</dt>
+              <dd className="tabular-nums text-ink-2">{num(options.length)}</dd>
+            </div>
+            <div className="flex justify-between gap-3">
+              <dt className="text-ink-3">메인 제품</dt>
+              <dd className="text-ink-2">
+                {options.filter((o) => o.is_main).length > 0
+                  ? `${num(options.filter((o) => o.is_main).length)}개 지정`
+                  : "미지정"}
+              </dd>
+            </div>
+          </dl>
+          {validation.warnCount > 0 && (
+            <div className="mt-3">
+              <InlineAlert tone="warning" title={`경고 ${validation.warnCount}개`}>
+                경고가 있어도 확정은 가능합니다. 확인 후 진행하세요.
+              </InlineAlert>
+            </div>
+          )}
+          <DialogFooter>
+            <Button variant="secondary" onClick={() => setConfirmOpen(false)}>
+              취소
+            </Button>
+            <Button onClick={doConfirm} disabled={busy}>
+              확정
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }
@@ -423,6 +546,7 @@ function OptionCard({
   mult,
   qtyHint,
   readOnly,
+  invalid,
   onPatch,
   onRemove,
   onAddItem,
@@ -434,6 +558,7 @@ function OptionCard({
   mult: number;
   qtyHint?: QtyHint;
   readOnly: boolean;
+  invalid?: boolean;
   onPatch: (patch: Partial<OptState>) => void;
   onRemove: () => void;
   onAddItem: (it: ItemState) => void;
@@ -441,7 +566,7 @@ function OptionCard({
   onRemoveItem: (itemKey: string) => void;
 }) {
   return (
-    <div className="rounded-xl card-soft p-4">
+    <div className={`rounded-xl card-soft p-4 ${invalid ? "ring-1 ring-danger/40" : ""}`}>
       <div className="flex flex-wrap items-center gap-2">
         <input
           className="min-w-[10rem] flex-1 rounded-lg border border-neutral-200 px-2.5 py-1.5 text-sm font-medium disabled:bg-neutral-50"

--- a/promo-analytics/lib/__tests__/plan-validation.test.ts
+++ b/promo-analytics/lib/__tests__/plan-validation.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { validatePlan, type ValOption } from "@/lib/plan-validation";
+
+const opt = (o: Partial<ValOption> & { key: string }): ValOption => ({
+  key: o.key,
+  option_label: o.option_label ?? o.key,
+  expected_option_qty: o.expected_option_qty ?? 10,
+  is_main: o.is_main ?? false,
+  items: o.items ?? [{ product_id: "p1", base_name: "치킨", sku_qty_per_option: 1, unit_sale_price: 1000, cost: 400 }],
+});
+
+describe("validatePlan", () => {
+  it("SKU 없는 옵션은 error", () => {
+    const v = validatePlan([opt({ key: "a", items: [] })], 0.715);
+    expect(v.byOption["a"].some((i) => i.code === "no-sku" && i.level === "error")).toBe(true);
+    expect(v.errorCount).toBeGreaterThan(0);
+  });
+  it("판매단가 ≤ 원가면 warn", () => {
+    const v = validatePlan(
+      [opt({ key: "a", items: [{ product_id: "p", base_name: "x", sku_qty_per_option: 1, unit_sale_price: 400, cost: 400 }] })],
+      0.715,
+    );
+    expect(v.byOption["a"].some((i) => i.code === "price-le-cost")).toBe(true);
+  });
+  it("동일 구성 중복 옵션 감지", () => {
+    const items = [{ product_id: "p1", base_name: "치킨", sku_qty_per_option: 2, unit_sale_price: 1000, cost: 400 }];
+    const v = validatePlan([opt({ key: "a", items }), opt({ key: "b", items })], 0.715);
+    expect(v.byOption["a"].some((i) => i.code === "dup-composition")).toBe(true);
+    expect(v.byOption["b"].some((i) => i.code === "dup-composition")).toBe(true);
+  });
+  it("메인 미지정이면 플랜 경고", () => {
+    const v = validatePlan([opt({ key: "a", is_main: false })], 0.715);
+    expect(v.plan.some((i) => i.code === "no-main")).toBe(true);
+  });
+  it("정상 옵션은 error 0", () => {
+    const v = validatePlan([opt({ key: "a", is_main: true })], 0.715);
+    expect(v.errorCount).toBe(0);
+  });
+});

--- a/promo-analytics/lib/plan-validation.ts
+++ b/promo-analytics/lib/plan-validation.ts
@@ -1,0 +1,101 @@
+// PR5: 플랜 옵션 검증 (순수 함수 — 테스트 대상). 확정 전 오류를 발생 위치에서 잡기 위함.
+export type ValItem = {
+  product_id: string;
+  base_name: string;
+  sku_qty_per_option: number;
+  unit_sale_price: number;
+  cost?: number | null;
+};
+export type ValOption = {
+  key: string;
+  option_label: string;
+  expected_option_qty: number;
+  is_main: boolean;
+  items: ValItem[];
+};
+
+export type Issue = { level: "error" | "warn"; code: string; message: string };
+export type OptionValidation = { key: string; issues: Issue[] };
+export type PlanValidation = {
+  byOption: Record<string, Issue[]>;
+  plan: Issue[];
+  errorCount: number;
+  warnCount: number;
+};
+
+function signature(o: ValOption): string {
+  return o.items
+    .map((i) => `${i.product_id}:${i.sku_qty_per_option}`)
+    .sort()
+    .join("|");
+}
+
+export function validatePlan(options: ValOption[], mult: number): PlanValidation {
+  const byOption: Record<string, Issue[]> = {};
+  let errorCount = 0;
+  let warnCount = 0;
+  const add = (key: string, issue: Issue) => {
+    (byOption[key] ??= []).push(issue);
+    if (issue.level === "error") errorCount++;
+    else warnCount++;
+  };
+
+  for (const o of options) {
+    if (o.items.length === 0) {
+      add(o.key, { level: "error", code: "no-sku", message: "옵션에 SKU가 없습니다." });
+    }
+    if (o.expected_option_qty <= 0) {
+      add(o.key, { level: "warn", code: "zero-qty", message: "예상 판매수가 0입니다." });
+    }
+    // 세트가 ≤ 원가 (마진 0 이하)
+    for (const it of o.items) {
+      if (it.cost != null && it.cost > 0 && it.unit_sale_price > 0 && it.unit_sale_price <= it.cost) {
+        add(o.key, {
+          level: "warn",
+          code: "price-le-cost",
+          message: `'${it.base_name}' 판매단가가 원가 이하입니다.`,
+        });
+      }
+    }
+    // 옵션 공헌이익 ≤ 0
+    const contrib = o.items.reduce(
+      (s, it) => s + o.expected_option_qty * it.sku_qty_per_option * (it.unit_sale_price * mult - (it.cost ?? 0)),
+      0,
+    );
+    if (o.items.length > 0 && o.expected_option_qty > 0 && contrib <= 0) {
+      add(o.key, { level: "warn", code: "contrib-le-0", message: "옵션 공헌이익이 0 이하입니다." });
+    }
+    // 동일 SKU 중복
+    const ids = o.items.map((i) => i.product_id);
+    if (new Set(ids).size < ids.length) {
+      add(o.key, { level: "warn", code: "dup-sku", message: "같은 SKU가 중복 추가되었습니다." });
+    }
+  }
+
+  // 동일 구성 시그니처 중복
+  const sigCount = new Map<string, number>();
+  for (const o of options) {
+    if (o.items.length === 0) continue;
+    const sig = signature(o);
+    sigCount.set(sig, (sigCount.get(sig) ?? 0) + 1);
+  }
+  for (const o of options) {
+    if (o.items.length === 0) continue;
+    if ((sigCount.get(signature(o)) ?? 0) > 1) {
+      add(o.key, { level: "warn", code: "dup-composition", message: "동일 구성의 옵션이 중복됩니다." });
+    }
+  }
+
+  // 플랜 레벨 — 메인 지정
+  const plan: Issue[] = [];
+  const mainCount = options.filter((o) => o.is_main).length;
+  if (options.length > 0 && mainCount === 0) {
+    plan.push({ level: "warn", code: "no-main", message: "메인 제품이 지정되지 않았습니다." });
+    warnCount++;
+  } else if (mainCount > Math.ceil(options.length / 2)) {
+    plan.push({ level: "warn", code: "too-many-main", message: "메인 제품이 과도하게 많습니다." });
+    warnCount++;
+  }
+
+  return { byOption, plan, errorCount, warnCount };
+}


### PR DESCRIPTION
## PR5 — 플랜 빌더 개선 (저장 상태·이탈 경고·인라인 검증·확정 검토)

개발지시서 §6 P0-5.

### 변경
- **`lib/plan-validation`** (순수·유닛테스트 5): 옵션 **SKU 없음(error)**, 예상수 0, **세트가≤원가**, **공헌≤0**, **동일 구성 중복**, 동일 SKU 중복, **메인 미지정/과다**.
- **PlanEditor**:
  - **저장 상태 표시** — `저장됨 / 저장되지 않은 변경 / 저장 중 / 저장 실패` + dirty 추적.
  - **이탈 경고**(`beforeunload`) — 저장 안 된 변경 보호.
  - **인라인 검증** — 상단 요약 + **옵션별 오류/경고 직접 표시** + 오류 옵션 카드 강조(ring).
  - **확정 검토 dialog**(목표 매출/공헌·옵션수·메인·경고·확정 후 잠김 안내) — `window.confirm` 제거.
  - **오류 있으면 확정 버튼 차단.**

### 완료 조건 (지시서)
- 공헌이익 음수·가격 이상·중복 구성 등이 **확정 전 발견** ✓
- 저장되지 않은 변경을 **사용자가 인식** ✓ (상태 표시 + 이탈 경고)

### 게이트
`tsc` 0 · `vitest` 22/22 · `next build` 통과.

> 후속(PR5b): 드래그 정렬·옵션 복제·좌우 분할(목록+상세) 레이아웃.

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_