### PR TITLE
fix(0044): rebuild_sale_options order_type NULL 가드 (DB 정합)

### DIFF
--- a/promo-analytics/supabase/migrations/0044_n13_rich_export.sql
+++ b/promo-analytics/supabase/migrations/0044_n13_rich_export.sql
@@ -84,8 +84,8 @@ begin
       coalesce(pr.base_name, ps.base_name) as bname,
       coalesce(ps.pack_size, 1) as pack,
       coalesce(pr.is_subscription, false) as prod_sub,
-      (coalesce(ps.option_info, '') ~ '(정기|구독)') as kw_sub,
-      (ps.order_type = 'subscription') as ord_sub,
+      coalesce(ps.option_info, '') ~ '(정기|구독)' as kw_sub,
+      coalesce(ps.order_type = 'subscription', false) as ord_sub,  -- NULL 가드(order_type null)
       (regexp_match(coalesce(ps.option_info, ''), '([0-9]+)\s*개월'))[1]::int as term,
       ps.option_info, ps.revenue, ps.quantity, ps.cost, ps.fee, ps.order_count
     from promo.promotion_sales ps
@@ -116,7 +116,7 @@ begin
     (promotion_id, option_code, label, label_raw, match_signature, pack_size, term_months,
      is_subscription, sub_source, revenue, quantity, cost, fee, order_count)
   select p_promotion_id, g.code, g.label, g.label_raw, m.sig, g.pack, g.term,
-    (g.prod_sub or g.kw_sub or g.ord_sub),
+    coalesce(g.prod_sub or g.kw_sub or g.ord_sub, false),
     case when g.ord_sub then 'export' when g.prod_sub then 'product'
          when g.kw_sub then 'derived' else null end,
     g.rev, g.qty, g.cost, g.fee, g.oc
@@ -221,3 +221,12 @@ $$;
 
 grant execute on all functions in schema promo to authenticated;
 notify pgrst, 'reload schema';
+
+-- rebuild 로직이 0042 대비 바뀌었으니(옵션코드 묶음·주문유형 신호) 전 캠페인 재구성
+do $$
+declare r record;
+begin
+  for r in select id from promo.promotions loop
+    perform promo.rebuild_sale_options(r.id);
+  end loop;
+end $$;


### PR DESCRIPTION
## 무엇 / 왜

머지된 `0044`를 prod에 적용하던 중 `rebuild_sale_options`가 실패했다:
`order_type`이 NULL인 행에서 `(order_type = 'subscription')`가 NULL → `is_subscription`이 NULL이 되어 NOT NULL 위반.

## 고침
- `coalesce(ps.order_type = 'subscription', false)` + insert 값 `coalesce(... , false)`로 가드.
- 0042 대비 rebuild 로직이 바뀌었으므로(옵션코드 묶음·주문유형 신호) **전 캠페인 재구성** DO 블록 추가.

> 이전 PR #102는 base 브랜치가 squash 머지돼 충돌이 나서 닫고, main 기준 새 브랜치로 다시 올림.

## 상태
- **prod DB(`mlbtnnchbpctgjjawkue`)에는 수정본으로 이미 적용 완료** — `0042/0043/0044` 모두 반영. 이 PR은 리포 파일을 적용본과 일치시키는 것.
- 검증: 실적옵션 2,470개·매출행 5,604/5,604 연결·구독옵션 19개(양성신호 정정), 옵션 공헌 분해 정상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_