### PR TITLE
PR7: 시뮬레이터·추천 설명가능성 + 공유 가능한 시나리오

### DIFF
--- a/promo-analytics/app/(dash)/library/LibraryTable.tsx
+++ b/promo-analytics/app/(dash)/library/LibraryTable.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { wonShort, pct } from "@/lib/format";
 import { useUrlState } from "@/hooks/useUrlState";
+import { parseSeedQuery } from "@/lib/scenario";
+import { InlineAlert } from "@/components/ui";
 
 export type CampaignStage = "plan" | "actual" | "linked" | "empty";
 
@@ -147,8 +149,31 @@ export default function LibraryTable({ data }: { data: LibraryRow[] }) {
     );
   }, [scored, stage, type, season, sort, purposeFilter]);
 
+  // PR7: 시뮬레이터/추천에서 넘어온 "플랜 조건" 배너 — 적용할 캠페인 선택 유도
+  const [seed, setSeed] = useState<ReturnType<typeof parseSeedQuery>>(null);
+  useEffect(() => {
+    setSeed(parseSeedQuery(window.location.search));
+  }, []);
+
   return (
     <div>
+      {seed?.active && (
+        <InlineAlert
+          tone="brand"
+          title="추천 조건으로 플랜 시작"
+          action={
+            <button onClick={() => setSeed(null)} className="text-[11px] text-ink-4 underline hover:text-ink-2">
+              닫기
+            </button>
+          }
+          className="mb-4"
+        >
+          {seed.promoType || "전체"}
+          {` · ${seed.discount}% 할인 · ${seed.days}일`}
+          {seed.season ? ` · ${seed.season}` : ""} — 이 조건을 적용할 캠페인을 아래에서 선택해 상세로 들어간 뒤 ‘가격 가이드(플랜)’를 작성하세요.
+        </InlineAlert>
+      )}
+
       {/* 생애주기 세그먼트 — 플랜+실적 / 실적만 / 플랜만 구분 */}
       <div className="mb-4 flex flex-wrap gap-1 rounded-xl bg-soft p-1 text-sm font-medium w-fit">
         {(

--- a/promo-analytics/app/(dash)/predict/Simulator.tsx
+++ b/promo-analytics/app/(dash)/predict/Simulator.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useDeferredValue, useMemo, useState } from "react";
 import Link from "next/link";
 import {
   Line,
@@ -15,44 +15,68 @@ import {
 } from "recharts";
 import { won, wonShort, pct } from "@/lib/format";
 import { predict, type CaseFeature, type PredictionSpec } from "@/lib/predict";
+import {
+  decodeScenarios,
+  encodeScenarios,
+  scenarioLabel,
+  diffPct,
+  specToSeedQuery,
+  type SavedScenario,
+  type SimSpec,
+} from "@/lib/scenario";
+import { useUrlState } from "@/hooks/useUrlState";
+import { CountUp, Button, InlineAlert } from "@/components/ui";
 
 type Options = { benefitTypes: string[]; seasonalities: string[]; purposes: string[] };
 
 const BRAND = "#e76f51";
 
-type Scenario = {
-  label: string;
-  uplift: number;
-  promoDaily: number;
-  baselineDaily: number;
-  ratio: number | null;
-  contribution: number;
-};
+function toSpec(s: SimSpec): PredictionSpec {
+  return {
+    promo_type: s.promoType || null,
+    season_tag: s.season || null,
+    purpose: s.purpose || null,
+    discount_rate: s.discount / 100,
+    duration_days: s.days,
+  };
+}
 
 export default function Simulator({ cases, options }: { cases: CaseFeature[]; options: Options }) {
-  const [promoType, setPromoType] = useState(options.benefitTypes[0] ?? "할인");
-  const [seasonTag, setSeasonTag] = useState("");
-  const [purpose, setPurpose] = useState("");
-  const [discount, setDiscount] = useState(40);
-  const [days, setDays] = useState(4);
-  const [pinned, setPinned] = useState<Scenario[]>([]);
+  // 조건·시나리오를 URL에 보존 → 링크 복사로 같은 결과 공유 (PR7)
+  const [url, setUrl] = useUrlState({
+    promo: options.benefitTypes[0] ?? "할인",
+    season: "",
+    purpose: "",
+    discount: "40",
+    days: "4",
+    sc: "",
+  });
 
-  const spec: PredictionSpec = {
-    promo_type: promoType || null,
-    season_tag: seasonTag || null,
-    purpose: purpose || null,
-    discount_rate: discount / 100,
-    duration_days: days,
-  };
+  const promoType = url.promo as string;
+  const seasonTag = url.season as string;
+  const purpose = url.purpose as string;
+  const discount = Number(url.discount) || 0;
+  const days = Number(url.days) || 1;
+
+  const liveSpec: SimSpec = { promoType, season: seasonTag, purpose, discount, days };
+  const scenarios = useMemo(() => decodeScenarios(url.sc as string), [url.sc]);
+
+  const [copied, setCopied] = useState(false);
+
+  // 슬라이더는 즉시 반응하되 무거운 곡선 계산은 지연(useDeferredValue) — 끊김 방지
+  const deferredDiscount = useDeferredValue(discount);
+  const deferredSpec: PredictionSpec = { ...toSpec(liveSpec), discount_rate: deferredDiscount / 100 };
+
+  const spec: PredictionSpec = toSpec(liveSpec);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const pred = useMemo(() => predict(spec, cases), [promoType, seasonTag, purpose, discount, days, cases]);
 
-  // 할인율별 예상 증분/공헌이익 곡선
+  // 할인율별 예상 증분/공헌이익 곡선 (지연된 할인율 기준 — 슬라이더 드래그 중 끊김 방지)
   const curve = useMemo(() => {
     const out: { discount: number; uplift: number; contribution: number }[] = [];
     for (let d = 0; d <= 70; d += 5) {
-      const p = predict({ ...spec, discount_rate: d / 100 }, cases);
+      const p = predict({ ...deferredSpec, discount_rate: d / 100 }, cases);
       out.push({
         discount: d,
         uplift: Math.round(p.expected_uplift),
@@ -61,7 +85,7 @@ export default function Simulator({ cases, options }: { cases: CaseFeature[]; op
     }
     return out;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [promoType, seasonTag, purpose, days, cases]);
+  }, [promoType, seasonTag, purpose, days, deferredDiscount, cases]);
 
   // 스윗스팟: 최고 효과(증분 최대) / 최고 효율(공헌이익 최대)
   const bestEffect = useMemo(
@@ -75,20 +99,59 @@ export default function Simulator({ cases, options }: { cases: CaseFeature[]; op
 
   const curUplift = Math.round(pred.expected_uplift);
 
-  function pin() {
-    setPinned((prev) =>
-      [
-        ...prev,
-        {
-          label: `${promoType || "?"} ${discount}%·${days}일${seasonTag ? `·${seasonTag}` : ""}${purpose ? `·${purpose}` : ""}`,
-          uplift: pred.expected_uplift,
-          promoDaily: pred.expected_promo_daily,
-          baselineDaily: pred.expected_baseline_daily,
-          ratio: pred.lift_ratio,
-          contribution: pred.expected_contribution,
-        },
-      ].slice(-3),
-    );
+  // 저장된 시나리오별 예측 (기준=현재 조건과 비교)
+  const scenarioRows = useMemo(
+    () =>
+      scenarios.map((s) => {
+        const p = predict(toSpec(s), cases);
+        return { s, p };
+      }),
+    [scenarios, cases],
+  );
+
+  function setSpec(patch: Partial<SimSpec>) {
+    const next: Record<string, string> = {};
+    if (patch.promoType !== undefined) next.promo = patch.promoType;
+    if (patch.season !== undefined) next.season = patch.season;
+    if (patch.purpose !== undefined) next.purpose = patch.purpose;
+    if (patch.discount !== undefined) next.discount = String(patch.discount);
+    if (patch.days !== undefined) next.days = String(patch.days);
+    setUrl(next);
+  }
+
+  function saveScenario() {
+    const s: SavedScenario = {
+      id: `s${Date.now().toString(36)}`,
+      name: scenarioLabel(liveSpec),
+      ...liveSpec,
+    };
+    const next = [...scenarios, s].slice(-4); // 최대 4개
+    setUrl({ sc: encodeScenarios(next) });
+  }
+  function removeScenario(id: string) {
+    setUrl({ sc: encodeScenarios(scenarios.filter((s) => s.id !== id)) });
+  }
+  function renameScenario(id: string) {
+    const cur = scenarios.find((s) => s.id === id);
+    const name = window.prompt("시나리오 이름", cur?.name ?? "");
+    if (name == null) return;
+    setUrl({ sc: encodeScenarios(scenarios.map((s) => (s.id === id ? { ...s, name: name.trim() || s.name } : s))) });
+  }
+  function applyScenario(s: SavedScenario) {
+    setSpec({ promoType: s.promoType, season: s.season, purpose: s.purpose, discount: s.discount, days: s.days });
+  }
+  function clearScenarios() {
+    setUrl({ sc: "" });
+  }
+
+  async function copyShareLink() {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1600);
+    } catch {
+      /* 클립보드 불가 환경 무시 */
+    }
   }
 
   const confColor =
@@ -102,24 +165,34 @@ export default function Simulator({ cases, options }: { cases: CaseFeature[]; op
 
   return (
     <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
-      <header className="mb-5">
-        <h1 className="text-xl font-semibold tracking-tight">성과 시뮬레이터</h1>
-        <p className="mt-1 text-sm text-neutral-500">
-          조건을 움직이면 과거 사례 기반으로 <strong>상시 대비 예상 매출</strong>이 즉시 갱신됩니다.
-        </p>
+      <header className="mb-5 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold tracking-tight">성과 시뮬레이터</h1>
+          <p className="mt-1 text-sm text-neutral-500">
+            조건을 움직이면 과거 사례 기반으로 <strong>상시 대비 예상 매출</strong>이 즉시 갱신됩니다.
+          </p>
+        </div>
+        <div className="flex shrink-0 gap-2">
+          <Button variant="ghost" size="sm" onClick={copyShareLink}>
+            {copied ? "링크 복사됨 ✓" : "🔗 공유 링크 복사"}
+          </Button>
+          <Button asChild size="sm" variant="secondary">
+            <Link href={`/library?${specToSeedQuery(liveSpec)}`}>이 조건으로 플랜 만들기 →</Link>
+          </Button>
+        </div>
       </header>
 
       <div className="grid gap-3 sm:gap-4 lg:grid-cols-5">
         {/* 컨트롤 */}
         <section className="rounded-2xl p-6 card-soft lg:col-span-2">
           <Field label="혜택 종류">
-            <Chips options={options.benefitTypes} value={promoType} onChange={setPromoType} />
+            <Chips options={options.benefitTypes} value={promoType} onChange={(v) => setSpec({ promoType: v })} />
           </Field>
           <Field label="시즈널리티">
-            <Chips options={options.seasonalities} value={seasonTag} onChange={setSeasonTag} clearable />
+            <Chips options={options.seasonalities} value={seasonTag} onChange={(v) => setSpec({ season: v })} clearable />
           </Field>
           <Field label="목적">
-            <Chips options={options.purposes} value={purpose} onChange={setPurpose} clearable />
+            <Chips options={options.purposes} value={purpose} onChange={(v) => setSpec({ purpose: v })} clearable />
             <p className="mt-1 text-[11px] text-neutral-400">
               목적을 고르면 같은 목적 캠페인 사례를 우선 가중해 예측합니다.
             </p>
@@ -133,7 +206,7 @@ export default function Simulator({ cases, options }: { cases: CaseFeature[]; op
             <input
               type="range" min={0} max={70} step={5}
               value={discount}
-              onChange={(e) => setDiscount(Number(e.target.value))}
+              onChange={(e) => setSpec({ discount: Number(e.target.value) })}
               className="w-full accent-brand-500"
             />
           </div>
@@ -146,16 +219,16 @@ export default function Simulator({ cases, options }: { cases: CaseFeature[]; op
             <input
               type="range" min={1} max={14} step={1}
               value={days}
-              onChange={(e) => setDays(Number(e.target.value))}
+              onChange={(e) => setSpec({ days: Number(e.target.value) })}
               className="w-full accent-brand-500"
             />
           </div>
 
           <button
-            onClick={pin}
+            onClick={saveScenario}
             className="mt-6 w-full rounded-full border border-neutral-200 py-2.5 text-sm font-medium text-neutral-700 transition hover:bg-neutral-50"
           >
-            + 이 시나리오 비교에 담기
+            + 이 시나리오 저장하고 비교
           </button>
         </section>
 
@@ -165,7 +238,11 @@ export default function Simulator({ cases, options }: { cases: CaseFeature[]; op
             <div>
               <div className="text-xs text-neutral-400">평소 대비 예상 매출</div>
               <div className="mt-0.5 text-4xl font-bold tracking-tight text-brand-500">
-                {pred.lift_ratio != null ? `${pred.lift_ratio.toFixed(1)}배` : "—"}
+                {pred.lift_ratio != null ? (
+                  <CountUp value={pred.lift_ratio} format={(n) => `${n.toFixed(1)}배`} />
+                ) : (
+                  "—"
+                )}
               </div>
             </div>
             <span className={`rounded-full px-3 py-1 text-xs font-medium ${confColor}`}>
@@ -181,9 +258,16 @@ export default function Simulator({ cases, options }: { cases: CaseFeature[]; op
 
           {/* KPI */}
           <div className="mt-5 grid grid-cols-3 gap-3">
-            <Mini label="예상 총 증분" value={won(curUplift)} />
-            <Mini label="예상 공헌이익" value={wonShort(pred.expected_contribution)} sub={pred.expected_contribution_rate != null ? `이익률 ${pct(pred.expected_contribution_rate)}` : undefined} />
-            <Mini label="예상 범위" value={`${wonShort(pred.low)}~${wonShort(pred.high)}`} />
+            <Mini label="예상 총 증분">
+              <CountUp value={curUplift} format={won} />
+            </Mini>
+            <Mini
+              label="예상 공헌이익"
+              sub={pred.expected_contribution_rate != null ? `이익률 ${pct(pred.expected_contribution_rate)}` : undefined}
+            >
+              <CountUp value={pred.expected_contribution} format={wonShort} />
+            </Mini>
+            <Mini label="예상 범위">{`${wonShort(pred.low)}~${wonShort(pred.high)}`}</Mini>
           </div>
           <p className="mt-3 rounded-xl bg-neutral-50 px-3 py-2 text-xs text-neutral-500">
             {pred.rationale}
@@ -204,7 +288,7 @@ export default function Simulator({ cases, options }: { cases: CaseFeature[]; op
         {/* 최고 포인트 미리보기 */}
         <div className="mt-4 grid gap-3 sm:grid-cols-2">
           <button
-            onClick={() => setDiscount(bestEffect.discount)}
+            onClick={() => setSpec({ discount: bestEffect.discount })}
             className="rounded-2xl bg-brand-50 p-4 text-left ring-1 ring-brand-100 transition hover:ring-brand-300"
           >
             <div className="text-xs font-semibold text-brand-600">최고 효과 (증분 최대)</div>
@@ -215,7 +299,7 @@ export default function Simulator({ cases, options }: { cases: CaseFeature[]; op
             <div className="mt-0.5 text-[11px] text-neutral-400">클릭하면 이 조건으로 설정</div>
           </button>
           <button
-            onClick={() => setDiscount(bestEfficiency.discount)}
+            onClick={() => setSpec({ discount: bestEfficiency.discount })}
             className="rounded-2xl bg-neutral-900 p-4 text-left transition hover:bg-neutral-800"
           >
             <div className="text-xs font-semibold text-brand-400">최고 효율 (공헌이익 최대)</div>
@@ -314,29 +398,70 @@ export default function Simulator({ cases, options }: { cases: CaseFeature[]; op
         </ResponsiveContainer>
       </section>
 
-      {/* 시나리오 비교 */}
-      {pinned.length > 0 && (
+      {/* 시나리오 비교 — 기준(현재 조건) 대비 차이 */}
+      {scenarioRows.length > 0 && (
         <section className="mt-3 rounded-2xl p-6 card-soft sm:mt-4">
           <div className="mb-3 flex items-center justify-between">
-            <h2 className="text-sm font-semibold text-neutral-700">시나리오 비교</h2>
-            <button onClick={() => setPinned([])} className="text-xs text-neutral-400 hover:text-brand-600">
-              초기화
+            <h2 className="text-sm font-semibold text-neutral-700">
+              시나리오 비교 <span className="font-normal text-neutral-400">· 기준 = 현재 조건</span>
+            </h2>
+            <button onClick={clearScenarios} className="text-xs text-neutral-400 hover:text-brand-600">
+              전체 삭제
             </button>
           </div>
-          <div className="grid gap-3 sm:grid-cols-3">
-            {pinned.map((s, i) => (
-              <div key={i} className="rounded-2xl bg-neutral-50 p-4">
-                <div className="truncate text-xs font-medium text-neutral-500">{s.label}</div>
-                <div className="mt-1 text-lg font-bold text-brand-600">
-                  {s.ratio != null ? `${s.ratio.toFixed(1)}배` : "—"}
-                </div>
-                <div className="mt-2 space-y-0.5 text-xs text-neutral-500">
-                  <div className="flex justify-between"><span>증분</span><span className="tabular-nums text-neutral-700">{wonShort(s.uplift)}</span></div>
-                  <div className="flex justify-between"><span>공헌이익</span><span className="tabular-nums text-neutral-700">{wonShort(s.contribution)}</span></div>
-                </div>
-              </div>
-            ))}
+
+          {/* 기준 요약 */}
+          <div className="mb-3 rounded-2xl bg-brand-50 p-4">
+            <div className="text-xs font-semibold text-brand-600">기준 · {scenarioLabel(liveSpec)}</div>
+            <div className="mt-1 flex flex-wrap gap-x-5 gap-y-1 text-xs text-neutral-600">
+              <span>배수 <strong className="text-neutral-900">{pred.lift_ratio != null ? `${pred.lift_ratio.toFixed(1)}배` : "—"}</strong></span>
+              <span>증분 <strong className="text-neutral-900">{wonShort(pred.expected_uplift)}</strong></span>
+              <span>공헌이익 <strong className="text-neutral-900">{wonShort(pred.expected_contribution)}</strong></span>
+            </div>
           </div>
+
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {scenarioRows.map(({ s, p }) => {
+              const dUplift = diffPct(pred.expected_uplift, p.expected_uplift);
+              const dContrib = diffPct(pred.expected_contribution, p.expected_contribution);
+              return (
+                <div key={s.id} className="rounded-2xl bg-neutral-50 p-4">
+                  <div className="flex items-start justify-between gap-1">
+                    <button
+                      onClick={() => renameScenario(s.id)}
+                      className="min-w-0 flex-1 truncate text-left text-xs font-medium text-neutral-600 hover:text-brand-600"
+                      title="클릭하면 이름 변경"
+                    >
+                      {s.name}
+                    </button>
+                    <button
+                      onClick={() => removeScenario(s.id)}
+                      className="shrink-0 text-neutral-300 hover:text-red-500"
+                      aria-label="시나리오 삭제"
+                    >
+                      ✕
+                    </button>
+                  </div>
+                  <div className="mt-1 text-lg font-bold text-brand-600">
+                    {p.lift_ratio != null ? `${p.lift_ratio.toFixed(1)}배` : "—"}
+                  </div>
+                  <div className="mt-2 space-y-1 text-xs text-neutral-500">
+                    <CompareRow label="증분" value={wonShort(p.expected_uplift)} delta={dUplift} />
+                    <CompareRow label="공헌이익" value={wonShort(p.expected_contribution)} delta={dContrib} />
+                  </div>
+                  <button
+                    onClick={() => applyScenario(s)}
+                    className="mt-3 w-full rounded-full border border-neutral-200 py-1.5 text-[11px] font-medium text-neutral-600 transition hover:bg-white"
+                  >
+                    이 조건 불러오기
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+          <InlineAlert tone="info" className="mt-3">
+            저장한 시나리오와 현재 조건은 URL에 담깁니다 — 링크를 복사하면 그대로 공유돼요.
+          </InlineAlert>
         </section>
       )}
 
@@ -410,7 +535,7 @@ function Bar({ label, value, max, tone }: { label: string; value: number; max: n
       <span className={`w-24 shrink-0 text-xs ${tone === "brand" ? "text-brand-600" : "text-neutral-400"}`}>{label}</span>
       <div className={`h-4 flex-1 overflow-hidden rounded-full ${tone === "brand" ? "bg-brand-50" : "bg-neutral-100"}`}>
         <div
-          className={`h-full rounded-full ${tone === "brand" ? "bg-brand-500" : "bg-neutral-300"}`}
+          className={`h-full rounded-full [transition:width_var(--duration-slow)_var(--ease-standard)] ${tone === "brand" ? "bg-brand-500" : "bg-neutral-300"}`}
           style={{ width: `${Math.min(100, (value / max) * 100)}%` }}
         />
       </div>
@@ -419,12 +544,29 @@ function Bar({ label, value, max, tone }: { label: string; value: number; max: n
   );
 }
 
-function Mini({ label, value, sub }: { label: string; value: string; sub?: string }) {
+function Mini({ label, sub, children }: { label: string; sub?: string; children: React.ReactNode }) {
   return (
     <div className="rounded-2xl bg-neutral-50 p-3">
       <div className="text-[11px] text-neutral-400">{label}</div>
-      <div className="mt-0.5 text-sm font-bold tabular-nums text-neutral-900">{value}</div>
+      <div className="mt-0.5 text-sm font-bold tabular-nums text-neutral-900">{children}</div>
       {sub && <div className="text-[11px] text-neutral-400">{sub}</div>}
+    </div>
+  );
+}
+
+function CompareRow({ label, value, delta }: { label: string; value: string; delta: number | null }) {
+  const tone =
+    delta == null ? "text-neutral-400" : delta > 0.001 ? "text-emerald-600" : delta < -0.001 ? "text-red-500" : "text-neutral-400";
+  const arrow = delta == null ? "" : delta > 0.001 ? "▲" : delta < -0.001 ? "▼" : "–";
+  return (
+    <div className="flex items-center justify-between">
+      <span>{label}</span>
+      <span className="flex items-center gap-1.5">
+        <span className="tabular-nums text-neutral-700">{value}</span>
+        <span className={`tabular-nums ${tone}`}>
+          {arrow} {delta == null ? "" : `${delta > 0 ? "+" : ""}${Math.round(delta * 100)}%`}
+        </span>
+      </span>
     </div>
   );
 }

--- a/promo-analytics/app/(dash)/prescribe/Recommend.tsx
+++ b/promo-analytics/app/(dash)/prescribe/Recommend.tsx
@@ -4,6 +4,9 @@ import { useState } from "react";
 import Link from "next/link";
 import { won, wonShort, pct, num } from "@/lib/format";
 import type { GoalRec, Goal } from "@/lib/predict";
+import { explainRecommendation, type Reason } from "@/lib/explain";
+import { specToSeedQuery } from "@/lib/scenario";
+import { InlineAlert } from "@/components/ui";
 
 type Options = { benefitTypes: string[]; seasonalities: string[]; purposes: string[] };
 
@@ -296,10 +299,110 @@ export default function Recommend({ options }: { options: Options }) {
                       <div className="text-2xl font-bold text-brand-600">{r.score}</div>
                     </div>
                   </div>
+
+                  {/* 설명가능성 — 왜 이 추천인가? + 플랜으로 이어가기 (PR7) */}
+                  <ExplainBlock
+                    rec={r}
+                    rank={i}
+                    allRecs={recs}
+                    seedHref={`/library?${specToSeedQuery({
+                      promoType: r.promo_type,
+                      season,
+                      purpose: "",
+                      discount: r.discount_rate != null ? Math.round(r.discount_rate * 100) : 0,
+                      days: Number(days) || 4,
+                    })}`}
+                  />
                 </div>
               ))}
             </div>
             </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ReasonList({ items, empty }: { items: Reason[]; empty: string }) {
+  if (items.length === 0)
+    return <p className="text-xs text-neutral-400">{empty}</p>;
+  return (
+    <ul className="space-y-1">
+      {items.map((r, i) => (
+        <li key={i} className="flex items-start gap-1.5 text-xs leading-snug">
+          <span
+            className={
+              r.tone === "good"
+                ? "text-emerald-500"
+                : r.tone === "warn"
+                  ? "text-amber-500"
+                  : "text-neutral-400"
+            }
+            aria-hidden
+          >
+            {r.tone === "good" ? "✓" : r.tone === "warn" ? "⚠" : "•"}
+          </span>
+          <span className="text-neutral-600">{r.text}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ExplainBlock({
+  rec,
+  rank,
+  allRecs,
+  seedHref,
+}: {
+  rec: GoalRec;
+  rank: number;
+  allRecs: GoalRec[];
+  seedHref: string;
+}) {
+  const [open, setOpen] = useState(rank === 0); // 1순위는 펼친 채로
+  const ex = explainRecommendation(rec, rank, allRecs);
+  return (
+    <div className="mt-4 border-t border-neutral-100 pt-3">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="flex w-full items-center justify-between gap-2 text-left"
+      >
+        <span className="text-xs font-semibold text-neutral-700">왜 이 추천인가?</span>
+        <span className="text-xs text-neutral-400">{open ? "접기 ▲" : "근거 보기 ▼"}</span>
+      </button>
+
+      {open && (
+        <div className="mt-2 space-y-3">
+          <p className="rounded-xl bg-neutral-50 px-3 py-2 text-xs leading-snug text-neutral-700">
+            {ex.headline}
+          </p>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <div className="mb-1 text-[11px] font-semibold text-neutral-500">추천 근거</div>
+              <ReasonList items={ex.reasons} empty="근거 정보가 부족합니다." />
+            </div>
+            <div>
+              <div className="mb-1 text-[11px] font-semibold text-neutral-500">주의·리스크</div>
+              <ReasonList items={ex.risks} empty="특별한 리스크 신호는 없습니다." />
+            </div>
+          </div>
+          {rec.discount_rate != null && (
+            <InlineAlert
+              tone="brand"
+              action={
+                <Link
+                  href={seedHref}
+                  className="rounded-full bg-brand-500 px-3 py-1 text-[11px] font-semibold text-white hover:bg-brand-600"
+                >
+                  플랜 만들기 →
+                </Link>
+              }
+            >
+              이 조건({rec.promo_type} · {pct(rec.discount_rate, 0)} 할인)을 적용할 캠페인을 골라 플랜을 시작하세요.
+            </InlineAlert>
           )}
         </div>
       )}

--- a/promo-analytics/components/ui/CountUp.tsx
+++ b/promo-analytics/components/ui/CountUp.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+// PR7: 숫자 상태 전환 모션 — 이전 값에서 현재 값으로 easeOutCubic 카운트업.
+// prefers-reduced-motion이면 즉시 표시.
+export function CountUp({
+  value,
+  format,
+  className,
+  duration = 600,
+}: {
+  value: number;
+  format: (n: number) => string;
+  className?: string;
+  duration?: number;
+}) {
+  const [display, setDisplay] = useState(value);
+  const fromRef = useRef(value);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const reduce =
+      typeof window !== "undefined" &&
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+    const from = fromRef.current;
+    const to = value;
+    if (reduce || from === to || !Number.isFinite(from) || !Number.isFinite(to)) {
+      setDisplay(to);
+      fromRef.current = to;
+      return;
+    }
+    const start = performance.now();
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - start) / duration);
+      const eased = 1 - Math.pow(1 - t, 3); // easeOutCubic
+      setDisplay(from + (to - from) * eased);
+      if (t < 1) rafRef.current = requestAnimationFrame(tick);
+      else fromRef.current = to;
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, [value, duration]);
+
+  return <span className={className}>{format(display)}</span>;
+}

--- a/promo-analytics/components/ui/index.ts
+++ b/promo-analytics/components/ui/index.ts
@@ -18,3 +18,4 @@ export { SegmentedControl, type SegmentOption } from "./SegmentedControl";
 export { InlineAlert } from "./InlineAlert";
 export { Skeleton } from "./Skeleton";
 export { EmptyState } from "./EmptyState";
+export { CountUp } from "./CountUp";

--- a/promo-analytics/lib/__tests__/explain.test.ts
+++ b/promo-analytics/lib/__tests__/explain.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { explainRecommendation } from "@/lib/explain";
+import type { GoalRec } from "@/lib/predict";
+
+function rec(over: Partial<GoalRec> = {}): GoalRec {
+  return {
+    promo_type: "할인",
+    discount_rate: 0.4,
+    metric_per_day: 100,
+    predicted_metric: 400,
+    predicted_uplift: 4_000_000,
+    predicted_contribution: 1_200_000,
+    contribution_rate: 0.3,
+    score: 82,
+    confidence: "높음",
+    reliability: 0.8,
+    sample: 5,
+    meets_target: true,
+    examples: [],
+    per_goal: [
+      { goal: "revenue", metric_per_day: 100, predicted_metric: 400, target: 300, meets_target: true },
+    ],
+    ...over,
+  };
+}
+
+describe("explainRecommendation", () => {
+  it("강한 1순위 추천 — 근거 다수, 리스크 없음", () => {
+    const r = rec();
+    const ex = explainRecommendation(r, 0, [r]);
+    expect(ex.headline).toContain("할인");
+    expect(ex.reasons.some((x) => x.text.includes("종합 점수가 가장 높"))).toBe(true);
+    expect(ex.reasons.some((x) => x.text.includes("충족"))).toBe(true);
+    expect(ex.reasons.some((x) => x.text.includes("공헌이익률"))).toBe(true);
+    expect(ex.reasons.some((x) => x.text.includes("달성 신뢰도"))).toBe(true);
+    expect(ex.risks).toHaveLength(0);
+    expect(ex.fulfillment[0].meets).toBe(true);
+  });
+
+  it("약한 추천 — 표본·신뢰도·미달 리스크 노출", () => {
+    const r = rec({
+      sample: 1,
+      reliability: 0.3,
+      confidence: "낮음",
+      discount_rate: 0.6,
+      per_goal: [
+        { goal: "stock", metric_per_day: 50, predicted_metric: 200, target: 1000, meets_target: false },
+      ],
+    });
+    const ex = explainRecommendation(r, 2, [rec(), rec(), r]);
+    expect(ex.risks.some((x) => x.text.includes("근거 사례"))).toBe(true);
+    expect(ex.risks.some((x) => x.text.includes("계획 달성률"))).toBe(true);
+    expect(ex.risks.some((x) => x.text.includes("신뢰도"))).toBe(true);
+    expect(ex.risks.some((x) => x.text.includes("미달"))).toBe(true);
+    expect(ex.risks.some((x) => x.text.includes("마진"))).toBe(true);
+    expect(ex.headline).toContain("미달");
+    expect(ex.fulfillment[0].meets).toBe(false);
+  });
+
+  it("per_goal 없으면 revenue로 fallback", () => {
+    const r = rec({ per_goal: undefined, meets_target: true });
+    const ex = explainRecommendation(r, 0, [r]);
+    expect(ex.fulfillment[0].goal).toBe("revenue");
+  });
+});

--- a/promo-analytics/lib/__tests__/scenario.test.ts
+++ b/promo-analytics/lib/__tests__/scenario.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import {
+  scenarioLabel,
+  encodeScenarios,
+  decodeScenarios,
+  diffPct,
+  specToSeedQuery,
+  parseSeedQuery,
+  type SavedScenario,
+} from "@/lib/scenario";
+
+describe("scenario url encode/decode", () => {
+  const list: SavedScenario[] = [
+    { id: "a", name: "기본", promoType: "할인", season: "여름", purpose: "재고소진", discount: 40, days: 4 },
+    { id: "b", name: "공격적 시나리오", promoType: "쿠폰", season: "", purpose: "", discount: 60, days: 7 },
+  ];
+
+  it("라운드트립 — 값 복원(id/name 제외 동일)", () => {
+    const restored = decodeScenarios(encodeScenarios(list));
+    expect(restored).toHaveLength(2);
+    expect(restored[0]).toMatchObject({
+      name: "기본", promoType: "할인", season: "여름", purpose: "재고소진", discount: 40, days: 4,
+    });
+    expect(restored[1]).toMatchObject({ name: "공격적 시나리오", promoType: "쿠폰", discount: 60, days: 7 });
+  });
+
+  it("특수문자(~;)가 라벨에 있어도 안전", () => {
+    const tricky: SavedScenario[] = [
+      { id: "x", name: "A~B;C", promoType: "할인", season: "", purpose: "", discount: 10, days: 2 },
+    ];
+    expect(decodeScenarios(encodeScenarios(tricky))[0].name).toBe("A~B;C");
+  });
+
+  it("빈/널 입력은 빈 배열", () => {
+    expect(decodeScenarios("")).toEqual([]);
+    expect(decodeScenarios(null)).toEqual([]);
+  });
+
+  it("범위 밖 숫자는 안전 기본값으로 보정", () => {
+    const r = decodeScenarios("이상치~할인~~~999~99");
+    expect(r[0].discount).toBe(70); // 0~70 클램프
+    expect(r[0].days).toBe(31); // 1~31 클램프
+  });
+});
+
+describe("scenarioLabel", () => {
+  it("조건 요약 문자열", () => {
+    expect(scenarioLabel({ promoType: "할인", season: "여름", purpose: "세일즈", discount: 40, days: 4 }))
+      .toBe("할인 40%·4일·여름·세일즈");
+    expect(scenarioLabel({ promoType: "", season: "", purpose: "", discount: 0, days: 1 }))
+      .toBe("전체 0%·1일");
+  });
+});
+
+describe("diffPct", () => {
+  it("상대 차이", () => {
+    expect(diffPct(100, 120)).toBeCloseTo(0.2);
+    expect(diffPct(100, 80)).toBeCloseTo(-0.2);
+  });
+  it("기준 0/비유한이면 null", () => {
+    expect(diffPct(0, 10)).toBeNull();
+    expect(diffPct(NaN, 10)).toBeNull();
+  });
+});
+
+describe("plan seed query", () => {
+  it("specToSeedQuery → parseSeedQuery 라운드트립", () => {
+    const q = specToSeedQuery({ promoType: "할인", season: "여름", purpose: "재고소진", discount: 35, days: 5 });
+    const parsed = parseSeedQuery(q);
+    expect(parsed).toMatchObject({ active: true, promoType: "할인", season: "여름", purpose: "재고소진", discount: 35, days: 5 });
+  });
+  it("plan_seed 없으면 null", () => {
+    expect(parseSeedQuery("foo=bar")).toBeNull();
+  });
+});

--- a/promo-analytics/lib/explain.ts
+++ b/promo-analytics/lib/explain.ts
@@ -1,0 +1,155 @@
+// PR7: 추천 설명가능성 — "왜 이 추천인가?"에 답하는 근거·리스크·충족도.
+// 순수 헬퍼(테스트 대상). GoalRec와 숫자 포맷만 의존.
+
+import type { GoalRec, Goal } from "./predict";
+import { won, num, pct } from "./format";
+
+export type ReasonTone = "good" | "warn" | "info";
+export type Reason = { tone: ReasonTone; text: string };
+
+export type Explanation = {
+  headline: string; // 한 줄 요약(왜 이 추천인가)
+  reasons: Reason[]; // 추천 근거
+  risks: Reason[]; // 주의해야 할 리스크
+  fulfillment: { goal: Goal; label: string; ratio: number | null; meets: boolean }[];
+};
+
+const GOAL_LABEL: Record<Goal, string> = {
+  revenue: "세일즈",
+  stock: "재고소진",
+  branding: "브랜딩",
+};
+
+const GOAL_UNIT: Record<Goal, "won" | "qty" | "orders"> = {
+  revenue: "won",
+  stock: "qty",
+  branding: "orders",
+};
+
+function fmtMetric(goal: Goal, v: number): string {
+  const u = GOAL_UNIT[goal];
+  if (u === "won") return won(v);
+  if (u === "qty") return `${num(v)}개`;
+  return `${num(v)}건`;
+}
+
+// 추천 1건에 대한 설명 생성.
+// rank: 정렬된 추천 목록에서의 0-based 순위. allRecs: 상대 비교(최고 점수 등)용.
+export function explainRecommendation(
+  rec: GoalRec,
+  rank: number,
+  allRecs: GoalRec[],
+): Explanation {
+  const reasons: Reason[] = [];
+  const risks: Reason[] = [];
+
+  // 충족도 (목표 대비) — per_goal 우선, 없으면 단일 revenue로 fallback
+  const perGoal = rec.per_goal ?? [
+    {
+      goal: "revenue" as Goal,
+      metric_per_day: rec.metric_per_day,
+      predicted_metric: rec.predicted_metric,
+      target: 0,
+      meets_target: rec.meets_target,
+    },
+  ];
+  const fulfillment = perGoal.map((pg) => ({
+    goal: pg.goal,
+    label: GOAL_LABEL[pg.goal],
+    ratio: pg.target > 0 ? pg.predicted_metric / pg.target : null,
+    meets: pg.meets_target,
+  }));
+
+  // ── 근거 ──
+  // 1) 순위/점수
+  if (rank === 0) {
+    reasons.push({
+      tone: "good",
+      text: `후보 ${allRecs.length}개 중 종합 점수가 가장 높습니다 (${rec.score}점).`,
+    });
+  } else {
+    reasons.push({
+      tone: "info",
+      text: `종합 점수 ${rec.score}점으로 ${rank + 1}순위 후보입니다.`,
+    });
+  }
+
+  // 2) 목표 충족
+  const unmet = fulfillment.filter((f) => f.ratio != null && !f.meets);
+  const met = fulfillment.filter((f) => f.ratio != null && f.meets);
+  if (met.length > 0 && unmet.length === 0) {
+    reasons.push({
+      tone: "good",
+      text:
+        met.length === 1
+          ? `목표 ‘${met[0].label}’를 충족할 것으로 예측됩니다 (${Math.round((met[0].ratio ?? 0) * 100)}%).`
+          : `선택한 ${met.length}개 목표를 모두 충족할 것으로 예측됩니다.`,
+    });
+  }
+
+  // 3) 수익성(공헌이익률)
+  if (rec.contribution_rate != null && rec.contribution_rate >= 0.2) {
+    reasons.push({
+      tone: "good",
+      text: `예상 공헌이익률이 ${pct(rec.contribution_rate, 0)}로 수익성이 좋은 구간입니다.`,
+    });
+  }
+
+  // 4) 달성 신뢰도(과거 계획 달성 패턴)
+  if (rec.reliability >= 0.66) {
+    reasons.push({
+      tone: "good",
+      text: `유사 캠페인의 계획 달성 신뢰도가 ${Math.round(rec.reliability * 100)}%로 안정적입니다.`,
+    });
+  }
+
+  // 5) 근거 표본
+  reasons.push({
+    tone: rec.sample >= 3 ? "info" : "warn",
+    text: `유사 사례 ${rec.sample}건을 근거로 예측했습니다.`,
+  });
+
+  // ── 리스크 ──
+  if (rec.sample < 3) {
+    risks.push({
+      tone: "warn",
+      text: `근거 사례가 ${rec.sample}건으로 적어 예측 변동성이 큽니다. 보수적으로 해석하세요.`,
+    });
+  }
+  if (rec.reliability < 0.5) {
+    risks.push({
+      tone: "warn",
+      text: `유사 캠페인의 계획 달성률이 낮아(${Math.round(rec.reliability * 100)}%) 실제 결과가 어긋날 수 있습니다.`,
+    });
+  }
+  if (rec.confidence === "낮음") {
+    risks.push({ tone: "warn", text: "예측 신뢰도가 ‘낮음’입니다. 참고 지표로만 활용하세요." });
+  }
+  for (const f of unmet) {
+    risks.push({
+      tone: "warn",
+      text: `목표 ‘${f.label}’는 예측 ${Math.round((f.ratio ?? 0) * 100)}% 수준으로 미달이 예상됩니다.`,
+    });
+  }
+  if (rec.discount_rate != null && rec.discount_rate >= 0.5) {
+    risks.push({
+      tone: "warn",
+      text: `할인 깊이가 ${pct(rec.discount_rate, 0)}로 커 마진 훼손 위험이 있습니다.`,
+    });
+  }
+
+  // ── 헤드라인 ──
+  const primaryGoal = perGoal[0]?.goal ?? "revenue";
+  const cond =
+    `${rec.promo_type}` + (rec.discount_rate != null ? ` ${pct(rec.discount_rate, 0)} 할인` : "");
+  let headline: string;
+  if (rank === 0 && unmet.length === 0) {
+    headline = `${cond} — 목표를 충족하면서 공헌이익·달성 신뢰도가 가장 좋은 후보입니다.`;
+  } else if (unmet.length > 0) {
+    headline = `${cond} — 점수는 ${rec.score}점이지만 일부 목표는 미달이 예상됩니다.`;
+  } else {
+    headline = `${cond} — 예상 ${GOAL_LABEL[primaryGoal]} ${fmtMetric(primaryGoal, rec.predicted_metric)} 수준의 후보입니다.`;
+  }
+
+  return { headline, reasons, risks, fulfillment };
+}

--- a/promo-analytics/lib/scenario.ts
+++ b/promo-analytics/lib/scenario.ts
@@ -1,0 +1,101 @@
+// PR7: 시뮬레이터 시나리오 — 공유 가능한 URL 인코딩 + 기준 대비 차이.
+// 순수 헬퍼(테스트 대상). React/DOM 의존 없음.
+
+export type SimSpec = {
+  promoType: string;
+  season: string;
+  purpose: string;
+  discount: number; // %
+  days: number;
+};
+
+export type SavedScenario = SimSpec & { id: string; name: string };
+
+export type ScenarioMetrics = {
+  ratio: number | null; // 평소 대비 배수
+  uplift: number; // 예상 총 증분
+  contribution: number; // 예상 공헌이익
+};
+
+const clampNum = (v: number, lo: number, hi: number, dflt: number): number =>
+  Number.isFinite(v) ? Math.min(hi, Math.max(lo, v)) : dflt;
+
+// 사람이 읽는 시나리오 라벨 (조건 요약)
+export function scenarioLabel(s: SimSpec): string {
+  return (
+    `${s.promoType || "전체"} ${s.discount}%·${s.days}일` +
+    (s.season ? `·${s.season}` : "") +
+    (s.purpose ? `·${s.purpose}` : "")
+  );
+}
+
+// 시나리오 목록 → URL 토큰 (각 필드 encodeURIComponent, ~ 구분, ; 연결)
+export function encodeScenarios(list: SavedScenario[]): string {
+  return list
+    .map((s) =>
+      [s.name, s.promoType, s.season, s.purpose, String(s.discount), String(s.days)]
+        // encodeURIComponent는 ~를 그대로 두므로 구분자 충돌 방지 위해 추가 이스케이프
+        .map((x) => encodeURIComponent(x ?? "").replace(/~/g, "%7E"))
+        .join("~"),
+    )
+    .join(";");
+}
+
+// URL 토큰 → 시나리오 목록 (잘못된 값은 안전 기본값으로 보정)
+export function decodeScenarios(raw: string | null | undefined): SavedScenario[] {
+  if (!raw) return [];
+  return raw
+    .split(";")
+    .filter(Boolean)
+    .map((chunk, i) => {
+      const parts = chunk.split("~").map((x) => {
+        try {
+          return decodeURIComponent(x ?? "");
+        } catch {
+          return "";
+        }
+      });
+      const [name, promoType, season, purpose, discount, days] = parts;
+      return {
+        id: `s${i}-${Date.now().toString(36)}`,
+        name: name || `시나리오 ${i + 1}`,
+        promoType: promoType || "",
+        season: season || "",
+        purpose: purpose || "",
+        discount: clampNum(Number(discount), 0, 70, 40),
+        days: clampNum(Number(days), 1, 31, 4),
+      };
+    });
+}
+
+// 기준값 대비 상대 차이(비율). 기준이 0/비유한이면 null.
+export function diffPct(base: number, val: number): number | null {
+  if (!Number.isFinite(base) || base === 0) return null;
+  return (val - base) / Math.abs(base);
+}
+
+// 시뮬레이터 조건 → 플랜 시드 쿼리스트링 (라이브러리로 이어가기용)
+export function specToSeedQuery(s: SimSpec): string {
+  const sp = new URLSearchParams();
+  sp.set("plan_seed", "1");
+  if (s.promoType) sp.set("promo", s.promoType);
+  if (s.season) sp.set("season", s.season);
+  if (s.purpose) sp.set("purpose", s.purpose);
+  sp.set("discount", String(s.discount));
+  sp.set("days", String(s.days));
+  return sp.toString();
+}
+
+// 플랜 시드 쿼리 파싱 (라이브러리 배너 표시용). plan_seed가 없으면 null.
+export function parseSeedQuery(search: string): (SimSpec & { active: boolean }) | null {
+  const sp = new URLSearchParams(search);
+  if (sp.get("plan_seed") !== "1") return null;
+  return {
+    active: true,
+    promoType: sp.get("promo") ?? "",
+    season: sp.get("season") ?? "",
+    purpose: sp.get("purpose") ?? "",
+    discount: clampNum(Number(sp.get("discount")), 0, 70, 40),
+    days: clampNum(Number(sp.get("days")), 1, 31, 4),
+  };
+}


### PR DESCRIPTION
## 개발지시서 §8 PR7 — 시뮬레이터·추천 설명가능성

PR1~6에 이어 마지막 단계. 완료 조건 두 가지를 충족합니다.

> 추천 결과에서 "왜 이 추천인가?"에 답할 수 있어야 함 · 시뮬레이터 결과를 실제 플랜 작업으로 이어갈 수 있어야 함

### 시뮬레이터 (`predict/Simulator.tsx`)
- **공유 가능한 URL**: 조건·시나리오를 URL에 보존 → 링크 복사로 동일 결과 재현
- **시나리오 관리**: 저장 / 이름 변경 / 삭제 / 불러오기 (최대 4개)
- **기준 대비 차이**: 현재 조건을 기준으로 각 시나리오의 증분·공헌이익 ±% 비교
- **모션**: 배수·증분·공헌이익 CountUp, 진행바 width transition — `prefers-reduced-motion` 존중
- **성능**: `useDeferredValue`로 슬라이더 드래그 중 곡선 재계산 지연(끊김 방지)
- **이어가기**: "이 조건으로 플랜 만들기" CTA → 라이브러리

### 추천 (`prescribe/Recommend.tsx`)
- **설명가능성**: `explainRecommendation`이 헤드라인 + 근거 + 리스크 + 목표 충족도 생성
  - 1순위는 펼친 채로, 나머지는 접힘
  - 리스크: 표본 부족 · 낮은 달성 신뢰도 · 낮은 예측 신뢰도 · 목표 미달 · 과도한 할인 깊이
- **이어가기**: 추천 조건을 적용할 캠페인 선택 CTA

### 라이브러리 (`library/LibraryTable.tsx`)
- 플랜 시드 쿼리 배너 — 넘어온 조건을 표시하고 적용할 캠페인 선택 유도

### 신규 순수 헬퍼 + 테스트
- `lib/scenario.ts` — 인코딩/디코딩/diff/시드쿼리 (9 tests)
- `lib/explain.ts` — 근거·리스크 생성 (3 tests)
- `components/ui/CountUp.tsx`

### 검증
- `tsc --noEmit` 0 · `vitest` 38/38 · `next build` 성공

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_