### PR TITLE
fix: self-비교 캠페인의 잘못된 "실적 연결 필요" 경고 제거

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/page.tsx
@@ -160,10 +160,13 @@ export default async function PromotionDetail({
   const unmatchedCount = diagnosticRows.filter(
     (r) => r.side !== "both" && !r.is_mapped && !r.is_subscription,
   ).length;
+  // self-비교(기본): 가이드·실적이 같은 코드로 올라와 실 매출이 이미 잡히면
+  // 명시적 짝짓기(actual_promotion_id)가 없어도 "실적 연결"은 충족된 것으로 본다.
+  const hasSelfActuals = (achSummary?.campaign_revenue_total ?? 0) > 0;
   const wfInput = {
     hasPlan: !!plan,
     planConfirmed: plan?.status === "confirmed",
-    hasActualLink: !!plan?.actual_promotion_id,
+    hasActualLink: !!plan?.actual_promotion_id || hasSelfActuals,
     hasActualData: !!achSummary?.has_confirmed_plan,
     unmatchedCount,
     expectedContribution:


### PR DESCRIPTION
## 문제

캠페인 상세에서 달성 카드(매출 160% / 수량 57% / 공헌이익 95%)가 **이미 실 매출로 채워져 있는데도**, 워크플로는 `실적 연결` 단계를 **X(blocked)**로 표시하고 "실적 연결 필요" 배너를 띄웠습니다.

## 원인

`실적 연결`은 "실적 데이터 존재" 여부가 아니라 **명시적 비교 짝짓기 링크**(`plan.actual_promotion_id`)만 봤습니다. 가이드·실적이 **같은 코드**로 올라오면 기본값인 **자기 캠페인 실적(self)**으로 달성률이 계산되지만 `actual_promotion_id`는 `null`이라, self-비교 캠페인은 항상 "미연결"로 오판정됐습니다.

## 수정

self-비교로 실 매출(`campaign_revenue_total > 0`)이 이미 잡혀 있으면 `실적 연결`을 충족으로 간주합니다.

```ts
const hasSelfActuals = (achSummary?.campaign_revenue_total ?? 0) > 0;
hasActualLink: !!plan?.actual_promotion_id || hasSelfActuals,
```

결과:
- 잘못된 "실적 연결 필요" 배너/blocked 제거
- 활성 단계가 실제 다음 할 일(**매칭 검증 — 미매칭 SKU 47개**)로 이동
- 명시적 짝짓기가 필요한 경우(가이드와 실적이 다른 코드)는 기존 동작 유지

## 검증
- `tsc --noEmit` 0 · workflow 테스트 8/8 · `next build` 성공

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_