### PR TITLE
재설계 증분 1(기초): 플랜 경제계산에 조건부 쿠폰

### DIFF
--- a/promo-analytics/lib/__tests__/plan.test.ts
+++ b/promo-analytics/lib/__tests__/plan.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { computeOptionTotals, couponDiscount, type PlanItemInput } from "../plan";
+
+// 옵션: SKU 4개 × 단가 12,500 = 세트가 50,000 / 원가 4×8,000 = 32,000
+const ITEMS: PlanItemInput[] = [
+  { sku_qty_per_option: 4, unit_sale_price: 12500, consumer_price: 20000, regular_price: 18000, cost: 8000 },
+];
+const MULT = 0.7;
+const QTY = 10;
+
+describe("couponDiscount — 조건부 쿠폰 (N원 이상 n% 최대 n원)", () => {
+  it("쿠폰 없으면 0", () => {
+    expect(couponDiscount(50000, null)).toBe(0);
+  });
+  it("기준 미달이면 0", () => {
+    expect(couponDiscount(50000, { min_order_amount: 60000, discount_rate: 0.1, max_discount_amount: 0 })).toBe(0);
+  });
+  it("기준 충족 + 캡 없음 → 정률 할인", () => {
+    expect(couponDiscount(50000, { min_order_amount: 40000, discount_rate: 0.1, max_discount_amount: 0 })).toBe(5000);
+  });
+  it("상한 캡 적용", () => {
+    expect(couponDiscount(50000, { min_order_amount: 40000, discount_rate: 0.1, max_discount_amount: 3000 })).toBe(3000);
+  });
+});
+
+describe("computeOptionTotals — 쿠폰 반영", () => {
+  it("쿠폰 없으면 기존 동작 불변 (회귀 가드)", () => {
+    const t = computeOptionTotals(ITEMS, MULT, QTY);
+    expect(t.set_price).toBe(50000);
+    expect(t.coupon_discount).toBe(0);
+    expect(t.net_price).toBe(50000);
+    expect(t.expected_revenue).toBe(500000);
+    // (50000×0.7 − 32000) × 10 = 30,000
+    expect(t.expected_contribution).toBeCloseTo(30000, 4);
+  });
+
+  it("기준 충족 쿠폰 → net_price·매출·공헌에 반영", () => {
+    const t = computeOptionTotals(ITEMS, MULT, QTY, {
+      min_order_amount: 40000, discount_rate: 0.1, max_discount_amount: 0,
+    });
+    expect(t.coupon_discount).toBe(5000);
+    expect(t.net_price).toBe(45000);
+    expect(t.expected_revenue).toBe(450000);
+    // (45000×0.7 − 32000) × 10 = −5,000
+    expect(t.expected_contribution).toBeCloseTo(-5000, 4);
+    // 최종 할인율은 쿠폰 포함: 1 − 45000/80000 = 0.4375
+    expect(t.discount_rate_consumer_net).toBeCloseTo(0.4375, 6);
+    // 기준 할인율(쿠폰 전)은 1 − 50000/80000 = 0.375 유지
+    expect(t.discount_rate_consumer).toBeCloseTo(0.375, 6);
+  });
+
+  it("상한 캡 쿠폰", () => {
+    const t = computeOptionTotals(ITEMS, MULT, QTY, {
+      min_order_amount: 40000, discount_rate: 0.1, max_discount_amount: 3000,
+    });
+    expect(t.net_price).toBe(47000);
+    expect(t.expected_revenue).toBe(470000);
+  });
+});

--- a/promo-analytics/lib/plan.ts
+++ b/promo-analytics/lib/plan.ts
@@ -35,23 +35,45 @@ export type PlanItemInput = {
   cost: number | null; // 원가(VAT+)
 };
 
+/** 플랜(캠페인) 단위 조건부 쿠폰: "N원 이상 주문 시 n% 할인(최대 n원)".
+   옵션 혜택가(set_price)가 기준액 이상일 때만 할인율 적용, 상한 캡. null=쿠폰 없음. */
+export type CouponSpec = {
+  min_order_amount: number; // N원 이상 (0 = 조건 없음)
+  discount_rate: number; // n% (0~1)
+  max_discount_amount: number; // 최대 n원 (0 = 캡 없음)
+} | null;
+
+/** 옵션 혜택가에 쿠폰을 적용한 할인액 (기준 미달=0, 상한 캡, 원 단위 반올림) */
+export function couponDiscount(setPrice: number, coupon: CouponSpec): number {
+  if (!coupon || !(coupon.discount_rate > 0)) return 0;
+  if (setPrice < (coupon.min_order_amount || 0)) return 0;
+  const raw = setPrice * coupon.discount_rate;
+  const capped =
+    coupon.max_discount_amount > 0 ? Math.min(raw, coupon.max_discount_amount) : raw;
+  return Math.round(capped);
+}
+
 export type OptionTotals = {
-  set_price: number; // Σ(sku_qty × unit_sale_price)
+  set_price: number; // Σ(sku_qty × unit_sale_price) — 쿠폰 전 세트 단가
+  coupon_discount: number; // 이 옵션에 적용된 쿠폰 할인액 (없으면 0)
+  net_price: number; // set_price − coupon_discount — 쿠폰 적용 후 실혜택가
   consumer_total: number; // Σ(consumer_price × sku_qty)
   regular_total: number; // Σ(regular_price × sku_qty)
   cost_total: number; // Σ(cost × sku_qty)
-  discount_rate_consumer: number | null;
+  discount_rate_consumer: number | null; // 쿠폰 전 기준 할인율
   discount_rate_regular: number | null;
-  expected_revenue: number;
-  expected_contribution: number;
+  discount_rate_consumer_net: number | null; // 쿠폰 포함 최종 할인율
+  expected_revenue: number; // net_price × qty
+  expected_contribution: number; // (net_price × mult − cost_total) × qty
   free_shipping: boolean;
 };
 
-/** 옵션 1개 롤업: 세트 단가·할인율 이중표기·예상 매출/공헌 */
+/** 옵션 1개 롤업: 세트 단가·할인율 이중표기·예상 매출/공헌. coupon=null이면 기존과 동일. */
 export function computeOptionTotals(
   items: PlanItemInput[],
   mult: number,
   qty: number,
+  coupon: CouponSpec = null,
 ): OptionTotals {
   let set_price = 0;
   let consumer_total = 0;
@@ -65,17 +87,23 @@ export function computeOptionTotals(
     cost_total += q * (it.cost || 0);
   }
   const expQty = qty || 0;
+  const coupon_discount = couponDiscount(set_price, coupon);
+  const net_price = set_price - coupon_discount;
   return {
     set_price,
+    coupon_discount,
+    net_price,
     consumer_total,
     regular_total,
     cost_total,
     discount_rate_consumer: consumer_total > 0 ? 1 - set_price / consumer_total : null,
     discount_rate_regular: regular_total > 0 ? 1 - set_price / regular_total : null,
-    expected_revenue: set_price * expQty,
+    discount_rate_consumer_net:
+      consumer_total > 0 ? 1 - net_price / consumer_total : null,
+    expected_revenue: net_price * expQty,
     // 물류비 12%는 mult에 일괄 반영 — 무료배송 여부와 무관하게 고정
-    expected_contribution: (set_price * mult - cost_total) * expQty,
-    free_shipping: set_price >= FREE_SHIP_THRESHOLD,
+    expected_contribution: (net_price * mult - cost_total) * expQty,
+    free_shipping: net_price >= FREE_SHIP_THRESHOLD,
   };
 }
 


### PR DESCRIPTION
## 재설계 증분 1 — 기초: 플랜 경제계산에 조건부 쿠폰

플랜↔성과 워크플로 재설계의 **첫 기초 단계**. 순수 계산 계층만 변경(스키마·UI·SQL 무변, 회귀 0).

### 쿠폰 모델 (사용자 확정)
"**N원 이상 주문 시 n% 할인(최대 n원)**" — 플랜(캠페인) 단위 조건부 쿠폰. 옵션 혜택가가 기준액 이상일 때만 정률 할인 + 상한 캡.

- `couponDiscount(setPrice, coupon)`: 기준 미달=0, 정률, 상한 캡, 원 단위 반올림
- `computeOptionTotals(items, mult, qty, coupon=null)`: `net_price`(쿠폰 후 실혜택가)·`coupon_discount`·`discount_rate_consumer_net` 추가. 매출·공헌이익은 `net_price` 기준.
- **`coupon=null`이면 결과 불변** → 기존 동작·`confirm_plan()` SQL 일치 유지(회귀 가드 테스트 포함).

### 검증
`plan.test.ts` 7케이스 신규, 전체 **49 테스트 통과**, `tsc` 통과.

> 전체 재설계 로드맵의 1/N. 다음 증분: 플랜 단위 쿠폰 스키마·저장/확정 연동 → 캠페인 생성+플랜 에디터 UI(3목적 가중치·쿠폰·목적별 총합) → 성과 업로드·자동분류.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_