### PR TITLE
재설계 증분 2-1: '캠페인 만들기' 생성 플로우

### DIFF
--- a/promo-analytics/app/(dash)/campaigns/new/page.tsx
+++ b/promo-analytics/app/(dash)/campaigns/new/page.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui";
+
+// 새 모델의 진입점 — 1·2단계: 캠페인 생성 + 목적/기간.
+// 목적은 3종 고정(세일즈/브랜딩/재고소진), 1~10 정수 가중치 → 정규화 비율(%) 자동 표기.
+const PURPOSES = [
+  { key: "세일즈", desc: "매출·판매 극대화" },
+  { key: "브랜딩", desc: "인지·구매건수 확대" },
+  { key: "재고소진", desc: "재고 회전·소진" },
+] as const;
+
+export default function NewCampaignPage() {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [start, setStart] = useState("");
+  const [end, setEnd] = useState("");
+  const [weights, setWeights] = useState<Record<string, number>>({});
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const selected = useMemo(
+    () => PURPOSES.filter((p) => weights[p.key] != null),
+    [weights],
+  );
+  const total = useMemo(
+    () => selected.reduce((s, p) => s + (weights[p.key] || 0), 0),
+    [selected, weights],
+  );
+
+  function toggle(key: string) {
+    setWeights((w) => {
+      const next = { ...w };
+      if (next[key] != null) delete next[key];
+      else next[key] = 5; // 기본 가중치
+      return next;
+    });
+  }
+  function setWeight(key: string, v: number) {
+    setWeights((w) => ({ ...w, [key]: Math.max(1, Math.min(10, v)) }));
+  }
+
+  const canSave = name.trim() && start && end && end >= start && selected.length > 0;
+
+  async function save() {
+    if (!canSave || saving) return;
+    setSaving(true);
+    setErr(null);
+    try {
+      const res = await fetch("/api/campaigns", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: name.trim(), start_date: start, end_date: end, purposes: selected.map((p) => p.key), weights }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? "생성 실패");
+      router.push(`/promotions/${data.promotion_id}/plan`);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "생성 실패");
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
+      <div className="mb-1 text-sm text-ink-4">
+        <Link href="/" className="hover:underline">대시보드</Link> / 새 캠페인
+      </div>
+      <h1 className="text-xl font-semibold text-ink">새 캠페인 만들기</h1>
+      <p className="mt-1 text-sm text-ink-3">
+        캠페인 하나 = 한 번의 행사. 여기서 목적·기간을 정하면 바로 플랜 작성으로 이어집니다.
+      </p>
+
+      <div className="mt-6 grid max-w-3xl gap-4 rise-in">
+        {/* 기본 정보 */}
+        <section className="rounded-2xl card-soft p-5 sm:p-6">
+          <h2 className="mb-4 text-sm font-semibold text-ink-2">기본 정보</h2>
+          <label className="block text-xs font-medium text-ink-3">캠페인 이름</label>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="예: 한가위 고양이 대잔치"
+            className="mt-1.5 w-full rounded-xl border border-line bg-card px-3.5 py-2.5 text-sm text-ink outline-none transition focus:border-brand-400"
+          />
+          <div className="mt-4 grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs font-medium text-ink-3">시작일</label>
+              <input type="date" value={start} onChange={(e) => setStart(e.target.value)}
+                className="mt-1.5 w-full rounded-xl border border-line bg-card px-3.5 py-2.5 text-sm text-ink outline-none transition focus:border-brand-400" />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-ink-3">종료일</label>
+              <input type="date" value={end} min={start || undefined} onChange={(e) => setEnd(e.target.value)}
+                className="mt-1.5 w-full rounded-xl border border-line bg-card px-3.5 py-2.5 text-sm text-ink outline-none transition focus:border-brand-400" />
+            </div>
+          </div>
+        </section>
+
+        {/* 목적 + 가중치 */}
+        <section className="rounded-2xl card-soft p-5 sm:p-6">
+          <h2 className="text-sm font-semibold text-ink-2">목적 &amp; 가중치</h2>
+          <p className="mt-1 text-xs text-ink-4">
+            복수 선택 가능 · 각 1~10 가중치 → 비율은 자동 계산됩니다.
+          </p>
+          <div className="mt-4 space-y-2.5">
+            {PURPOSES.map((p) => {
+              const on = weights[p.key] != null;
+              const share = on && total > 0 ? Math.round(((weights[p.key] || 0) / total) * 100) : 0;
+              return (
+                <div
+                  key={p.key}
+                  className={`rounded-xl border p-3 transition ${on ? "border-brand-300 bg-brand-50/60" : "border-line bg-card"}`}
+                >
+                  <div className="flex items-center gap-3">
+                    <button
+                      type="button"
+                      onClick={() => toggle(p.key)}
+                      className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-md border text-xs transition ${on ? "border-brand-500 bg-brand-500 text-white" : "border-line text-transparent"}`}
+                      aria-label={`${p.key} 선택`}
+                    >
+                      ✓
+                    </button>
+                    <div className="min-w-0 flex-1">
+                      <div className="text-sm font-semibold text-ink">{p.key}</div>
+                      <div className="text-xs text-ink-4">{p.desc}</div>
+                    </div>
+                    {on && (
+                      <div className="flex items-center gap-3">
+                        <div className="flex items-center gap-1.5">
+                          <button type="button" onClick={() => setWeight(p.key, (weights[p.key] || 0) - 1)}
+                            className="flex h-7 w-7 items-center justify-center rounded-lg surface-pressed-soft text-ink-2 hover:text-ink">−</button>
+                          <span className="w-6 text-center text-sm font-bold tabular-nums text-ink">{weights[p.key]}</span>
+                          <button type="button" onClick={() => setWeight(p.key, (weights[p.key] || 0) + 1)}
+                            className="flex h-7 w-7 items-center justify-center rounded-lg surface-pressed-soft text-ink-2 hover:text-ink">+</button>
+                        </div>
+                        <span className="w-12 shrink-0 text-right text-sm font-bold tabular-nums text-brand-600">{share}%</span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+
+        {err && (
+          <div className="rounded-xl border border-danger/30 bg-danger-soft px-4 py-2.5 text-sm text-danger">{err}</div>
+        )}
+
+        <div className="flex items-center justify-end gap-2">
+          <Button asChild variant="ghost">
+            <Link href="/">취소</Link>
+          </Button>
+          <Button onClick={save} loading={saving} disabled={!canSave}>
+            캠페인 만들고 플랜 작성 →
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/promo-analytics/app/(dash)/page.tsx
+++ b/promo-analytics/app/(dash)/page.tsx
@@ -278,12 +278,20 @@ export default async function Dashboard() {
             <div className="text-xs text-ink-4">캠페인 {rows.length}건 분석 중</div>
           </div>
         </div>
-        <Link
-          href="/predict"
-          className="rounded-full bg-brand-500 px-5 py-2.5 text-sm font-semibold text-white shadow-soft transition duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-0.5 hover:bg-brand-600 hover:shadow-float"
-        >
-          성과 시뮬레이터 →
-        </Link>
+        <div className="flex items-center gap-2">
+          <Link
+            href="/campaigns/new"
+            className="rounded-full border border-line bg-card px-5 py-2.5 text-sm font-semibold text-ink-2 shadow-soft transition duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-0.5 hover:text-ink hover:shadow-float"
+          >
+            + 새 캠페인
+          </Link>
+          <Link
+            href="/predict"
+            className="rounded-full bg-brand-500 px-5 py-2.5 text-sm font-semibold text-white shadow-soft transition duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-0.5 hover:bg-brand-600 hover:shadow-float"
+          >
+            성과 시뮬레이터 →
+          </Link>
+        </div>
       </header>
 
       {stale && (

--- a/promo-analytics/app/api/campaigns/route.ts
+++ b/promo-analytics/app/api/campaigns/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export const runtime = "nodejs";
+
+// 새 캠페인 = promotion(메타) + draft 플랜 + 목적 가중치를 한 번에 생성.
+// (N5에서 '빈 draft 자동생성'을 막았던 이유는 플랜/실적 머지 충돌 — 새 모델은
+//  한 캠페인=한 행사(플랜+자기 성과)라 그 충돌이 사라져 생성 플로우를 복원한다.)
+type Body = {
+  name: string;
+  start_date: string;
+  end_date: string;
+  purposes: string[]; // 세일즈/브랜딩/재고소진 (1~3개)
+  weights: Record<string, number>; // 목적별 1~10 정수
+};
+
+export async function POST(req: Request) {
+  try {
+    const body = (await req.json()) as Body;
+    const name = (body.name ?? "").trim();
+    const { start_date, end_date } = body;
+    const purposes = (body.purposes ?? []).filter(Boolean);
+
+    if (!name) return NextResponse.json({ error: "캠페인 이름을 입력하세요." }, { status: 400 });
+    if (!start_date || !end_date)
+      return NextResponse.json({ error: "기간(시작·종료일)을 입력하세요." }, { status: 400 });
+    if (end_date < start_date)
+      return NextResponse.json({ error: "종료일이 시작일보다 빠릅니다." }, { status: 400 });
+    if (purposes.length === 0)
+      return NextResponse.json({ error: "목적을 1개 이상 선택하세요." }, { status: 400 });
+
+    const supabase = await createClient();
+
+    // 1) 프로모션 메타
+    const { data: promo, error: pErr } = await supabase
+      .from("promotions")
+      .insert({
+        name,
+        start_date,
+        end_date,
+        purposes,
+        purpose: purposes[0], // 레거시 단일 목적 = 주목적
+      })
+      .select("id")
+      .single();
+    if (pErr || !promo) throw pErr ?? new Error("캠페인 생성 실패");
+    const promotionId = promo.id as string;
+
+    // 2) draft 플랜 (v1, current)
+    const { data: plan, error: plErr } = await supabase
+      .from("campaign_plans")
+      .insert({
+        promotion_id: promotionId,
+        version: 1,
+        is_current: true,
+        status: "draft",
+      })
+      .select("id")
+      .single();
+    if (plErr || !plan) throw plErr ?? new Error("플랜 생성 실패");
+
+    // 3) 목적 가중치 — 1~10 정수를 합=1 로 정규화 저장 (effective_purpose_weights 기대 형식)
+    const total = purposes.reduce((s, p) => s + (Number(body.weights?.[p]) || 0), 0);
+    if (total > 0) {
+      const rows = purposes.map((p) => ({
+        promotion_id: promotionId,
+        purpose: p,
+        weight: (Number(body.weights?.[p]) || 0) / total,
+      }));
+      const { error: wErr } = await supabase
+        .from("promotion_purpose_weights")
+        .insert(rows);
+      if (wErr) throw wErr;
+    }
+
+    return NextResponse.json({ promotion_id: promotionId, plan_id: plan.id });
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : "캠페인 생성 실패" },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## 재설계 증분 2-1 — '캠페인 만들기' 생성 플로우

새 모델("한 캠페인 = 한 번의 행사, 플랜+자기 성과")의 **진입점(1·2단계)** 신설.

> N5에서 '빈 draft 생성'을 막았던 이유는 플랜/실적 머지 충돌이었는데, 새 모델은 캠페인마다 자기 성과만 붙으므로 그 충돌이 사라져 **생성 플로우를 안전하게 복원**합니다.

### 추가
- **`POST /api/campaigns`**: `promotion`(메타) + `draft 플랜(v1)` + `목적 가중치`를 한 번에 생성. 목적 1~10 정수 가중치를 **합=1로 정규화** 저장(`effective_purpose_weights` 형식).
- **`/campaigns/new`**: 이름·기간 + **목적 3종(세일즈/브랜딩/재고소진)** 다중선택 + 1~10 가중치 스텝퍼 → **정규화 비율(%) 자동 표기** → 생성 후 플랜 에디터로 이동.
- 대시보드 헤더에 **`+ 새 캠페인`** 버튼(Neo Organic 톤).

### 안전성 / 검증
- **추가형** — 기존 플로우·데이터 무변(새 페이지·라우트·버튼만 추가).
- `tsc` + `next build`(15 routes) 통과.

### 다음 (증분 2-2~)
플랜 에디터에 **쿠폰 입력 + 목적별 총합 헤더(매출/구매건수/판매수량/공헌·률)** → 이어서 **성과 업로드·자동분류**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_