### PR TITLE
재설계 증분 2-2: 플랜 에디터 쿠폰 + 목적별 총합 헤더

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
@@ -12,6 +12,7 @@ import {
   discountFromPrice,
   priceFromDiscount,
   type PlanItemInput,
+  type CouponSpec,
 } from "@/lib/plan";
 import { won, pct, num } from "@/lib/format";
 import { validatePlan } from "@/lib/plan-validation";
@@ -85,15 +86,28 @@ export default function PlanEditor({
   initialOptions,
   rateCard,
   qtyHint,
+  purposes,
 }: {
   promotionId: string;
   plan: CampaignPlan | null;
   initialOptions: EditorOption[];
   rateCard: RateCard | null;
   qtyHint?: QtyHint;
+  purposes?: string[];
 }) {
   const router = useRouter();
   const [options, setOptions] = useState<OptState[]>(() => toState(initialOptions));
+  // 플랜(캠페인) 단위 조건부 쿠폰 — UI는 할인율을 %로 입력
+  const planC = plan as (CampaignPlan & {
+    coupon_min_order?: number | null;
+    coupon_rate?: number | null;
+    coupon_max?: number | null;
+  }) | null;
+  const [coupon, setCoupon] = useState(() => ({
+    min: Number(planC?.coupon_min_order ?? 0) || 0,
+    ratePct: (Number(planC?.coupon_rate ?? 0) || 0) * 100,
+    max: Number(planC?.coupon_max ?? 0) || 0,
+  }));
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState<{ kind: "err" | "ok"; text: string } | null>(null);
   const [dirty, setDirty] = useState(false);
@@ -135,6 +149,16 @@ export default function PlanEditor({
     );
   }
 
+  // 쿠폰 스펙 (할인율>0일 때만 적용)
+  const couponSpec: CouponSpec =
+    coupon.ratePct > 0
+      ? {
+          min_order_amount: coupon.min,
+          discount_rate: coupon.ratePct / 100,
+          max_discount_amount: coupon.max,
+        }
+      : null;
+
   // ── 라이브 롤업 ──────────────────────────────
   const optionResults = options.map((o) => {
     const inputs: PlanItemInput[] = o.items.map((it) => ({
@@ -144,7 +168,7 @@ export default function PlanEditor({
       regular_price: it.regular_price,
       cost: it.cost,
     }));
-    return computeOptionTotals(inputs, mult, o.expected_option_qty);
+    return computeOptionTotals(inputs, mult, o.expected_option_qty, couponSpec);
   });
   const planTotals = computePlanTotals(
     options.map((o, i) => ({
@@ -156,6 +180,18 @@ export default function PlanEditor({
         sku_qty_per_option: it.sku_qty_per_option,
       })),
     })),
+  );
+  // 목적별 총합 — 구매건수(=Σ옵션 세트수)·판매수량(=Σ SKU 단위)·공헌이익률·쿠폰 할인 총액
+  const expOrderCount = options.reduce((s, o) => s + (o.expected_option_qty || 0), 0);
+  let expSkuUnits = 0;
+  for (const v of planTotals.skuExpectedQty.values()) expSkuUnits += v.qty;
+  const contribRate =
+    planTotals.expected_revenue_total > 0
+      ? planTotals.expected_contribution_total / planTotals.expected_revenue_total
+      : null;
+  const couponTotal = optionResults.reduce(
+    (s, r, i) => s + r.coupon_discount * (options[i].expected_option_qty || 0),
+    0,
   );
 
   // ── 인라인 검증 (확정 전 오류 발견) ──────────
@@ -214,6 +250,7 @@ export default function PlanEditor({
   function payload() {
     return {
       plan_id: plan!.id,
+      coupon: { min_order: coupon.min, rate: coupon.ratePct / 100, max: coupon.max },
       options: options.map((o, i) => ({
         option_label: o.option_label,
         expected_option_qty: o.expected_option_qty,
@@ -333,15 +370,69 @@ export default function PlanEditor({
         )}
       </div>
 
-      {/* 플랜 합계 */}
-      <div className="mt-4 grid grid-cols-2 gap-3 md:grid-cols-4">
-        <Stat label="예상 매출 합계" value={won(planTotals.expected_revenue_total)} primary />
-        <Stat label="예상 공헌이익 합계" value={won(planTotals.expected_contribution_total)} />
-        <Stat label="옵션 수" value={num(options.length)} />
-        <Stat
-          label="SKU 종류"
-          value={num(planTotals.skuExpectedQty.size)}
-        />
+      {/* 플랜 목적 + 목적별 총합 헤더 */}
+      <div className="mt-4 rounded-2xl card-soft p-5">
+        {purposes && purposes.length > 0 && (
+          <div className="mb-3 flex flex-wrap items-center gap-1.5">
+            <span className="text-xs font-medium text-ink-4">목적</span>
+            {purposes.map((p) => (
+              <span key={p} className="rounded-full bg-brand-50 px-2.5 py-0.5 text-xs font-semibold text-brand-700">
+                {p}
+              </span>
+            ))}
+          </div>
+        )}
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-5">
+          <Stat label="예상 매출액" value={won(planTotals.expected_revenue_total)} primary />
+          <Stat label="구매건수 (세트)" value={num(expOrderCount)} />
+          <Stat label="판매수량 (SKU)" value={num(expSkuUnits)} />
+          <Stat label="공헌이익액" value={won(planTotals.expected_contribution_total)} />
+          <Stat label="공헌이익률" value={contribRate != null ? pct(contribRate, 1) : "—"} />
+        </div>
+        <div className="mt-2 text-[11px] text-ink-4">
+          옵션 {num(options.length)}종 · SKU {num(planTotals.skuExpectedQty.size)}종
+          {couponTotal > 0 && <> · 쿠폰 할인 반영 −{won(couponTotal)}</>}
+        </div>
+      </div>
+
+      {/* 추가 할인 쿠폰 (플랜 단위 · N원 이상 n% 최대 n원) */}
+      <div className="mt-3 rounded-2xl card-soft p-5">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-ink-2">추가 할인 쿠폰</h3>
+          <span className="text-[11px] text-ink-4">옵션 혜택가가 기준액 이상이면 자동 적용</span>
+        </div>
+        <div className="mt-3 grid grid-cols-3 gap-3">
+          <label className="block">
+            <span className="block text-[11px] font-medium text-ink-4">기준액 (원 이상)</span>
+            <input
+              type="number" inputMode="numeric" min={0} disabled={confirmed}
+              value={coupon.min || ""}
+              onChange={(e) => { setCoupon((c) => ({ ...c, min: Math.max(0, Number(e.target.value) || 0) })); setDirty(true); }}
+              placeholder="예: 50000"
+              className="mt-1 w-full rounded-xl border border-line bg-card px-3 py-2 text-sm tabular-nums text-ink outline-none transition focus:border-brand-400 disabled:opacity-60"
+            />
+          </label>
+          <label className="block">
+            <span className="block text-[11px] font-medium text-ink-4">할인율 (%)</span>
+            <input
+              type="number" inputMode="decimal" min={0} max={100} disabled={confirmed}
+              value={coupon.ratePct || ""}
+              onChange={(e) => { setCoupon((c) => ({ ...c, ratePct: Math.max(0, Math.min(100, Number(e.target.value) || 0)) })); setDirty(true); }}
+              placeholder="예: 10"
+              className="mt-1 w-full rounded-xl border border-line bg-card px-3 py-2 text-sm tabular-nums text-ink outline-none transition focus:border-brand-400 disabled:opacity-60"
+            />
+          </label>
+          <label className="block">
+            <span className="block text-[11px] font-medium text-ink-4">최대 할인 (원, 0=무제한)</span>
+            <input
+              type="number" inputMode="numeric" min={0} disabled={confirmed}
+              value={coupon.max || ""}
+              onChange={(e) => { setCoupon((c) => ({ ...c, max: Math.max(0, Number(e.target.value) || 0) })); setDirty(true); }}
+              placeholder="예: 10000"
+              className="mt-1 w-full rounded-xl border border-line bg-card px-3 py-2 text-sm tabular-nums text-ink outline-none transition focus:border-brand-400 disabled:opacity-60"
+            />
+          </label>
+        </div>
       </div>
 
       {/* 검증 요약 (확정 전 오류 발견) */}

--- a/promo-analytics/app/(dash)/promotions/[id]/plan/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/page.tsx
@@ -26,7 +26,7 @@ export default async function PlanPage({
 
   const { data: promo } = await supabase
     .from("promotions")
-    .select("id, name, start_date, end_date")
+    .select("id, name, start_date, end_date, purposes")
     .eq("id", id)
     .single();
   if (!promo) notFound();
@@ -181,6 +181,7 @@ export default async function PlanPage({
         initialOptions={options}
         rateCard={(rc as RateCard) ?? null}
         qtyHint={qtyHint}
+        purposes={(promo.purposes as string[] | null) ?? []}
       />
 
       {plan && (

--- a/promo-analytics/app/api/promotions/[id]/plan/route.ts
+++ b/promo-analytics/app/api/promotions/[id]/plan/route.ts
@@ -31,8 +31,20 @@ export async function PATCH(
 ) {
   try {
     const { id } = await params;
-    const body = (await req.json()) as { plan_id: string; options: OptionIn[] };
+    const body = (await req.json()) as {
+      plan_id: string;
+      options: OptionIn[];
+      coupon?: { min_order: number; rate: number; max: number };
+    };
     const { plan_id, options } = body;
+    const couponSpec =
+      body.coupon && body.coupon.rate > 0
+        ? {
+            min_order_amount: Number(body.coupon.min_order) || 0,
+            discount_rate: Number(body.coupon.rate) || 0,
+            max_discount_amount: Number(body.coupon.max) || 0,
+          }
+        : null;
     const supabase = await createClient();
 
     const { data: plan, error: pErr } = await supabase
@@ -100,7 +112,7 @@ export async function PATCH(
           cost: pm?.cost ?? null,
         };
       });
-      const t = computeOptionTotals(itemInputs, mult, opt.expected_option_qty);
+      const t = computeOptionTotals(itemInputs, mult, opt.expected_option_qty, couponSpec);
       revTotal += t.expected_revenue;
       contribTotal += t.expected_contribution;
 
@@ -156,6 +168,9 @@ export async function PATCH(
       .update({
         expected_revenue_total: revTotal,
         expected_contribution_total: contribTotal,
+        coupon_min_order: couponSpec?.min_order_amount ?? 0,
+        coupon_rate: couponSpec?.discount_rate ?? 0,
+        coupon_max: couponSpec?.max_discount_amount ?? 0,
         updated_at: new Date().toISOString(),
       })
       .eq("id", plan_id);

--- a/promo-analytics/supabase/migrations/0047_plan_coupon.sql
+++ b/promo-analytics/supabase/migrations/0047_plan_coupon.sql
@@ -1,0 +1,173 @@
+-- 0047: 플랜(캠페인) 단위 조건부 쿠폰 — "N원 이상 n% 할인(최대 n원)"
+--
+-- 재설계 증분 2-2. campaign_plans에 쿠폰 3필드 추가. confirm_plan 롤업은 옵션 혜택가
+-- (set_price)가 기준액 이상이면 정률 할인(상한 캡)한 net_price로 예상매출·공헌이익 계산.
+-- lib/plan.ts computeOptionTotals/couponDiscount 와 식 동일. 쿠폰 없으면(rate=0) 무변.
+-- set_price·discount_rate는 쿠폰 전(gross) 유지 — lib와 일치.
+
+alter table promo.campaign_plans
+  add column if not exists coupon_min_order numeric not null default 0,
+  add column if not exists coupon_rate      numeric not null default 0,
+  add column if not exists coupon_max        numeric not null default 0;
+
+create or replace function promo.confirm_plan(p_plan_id uuid)
+returns void
+language plpgsql
+set search_path = ''
+as $$
+declare
+  v_promo uuid;
+  v_rc record;
+  v_mult numeric;
+  v_snapshot jsonb;
+  v_opt_count int;
+  v_bad_opt int;
+  v_rev_total numeric;
+  v_contrib_total numeric;
+  v_cmin numeric;
+  v_crate numeric;
+  v_cmax numeric;
+begin
+  select promotion_id, coalesce(coupon_min_order,0), coalesce(coupon_rate,0), coalesce(coupon_max,0)
+    into v_promo, v_cmin, v_crate, v_cmax
+  from promo.campaign_plans where id = p_plan_id;
+  if v_promo is null then
+    raise exception 'plan % not found', p_plan_id;
+  end if;
+
+  select count(*) into v_opt_count
+  from promo.campaign_plan_options
+  where campaign_plan_id = p_plan_id and expected_option_qty > 0;
+  if v_opt_count = 0 then
+    raise exception '확정하려면 예상 세트수가 1 이상인 옵션이 최소 1개 필요합니다';
+  end if;
+
+  select count(*) into v_bad_opt
+  from promo.campaign_plan_options o
+  where o.campaign_plan_id = p_plan_id
+    and not exists (
+      select 1 from promo.campaign_plan_option_items i
+      where i.campaign_plan_option_id = o.id
+    );
+  if v_bad_opt > 0 then
+    raise exception '구성 SKU가 없는 옵션이 % 개 있습니다', v_bad_opt;
+  end if;
+
+  select * into v_rc from promo.rate_card where is_current order by effective_from desc limit 1;
+  if v_rc is null then
+    raise exception 'current rate_card 가 없습니다';
+  end if;
+  v_mult := 1 - (v_rc.fee_rate + v_rc.ad_rate + v_rc.logistics_rate + v_rc.reward_rate);
+  v_snapshot := jsonb_build_object(
+    'fee_rate', v_rc.fee_rate, 'ad_rate', v_rc.ad_rate,
+    'logistics_rate', v_rc.logistics_rate, 'reward_rate', v_rc.reward_rate,
+    'mult', v_mult, 'rate_card_id', v_rc.id, 'snapped_at', now()
+  );
+
+  -- 1) item frozen_* (products 라이브 → 동결)
+  update promo.campaign_plan_option_items i
+  set frozen_consumer_price = p.consumer_price,
+      frozen_regular_price  = p.regular_price,
+      frozen_cost           = p.cost,
+      updated_at = now()
+  from promo.products p
+  where i.product_id = p.id
+    and i.campaign_plan_option_id in (
+      select id from promo.campaign_plan_options where campaign_plan_id = p_plan_id
+    );
+
+  -- 2) 옵션 롤업 (frozen 기준) — 쿠폰 적용 net_price로 매출/공헌
+  update promo.campaign_plan_options o
+  set set_price = agg.set_price,
+      consumer_total = agg.consumer_total,
+      regular_total = agg.regular_total,
+      discount_rate_consumer = case when agg.consumer_total > 0 then 1 - agg.set_price/agg.consumer_total else null end,
+      discount_rate_regular  = case when agg.regular_total  > 0 then 1 - agg.set_price/agg.regular_total  else null end,
+      expected_revenue = agg.net_price * o.expected_option_qty,
+      expected_contribution = (agg.net_price * v_mult - agg.cost_total) * o.expected_option_qty,
+      updated_at = now()
+  from (
+    select a.oid, a.set_price, a.consumer_total, a.regular_total, a.cost_total,
+           a.set_price - (
+             case when v_crate > 0 and a.set_price >= v_cmin
+                  then round(least(a.set_price * v_crate,
+                                   case when v_cmax > 0 then v_cmax else a.set_price * v_crate end))
+                  else 0 end
+           ) as net_price
+    from (
+      select i.campaign_plan_option_id as oid,
+             sum(i.sku_qty_per_option * i.unit_sale_price)                   as set_price,
+             sum(i.sku_qty_per_option * coalesce(i.frozen_consumer_price,0)) as consumer_total,
+             sum(i.sku_qty_per_option * coalesce(i.frozen_regular_price,0))  as regular_total,
+             sum(i.sku_qty_per_option * coalesce(i.frozen_cost,0))           as cost_total
+      from promo.campaign_plan_option_items i
+      group by i.campaign_plan_option_id
+    ) a
+  ) agg
+  where o.id = agg.oid and o.campaign_plan_id = p_plan_id;
+
+  -- 3) 플랜 합계
+  select coalesce(sum(expected_revenue),0), coalesce(sum(expected_contribution),0)
+  into v_rev_total, v_contrib_total
+  from promo.campaign_plan_options where campaign_plan_id = p_plan_id;
+
+  -- 4) 같은 promotion 의 다른 current 해제
+  update promo.campaign_plans
+  set is_current = false, updated_at = now()
+  where promotion_id = v_promo and is_current and id <> p_plan_id;
+
+  -- 5) 동결·확정·current
+  update promo.campaign_plans
+  set status='confirmed', confirmed_at=now(), rate_card_id=v_rc.id,
+      rate_card_snapshot=v_snapshot, expected_revenue_total=v_rev_total,
+      expected_contribution_total=v_contrib_total, is_current=true, updated_at=now()
+  where id = p_plan_id;
+end;
+$$;
+
+-- clone: 쿠폰 필드도 새 draft로 복제
+create or replace function promo.clone_plan_as_draft(p_plan_id uuid)
+returns uuid
+language plpgsql
+set search_path = ''
+as $$
+declare
+  v_promo uuid;
+  v_new_plan uuid;
+  v_maxver int;
+  r_opt record;
+  v_new_opt uuid;
+begin
+  select promotion_id into v_promo from promo.campaign_plans where id = p_plan_id;
+  if v_promo is null then raise exception 'plan % not found', p_plan_id; end if;
+
+  select coalesce(max(version),0)+1 into v_maxver
+  from promo.campaign_plans where promotion_id = v_promo;
+
+  insert into promo.campaign_plans
+    (promotion_id, version, is_current, status, notes, coupon_min_order, coupon_rate, coupon_max)
+  select promotion_id, v_maxver, false, 'draft', notes, coupon_min_order, coupon_rate, coupon_max
+  from promo.campaign_plans where id = p_plan_id
+  returning id into v_new_plan;
+
+  for r_opt in
+    select * from promo.campaign_plan_options where campaign_plan_id = p_plan_id order by sort
+  loop
+    insert into promo.campaign_plan_options
+      (campaign_plan_id, option_label, expected_option_qty, is_main, match_patterns, sort)
+    values
+      (v_new_plan, r_opt.option_label, r_opt.expected_option_qty, r_opt.is_main, r_opt.match_patterns, r_opt.sort)
+    returning id into v_new_opt;
+
+    insert into promo.campaign_plan_option_items
+      (campaign_plan_option_id, product_id, base_name, sku_qty_per_option, unit_sale_price, source_config_id, sort)
+    select v_new_opt, product_id, base_name, sku_qty_per_option, unit_sale_price, source_config_id, sort
+    from promo.campaign_plan_option_items where campaign_plan_option_id = r_opt.id;
+  end loop;
+
+  return v_new_plan;
+end;
+$$;
+
+grant execute on all functions in schema promo to authenticated;
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## 재설계 증분 2-2 — 플랜 에디터: 쿠폰 + 목적별 총합

3·4단계. 플랜 작성 시 **조건부 쿠폰**과 **목적별 총합**을 실시간 반영.

### 변경
- **0047 마이그레이션**(prod 적용 완료): `campaign_plans`에 쿠폰 3필드(`coupon_min_order/rate/max`). `confirm_plan` 롤업이 **net_price**(쿠폰 후)로 예상매출·공헌이익 계산 — `lib/plan.ts`와 식 동일. `clone_plan_as_draft`도 쿠폰 복제. **쿠폰 없으면(rate=0) 결과 무변**.
- **PlanEditor**: 플랜 단위 쿠폰 입력(기준액·할인율%·최대 할인) + 라이브 반영. 상단 헤더를 **목적칩 + 목적별 총합**(예상 매출액 / 구매건수(세트) / 판매수량(SKU) / 공헌이익액 / **공헌이익률**) + 쿠폰 할인 총액으로 확장.
- **plan PATCH route**: 쿠폰 수신·저장 + `computeOptionTotals`에 쿠폰 전달(라이브=확정 일치).
- **plan page**: `promotions.purposes` 로드 → 에디터 목적칩.

### 검증
`tsc` + `next build` + `plan.test`(7) 통과. 추가형(쿠폰 미설정 시 기존과 동일).

### 다음 (증분 2-3)
캠페인에 **성과 업로드 → 자동분류**(라플라스 양식 → 옵션/SKU별 목적 달성률 + 구독 제외).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_