### PR TITLE
리치 export 매칭 정확도 — 기초상품명 우선 + '일반/정기 배송' 인식

### DIFF
--- a/promo-analytics/lib/__tests__/parse.test.ts
+++ b/promo-analytics/lib/__tests__/parse.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import * as XLSX from "xlsx";
+import { parsePromotionSheet } from "../parse";
+
+/** AOA → xlsx ArrayBuffer (parsePromotionSheet 입력 형태) */
+function sheetBuf(aoa: unknown[][]): ArrayBuffer {
+  const ws = XLSX.utils.aoa_to_sheet(aoa);
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, "채널별 매출");
+  const out = XLSX.write(wb, { type: "array", bookType: "xlsx" });
+  return (out instanceof Uint8Array ? out.buffer : out) as ArrayBuffer;
+}
+
+// 닥터펠리스 '채널별 매출' 리치 export 헤더 (상품명 + 일반/정기 배송 + 기초 상품명 동시 존재)
+const HEADER = [
+  "일자 (누적)",
+  "상품명",
+  "일반/정기 배송",
+  "옵션정보",
+  "기초 상품명",
+  "결제금액 (환불/취소 제외)",
+  "결제 건수 (클레임 제외)",
+  "수수료 (환불/취소 제외)",
+  "원가 (환불/취소 제외)",
+];
+
+describe("parsePromotionSheet — 리치 채널별 매출 export", () => {
+  const buf = sheetBuf([
+    HEADER,
+    [
+      "2026-01-01 ~ 2026-06-17",
+      "[정기구독] 모래 4.3kg/8.3kg", // 마케팅 상품명 (SKU 없음)
+      "정기",
+      "상품선택=마스터, 중량/수량=8.3kg/2개",
+      "펠리스샌드 마스터 8.3kg (대용량)", // 기초상품명 (정규화명)
+      "88029979",
+      "1817",
+      "3388871",
+      "33832888",
+    ],
+    [
+      "2026-01-01 ~ 2026-06-17",
+      "퓨저나이트 슈퍼볼 8.3kg",
+      "일반",
+      "상품선택=🔥BEST DEAL🔥[56%⬇️] 퓨저나이트 슈퍼볼 8.3kg 4개",
+      "퓨저나이트 슈퍼볼 8.3kg (대용량)",
+      "57055970",
+      "707",
+      "2187327",
+      "27485600",
+    ],
+  ]);
+  const parsed = parsePromotionSheet(buf);
+
+  it("기초상품명을 base_name으로 사용한다 (마케팅 상품명이 아님)", () => {
+    expect(parsed.rows[0].base_name).toBe("펠리스샌드 마스터 8.3kg (대용량)");
+    expect(parsed.rows[0].base_name).not.toContain("정기구독");
+  });
+
+  it("'일반/정기 배송' 컬럼을 order_type으로 인식한다", () => {
+    expect(parsed.rows[0].order_type).toBe("subscription");
+    expect(parsed.rows[1].order_type).toBe("onetime");
+  });
+
+  it("누적 기간(시작~종료)을 파싱한다", () => {
+    expect(parsed.start_date).toBe("2026-01-01");
+    expect(parsed.end_date).toBe("2026-06-17");
+  });
+
+  it("금액·원가를 읽는다", () => {
+    expect(parsed.rows[0].revenue).toBe(88029979);
+    expect(parsed.rows[1].cost).toBe(27485600);
+  });
+});

--- a/promo-analytics/lib/parse.ts
+++ b/promo-analytics/lib/parse.ts
@@ -100,6 +100,14 @@ function findHeaderRowAll(rows: unknown[][], keys: string[], maxScan = 20): numb
   return -1;
 }
 
+/** 상품명 컬럼 선택: 기초상품명(정규화명) 우선, 없으면 마케팅 상품명 폴백.
+   같은 시트에 '상품명'과 '기초 상품명'이 둘 다 있을 때 findCol이 먼저 나오는
+   '상품명'(예: "[정기구독] 모래 4.3kg/8.3kg")을 집어 SKU 매칭이 깨지던 문제 방지. */
+function preferBaseName(header: unknown[]): number {
+  const base = findCol(header, ["기초상품명"]);
+  return base >= 0 ? base : findCol(header, ["상품명"]);
+}
+
 /** 행에 데이터가 한 칸이라도 있는지 (빈 행을 skip 카운트에서 제외) */
 function rowHasData(r: unknown[]): boolean {
   return r.some((c) => String(c ?? "").trim() !== "");
@@ -147,7 +155,7 @@ export function parseDailySales(buf: ArrayBuffer): DailyRow[] {
     );
   const header = rows[h];
   const cDate = findCol(header, ["일자"]);
-  const cName = findCol(header, ["기초상품명", "상품명"]);
+  const cName = preferBaseName(header);
   const cOpt = findCol(header, ["옵션정보", "옵션"]);
   const cRev = findCol(header, ["결제금액"]);
   const cQty = findCol(header, ["판매수량", "수량"]);
@@ -212,7 +220,9 @@ export function parsePromotionSheet(buf: ArrayBuffer): ParsedPromotion {
     );
   const header = rows[h];
   const cPeriod = findCol(header, ["일자"]);
-  const cName = findCol(header, ["기초상품명", "상품명"]);
+  // 기초상품명(플랫폼 정규화명)을 최우선 — 마케팅 '상품명'([정기구독]·[4+4]…)이 함께 와도
+  // SKU가 빠진 마케팅명 대신 깨끗한 기초상품명으로 매칭(정확도↑). 없으면 상품명 폴백.
+  const cName = preferBaseName(header);
   const cOpt = findCol(header, ["옵션정보", "옵션"]);
   const cRev = findCol(header, ["결제금액"]);
   const cCnt = findCol(header, ["결제건수", "건수"]);
@@ -221,7 +231,10 @@ export function parsePromotionSheet(buf: ArrayBuffer): ParsedPromotion {
   const cCost = findCol(header, ["원가"]);
   const cQty = findCol(header, ["판매수량", "수량"]);
   // N13 P2: 리치 export 선택 컬럼 — 없으면 -1 → null로 채움(하위호환)
-  const cOrderType = findCol(header, ["주문유형", "주문형태", "정기여부", "구독여부"]);
+  // '일반/정기 배송'(닥터펠리스 채널별 매출 export 헤더)까지 인식 → 구독 정확 분류.
+  const cOrderType = findCol(header, [
+    "주문유형", "주문형태", "정기여부", "구독여부", "일반/정기 배송", "일반/정기",
+  ]);
   const cOptCode = findCol(header, ["옵션코드", "옵션번호", "옵션id"]);
   const cComp = findCol(header, ["구성", "구성정보", "세트구성"]);
 


### PR DESCRIPTION
## 무엇 / 왜

첨부된 **채널별 매출 export**(`상품명` · `일반/정기 배송` · `옵션정보` · `기초 상품명` 동시 포함, 1/1~6/17 누적)를 분석한 결과, 캠페인 플랜↔성과 매칭 정확도를 떨어뜨리는 **파서 결함 2건**을 확인하고 수정.

### 분석 결과
| 구분 | 행 | 결제금액 |
|---|---|---|
| 정기 | 234 | **730,158,652원** |
| 일반 | 570 | 1,070,560,509원 |

- **63개 기초상품명 중 53개가 정기·일반 둘 다로 판매** → 구독은 품목이 아니라 **주문 단위(`일반/정기 배송` 컬럼)로만** 구분 가능함이 실데이터로 확정(품목 플래그 방식이 틀렸다는 증거).

### 고침
1. **기초상품명 우선** (`preferBaseName`): 같은 시트에 `상품명`(마케팅명 `"[정기구독] 모래 4.3kg/8.3kg"` — 실제 SKU 없음)과 `기초 상품명`(`"펠리스샌드 마스터 8.3kg"`)이 둘 다 있을 때 `findCol`이 먼저 나오는 `상품명`을 집어 SKU 시그니처 매칭이 깨지던 문제 → 기초상품명 최우선, 없으면 상품명 폴백.
2. **`일반/정기 배송` 컬럼 인식**: order_type 별칭에 추가 → 구독(이 export 기준 **7.3억** 규모)이 적재 시 누락되던 문제 해결. `정기`→subscription / `일반`→onetime.

### 영향 / 호환
- 둘 다 **하위호환** — `기초상품명`만 있던 기존 export 동작 불변.
- `lib/__tests__/parse.test.ts` 신규 4케이스, 전체 **42 테스트 통과**, `tsc` 통과.

> 참고: 첨부 파일 자체는 **전체 누적 집계**(캠페인별·일자별 분해 없음)라 플랜에 직접 연결되진 않습니다. 가치는 (a) 위 접근 검증 + (b) 이 파서 수정. **per-캠페인 export에 같은 컬럼을 넣어 업로드**하면 구독 분리·SKU 매칭이 정확해집니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_