### PR TITLE
재설계 증분 2-4: 이전 플랜 추천·적용 (5단계)

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
@@ -17,6 +17,7 @@ import {
 import { won, pct, num } from "@/lib/format";
 import { validatePlan } from "@/lib/plan-validation";
 import { InlineAlert, Dialog, DialogContent, DialogHeader, DialogFooter, Button } from "@/components/ui";
+import PlanTemplatePanel from "./PlanTemplatePanel";
 
 export type EditorItem = {
   product_id: string;
@@ -434,6 +435,9 @@ export default function PlanEditor({
           </label>
         </div>
       </div>
+
+      {/* 이전 플랜 추천 (draft에서만) */}
+      {!confirmed && <PlanTemplatePanel promotionId={promotionId} />}
 
       {/* 검증 요약 (확정 전 오류 발견) */}
       {!confirmed && (validation.errorCount > 0 || validation.warnCount > 0) && (

--- a/promo-analytics/app/(dash)/promotions/[id]/plan/PlanTemplatePanel.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/PlanTemplatePanel.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+import { won } from "@/lib/format";
+
+// 5단계 — 저장 전, 이전에 저장된 플랜을 추천. 누르면 이 캠페인 draft에 적용(복사)되어
+// 수정해서 사용 가능. (추후 목적·성과 기반 추천으로 고도화 가능)
+type Template = {
+  id: string;
+  promotion_id: string | null;
+  name: string;
+  purposes: string[];
+  expected_revenue_total: number | null;
+};
+
+export default function PlanTemplatePanel({ promotionId }: { promotionId: string }) {
+  const router = useRouter();
+  const [templates, setTemplates] = useState<Template[] | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      const supabase = createClient();
+      const { data } = await supabase
+        .from("campaign_plans")
+        .select("id, promotion_id, expected_revenue_total, promotions(name, purposes)")
+        .eq("status", "confirmed")
+        .neq("promotion_id", promotionId)
+        .order("confirmed_at", { ascending: false })
+        .limit(12);
+      if (!alive) return;
+      const rows = (data ?? []).map((r) => {
+        const p = (Array.isArray(r.promotions) ? r.promotions[0] : r.promotions) as
+          | { name?: string; purposes?: string[] | null }
+          | null;
+        return {
+          id: r.id as string,
+          promotion_id: r.promotion_id as string | null,
+          name: p?.name ?? "(이름 없음)",
+          purposes: (p?.purposes ?? []) as string[],
+          expected_revenue_total: r.expected_revenue_total as number | null,
+        };
+      });
+      setTemplates(rows);
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [promotionId]);
+
+  async function apply(t: Template) {
+    if (busy) return;
+    setBusy(t.id);
+    setErr(null);
+    try {
+      const res = await fetch(`/api/promotions/${promotionId}/plan/apply-template`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ source_plan_id: t.id }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? "적용 실패");
+      router.refresh();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "적용 실패");
+      setBusy(null);
+    }
+  }
+
+  if (!templates || templates.length === 0) return null;
+
+  return (
+    <div className="mt-3 rounded-2xl card-soft p-5">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center justify-between"
+      >
+        <span className="text-sm font-semibold text-ink-2">
+          이전 플랜에서 시작 <span className="font-normal text-ink-4">· {templates.length}개 추천</span>
+        </span>
+        <span className="text-ink-4">{open ? "▲" : "▼"}</span>
+      </button>
+      {open && (
+        <>
+          <p className="mt-1 text-xs text-ink-4">
+            누르면 이 캠페인 플랜에 옵션·구성·쿠폰이 복사됩니다. 기존 작성 내용은 대체되니 빈 플랜에서 사용하세요.
+          </p>
+          {err && (
+            <div className="mt-2 rounded-lg bg-danger-soft px-3 py-2 text-xs text-danger">{err}</div>
+          )}
+          <ul className="mt-3 grid gap-2 sm:grid-cols-2">
+            {templates.map((t) => (
+              <li key={t.id}>
+                <button
+                  type="button"
+                  onClick={() => apply(t)}
+                  disabled={!!busy}
+                  className="flex w-full items-start justify-between gap-2 rounded-xl border border-line bg-card p-3 text-left transition hover:border-brand-300 hover:bg-brand-50/50 disabled:opacity-60"
+                >
+                  <span className="min-w-0">
+                    <span className="block truncate text-sm font-medium text-ink">{t.name}</span>
+                    <span className="mt-0.5 flex flex-wrap gap-1">
+                      {t.purposes.slice(0, 3).map((p) => (
+                        <span key={p} className="rounded-full bg-soft px-1.5 py-0.5 text-[10px] text-ink-3">
+                          {p}
+                        </span>
+                      ))}
+                    </span>
+                  </span>
+                  <span className="shrink-0 text-right">
+                    <span className="block text-xs font-semibold tabular-nums text-ink-2">
+                      {won(t.expected_revenue_total)}
+                    </span>
+                    <span className="text-[10px] text-brand-600">{busy === t.id ? "적용 중…" : "적용 →"}</span>
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+}

--- a/promo-analytics/app/api/promotions/[id]/plan/apply-template/route.ts
+++ b/promo-analytics/app/api/promotions/[id]/plan/apply-template/route.ts
@@ -1,0 +1,114 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export const runtime = "nodejs";
+
+// 5단계 — 이전에 저장된 플랜을 새 캠페인의 draft에 적용(복사해서 수정 사용).
+// clone_plan_as_draft는 같은 캠페인 내 버전 복제용 → 이건 '다른 캠페인의 플랜'을
+// 이 캠페인의 현재 draft로 옮겨 담는다(옵션·구성·쿠폰 복사, 기존 draft 옵션 교체).
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const { source_plan_id } = (await req.json()) as { source_plan_id: string };
+    if (!source_plan_id)
+      return NextResponse.json({ error: "원본 플랜이 필요합니다" }, { status: 400 });
+    const supabase = await createClient();
+
+    // 대상 = 이 캠페인의 현재 draft
+    const { data: target, error: tErr } = await supabase
+      .from("campaign_plans")
+      .select("id, status")
+      .eq("promotion_id", id)
+      .eq("is_current", true)
+      .single();
+    if (tErr || !target)
+      return NextResponse.json({ error: "이 캠페인의 플랜을 찾을 수 없습니다" }, { status: 404 });
+    if (target.status === "confirmed")
+      return NextResponse.json(
+        { error: "확정된 플랜에는 적용할 수 없습니다. '수정(새 버전)'으로 draft를 만드세요." },
+        { status: 409 },
+      );
+
+    // 원본 플랜의 옵션 + 쿠폰
+    const { data: srcPlan } = await supabase
+      .from("campaign_plans")
+      .select("coupon_min_order, coupon_rate, coupon_max")
+      .eq("id", source_plan_id)
+      .single();
+    const { data: srcOpts, error: oErr } = await supabase
+      .from("campaign_plan_options")
+      .select("id, option_label, expected_option_qty, is_main, match_patterns, sort")
+      .eq("campaign_plan_id", source_plan_id)
+      .order("sort");
+    if (oErr) throw oErr;
+    if (!srcOpts || srcOpts.length === 0)
+      return NextResponse.json({ error: "원본 플랜에 옵션이 없습니다" }, { status: 400 });
+
+    const srcOptIds = srcOpts.map((o) => o.id);
+    const { data: srcItems, error: iErr } = await supabase
+      .from("campaign_plan_option_items")
+      .select("campaign_plan_option_id, product_id, base_name, sku_qty_per_option, unit_sale_price, source_config_id, sort")
+      .in("campaign_plan_option_id", srcOptIds);
+    if (iErr) throw iErr;
+
+    // 기존 draft 옵션 전체 교체 (아이템 cascade)
+    const { error: delErr } = await supabase
+      .from("campaign_plan_options")
+      .delete()
+      .eq("campaign_plan_id", target.id);
+    if (delErr) throw delErr;
+
+    // 옵션·아이템 복사 (frozen/rollup은 비우고 — 저장 시 라이브 재계산)
+    for (const [idx, o] of srcOpts.entries()) {
+      const { data: newOpt, error: niErr } = await supabase
+        .from("campaign_plan_options")
+        .insert({
+          campaign_plan_id: target.id,
+          option_label: o.option_label,
+          expected_option_qty: o.expected_option_qty,
+          is_main: o.is_main,
+          match_patterns: o.match_patterns ?? [],
+          sort: o.sort ?? idx,
+        })
+        .select("id")
+        .single();
+      if (niErr) throw niErr;
+      const items = (srcItems ?? []).filter((it) => it.campaign_plan_option_id === o.id);
+      if (items.length > 0) {
+        const { error: insErr } = await supabase.from("campaign_plan_option_items").insert(
+          items.map((it, i) => ({
+            campaign_plan_option_id: newOpt.id,
+            product_id: it.product_id,
+            base_name: it.base_name,
+            sku_qty_per_option: it.sku_qty_per_option,
+            unit_sale_price: it.unit_sale_price,
+            source_config_id: it.source_config_id ?? null,
+            sort: it.sort ?? i,
+          })),
+        );
+        if (insErr) throw insErr;
+      }
+    }
+
+    // 쿠폰 복사
+    await supabase
+      .from("campaign_plans")
+      .update({
+        coupon_min_order: srcPlan?.coupon_min_order ?? 0,
+        coupon_rate: srcPlan?.coupon_rate ?? 0,
+        coupon_max: srcPlan?.coupon_max ?? 0,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", target.id);
+
+    return NextResponse.json({ ok: true, options: srcOpts.length });
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : "플랜 적용 실패" },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## 재설계 증분 2-4 — 이전 플랜 추천·적용 (5단계)

플랜 작성 전 이전에 저장된 확정 플랜을 추천하고, 누르면 이 캠페인 draft에 **옵션·구성·쿠폰이 복사**되어 수정해 사용할 수 있습니다.

### 추가
- **`POST /api/promotions/[id]/plan/apply-template`**: 다른 캠페인의 플랜을 이 캠페인의 현재 draft로 복사(옵션·아이템·쿠폰 교체). `clone_plan_as_draft`(같은 캠페인 버전 복제)와 달리 **캠페인 간 템플릿 적용**.
- **`PlanTemplatePanel`**: 확정 플랜 목록(이름·목적칩·예상매출) 추천 → '적용 →'. **draft에서만** 노출.

### 검증
`tsc` + `next build` 통과. 추가형(기존 무변).

---

## 🎉 재설계 증분 2 완료 — 전체 수직 슬라이스 동작

| 단계 | 상태 |
|---|---|
| 1·2 캠페인 생성 + 목적/기간 | ✅ #109 |
| 3·4 플랜 에디터 (쿠폰 + 목적별 총합) | ✅ #108·#110 |
| 5 이전 플랜 추천·적용 | ✅ (이 PR) |
| 6 성과 업로드·자동분류(구독 제외) | ✅ #111 |
| 7 서브상품·재고 예측 | ⏭️ 추후(사용자 표기) |

**`+ 새 캠페인` → 목적·기간 → 플랜(이전 플랜 적용·SKU·쿠폰·목적별 총합) → 성과 업로드 → 달성률(구독 제외)** 이 한 흐름으로 완결.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_