### PR TITLE
PR6: 라이브러리 필터·정렬 URL 동기화 (공유 가능한 링크)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .next/
+node_modules/

--- a/promo-analytics/app/(dash)/library/LibraryTable.tsx
+++ b/promo-analytics/app/(dash)/library/LibraryTable.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import Link from "next/link";
 import { wonShort, pct } from "@/lib/format";
+import { useUrlState } from "@/hooks/useUrlState";
 
 export type CampaignStage = "plan" | "actual" | "linked" | "empty";
 
@@ -69,11 +70,20 @@ function rowFitScore(r: LibraryRow, filter: string[]): number {
 type StageFilter = "all" | "linked" | "actual" | "plan";
 
 export default function LibraryTable({ data }: { data: LibraryRow[] }) {
-  const [type, setType] = useState("");
-  const [season, setSeason] = useState("");
-  const [sort, setSort] = useState<SortKey>("score");
-  const [purposeFilter, setPurposeFilter] = useState<string[]>([]);
-  const [stage, setStage] = useState<StageFilter>("all");
+  // PR6: 필터/정렬을 URL에 보존 — 링크 복사 시 같은 결과 복원
+  const [f, setF, clearF] = useUrlState({
+    type: "",
+    season: "",
+    sort: "score",
+    stage: "all",
+    purpose: [] as string[],
+  });
+  const type = f.type;
+  const season = f.season;
+  const sort = f.sort as SortKey;
+  const stage = f.stage as StageFilter;
+  const purposeFilter = f.purpose;
+  const anyFilter = !!(type || season || stage !== "all" || purposeFilter.length || sort !== "score");
 
   const stageCounts = useMemo(() => {
     const c = { linked: 0, actual: 0, plan: 0 };
@@ -94,9 +104,11 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
     [data],
   );
   const togglePurpose = (p: string) =>
-    setPurposeFilter((prev) =>
-      prev.includes(p) ? prev.filter((x) => x !== p) : [...prev, p],
-    );
+    setF({
+      purpose: purposeFilter.includes(p)
+        ? purposeFilter.filter((x) => x !== p)
+        : [...purposeFilter, p],
+    });
 
   // 종합 점수 = 공헌이익 0.4 · 일평균 기여 0.3 · 효율(기여/할인) 0.2 · 간접비중 0.1
   const scored = useMemo<Scored[]>(() => {
@@ -149,7 +161,8 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
         ).map((t) => (
           <button
             key={t.key}
-            onClick={() => setStage(t.key)}
+            onClick={() => setF({ stage: t.key })}
+            aria-pressed={stage === t.key}
             className={`rounded-lg px-3.5 py-1.5 transition ${
               stage === t.key ? "card-soft text-ink" : "text-ink-3 hover:text-ink"
             }`}
@@ -160,14 +173,20 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
       </div>
 
       <div className="mb-4 flex flex-wrap items-center gap-2">
-        <Select value={type} onChange={setType} placeholder="혜택종류 전체" options={types} />
-        <Select value={season} onChange={setSeason} placeholder="시즈널리티 전체" options={seasons} />
+        <Select value={type} onChange={(v) => setF({ type: v })} placeholder="혜택종류 전체" options={types} />
+        <Select value={season} onChange={(v) => setF({ season: v })} placeholder="시즈널리티 전체" options={seasons} />
+        {anyFilter && (
+          <button onClick={clearF} className="text-xs text-ink-4 underline hover:text-ink-2">
+            필터 초기화
+          </button>
+        )}
         <div className="ml-auto flex items-center gap-1 text-xs text-neutral-500">
           정렬:
           {SORTS.map((s) => (
             <button
               key={s.key}
-              onClick={() => setSort(s.key)}
+              onClick={() => setF({ sort: s.key })}
+              aria-pressed={sort === s.key}
               className={`rounded-full px-2.5 py-1 ${
                 sort === s.key ? "bg-brand-500 text-white" : "text-neutral-600 hover:bg-neutral-100"
               }`}
@@ -198,7 +217,7 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
             ))}
             {purposeFilter.length > 0 && (
               <button
-                onClick={() => setPurposeFilter([])}
+                onClick={() => setF({ purpose: [] })}
                 className="text-xs text-neutral-400 hover:text-neutral-600"
               >
                 초기화

--- a/promo-analytics/hooks/__tests__/useUrlState.test.ts
+++ b/promo-analytics/hooks/__tests__/useUrlState.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { serializeUrlState, parseUrlState } from "@/hooks/useUrlState";
+
+describe("url state serialize/parse (round-trip)", () => {
+  const defaults = { type: "", season: "", sort: "score", stage: "all", purpose: [] as string[] };
+
+  it("빈/기본값은 query에서 생략", () => {
+    expect(serializeUrlState({ ...defaults })).toBe("sort=score&stage=all");
+  });
+
+  it("배열·문자열을 직렬화", () => {
+    const qs = serializeUrlState({ ...defaults, type: "할인", purpose: ["재고소진", "브랜딩"] });
+    const sp = new URLSearchParams(qs);
+    expect(sp.get("type")).toBe("할인");
+    expect(sp.getAll("purpose")).toEqual(["재고소진", "브랜딩"]);
+  });
+
+  it("parse는 존재하는 키만 덮어쓰고 나머지는 기본값", () => {
+    const parsed = parseUrlState("type=할인&purpose=재고소진&purpose=세일즈", defaults);
+    expect(parsed.type).toBe("할인");
+    expect(parsed.purpose).toEqual(["재고소진", "세일즈"]);
+    expect(parsed.sort).toBe("score"); // 기본값 유지
+    expect(parsed.season).toBe("");
+  });
+
+  it("직렬화→파싱 라운드트립 복원", () => {
+    const state = { ...defaults, type: "쿠폰", stage: "linked", purpose: ["브랜딩"] };
+    const restored = parseUrlState(serializeUrlState(state), defaults);
+    expect(restored).toEqual(state);
+  });
+});

--- a/promo-analytics/hooks/useUrlState.ts
+++ b/promo-analytics/hooks/useUrlState.ts
@@ -1,0 +1,59 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+// PR6: 필터/정렬 상태를 URL query에 보존 — 링크 복사 시 같은 결과 복원.
+// 클라 전용(서버 재요청 없이 즉시 필터). 순수 헬퍼는 테스트 대상.
+
+export type UrlStateShape = Record<string, string | string[]>;
+
+// state → query string (빈 값/빈 배열은 생략)
+export function serializeUrlState(state: UrlStateShape): string {
+  const sp = new URLSearchParams();
+  for (const [k, v] of Object.entries(state)) {
+    if (Array.isArray(v)) v.forEach((x) => x && sp.append(k, x));
+    else if (v) sp.set(k, v);
+  }
+  return sp.toString();
+}
+
+// query string → state (defaults 기준, 존재하는 키만 덮어씀)
+export function parseUrlState<T extends UrlStateShape>(search: string, defaults: T): T {
+  const sp = new URLSearchParams(search);
+  const next = { ...defaults } as Record<string, string | string[]>;
+  for (const k of Object.keys(defaults)) {
+    if (Array.isArray(defaults[k])) {
+      const all = sp.getAll(k);
+      if (all.length) next[k] = all;
+    } else {
+      const v = sp.get(k);
+      if (v != null) next[k] = v;
+    }
+  }
+  return next as T;
+}
+
+export function useUrlState<T extends UrlStateShape>(defaults: T) {
+  const [state, setState] = useState<T>(defaults);
+
+  // 마운트 시 URL에서 초기화 (SSR 안전 — window는 effect에서만)
+  useEffect(() => {
+    const parsed = parseUrlState(window.location.search, defaults);
+    setState(parsed);
+    // defaults는 첫 렌더 기준 — 마운트 1회만
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const set = useCallback((patch: Partial<T>) => {
+    setState((prev) => {
+      const next = { ...prev, ...patch };
+      const qs = serializeUrlState(next);
+      window.history.replaceState(null, "", qs ? `?${qs}` : window.location.pathname);
+      return next;
+    });
+  }, []);
+
+  const clear = useCallback(() => set(defaults), [set, defaults]);
+
+  return [state, set, clear] as const;
+}


### PR DESCRIPTION
## PR6 — 라이브러리 필터·정렬 URL 동기화 (공유 가능한 링크)

개발지시서 §7 P1-3의 핵심 완료 조건("라이브러리 필터 링크를 복사해도 같은 결과 복원").

### 변경
- **`hooks/useUrlState`**: 필터/정렬 상태를 URL query에 보존(클라 전용 — 즉시 필터, 서버 재요청 없음). 순수 헬퍼 `serializeUrlState`/`parseUrlState` + **라운드트립 유닛테스트 4**.
- **LibraryTable**: 혜택종류·시즈널리티·정렬·생애주기·목적 필터를 **URL에 동기화** → 필터 링크 복사 시 같은 결과 복원. **'필터 초기화'** + `aria-pressed`(키보드/접근성).

### 완료 조건
- 라이브러리 필터 링크 복사 → 같은 결과 복원 ✓
- 키보드로 정렬·필터 가능(button + aria-pressed) ✓

### 게이트
`tsc` 0 · `vitest` 26/26 · `next build` 통과.

> 후속(PR6b): 공용 `DataTable` 추출(sticky/정렬/모바일카드 통일) · plans/상세 탭 URL 동기화 · 커맨드 팔레트 액션 확장.

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_