### PR TITLE
재설계 Phase 1: 캠페인 상세 자가완결 모델 정리

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/page.tsx
@@ -20,7 +20,7 @@ import Achievement from "./Achievement";
 import PerformanceUpload from "./PerformanceUpload";
 import PurposeBlock, { type PurposeMetricRow } from "./PurposeBlock";
 import { type DiagnosticRow, type SkuMapping } from "./SkuMatchPanel";
-import ActualsLink, { type ActualsCandidate } from "./ActualsLink";
+import { type ActualsCandidate } from "./ActualsLink";
 import OptionContribution, { type OptionContribRow } from "./OptionContribution";
 import CampaignTrend, { type DailyPoint } from "./CampaignTrend";
 import { CampaignWorkflowBar } from "./CampaignWorkflowBar";
@@ -101,11 +101,7 @@ export default async function PromotionDetail({
   const summary = bundle?.rollup?.features ?? null;
   const notes = bundle?.notes ?? [];
   const plan = bundle?.plan ?? null;
-  const candidates = bundle?.candidates ?? [];
   const linkedPlans = bundle?.linked_plans ?? [];
-  const linkedActualName = plan?.actual_promotion_id
-    ? candidates.find((c) => c.id === plan.actual_promotion_id)?.name ?? null
-    : null;
 
   const achSummary = bundle?.rollup?.pva_summary ?? null;
   const achRows = bundle?.rollup?.pva_rows ?? [];
@@ -162,17 +158,16 @@ export default async function PromotionDetail({
 
   // ── 생애주기 워크플로 + 즉시 조치 (Layer A/B) ────────────────
   const today = new Date().toISOString().slice(0, 10);
-  const unmatchedCount = diagnosticRows.filter(
-    (r) => r.side !== "both" && !r.is_mapped && !r.is_subscription,
-  ).length;
-  // self-비교(기본): 가이드·실적이 같은 코드로 올라와 실 매출이 이미 잡히면
-  // 명시적 짝짓기(actual_promotion_id)가 없어도 "실적 연결"은 충족된 것으로 본다.
-  const hasSelfActuals = (achSummary?.campaign_revenue_total ?? 0) > 0;
+  // 새 모델: 성과는 이 캠페인에 직접 올린다. 성과(실 매출)가 실제로 있을 때만
+  // 매칭·달성 관련 UI를 노출한다 (성과 0인데 미매칭/실적연결 노티 X).
+  const hasActuals = (achSummary?.campaign_revenue_total ?? 0) > 0;
+  const unmatchedCount = hasActuals
+    ? diagnosticRows.filter((r) => r.side !== "both" && !r.is_mapped && !r.is_subscription).length
+    : 0;
   const wfInput = {
     hasPlan: !!plan,
     planConfirmed: plan?.status === "confirmed",
-    hasActualLink: !!plan?.actual_promotion_id || hasSelfActuals,
-    hasActualData: !!achSummary?.has_confirmed_plan,
+    hasActuals,
     unmatchedCount,
     expectedContribution:
       achSummary?.expected_contribution_total ?? plan?.expected_contribution_total ?? null,
@@ -236,7 +231,7 @@ export default async function PromotionDetail({
       {/* Layer A — 생애주기 + 핵심 결과 + 즉시 조치 */}
       <CampaignWorkflowBar steps={workflow} basePath={basePath} />
 
-      {wfInput.hasActualData && achSummary ? (
+      {hasActuals && achSummary ? (
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
           <ProgressMetric
             label="캠페인 매출 달성 (전체)"
@@ -275,7 +270,7 @@ export default async function PromotionDetail({
       ) : (
         <InlineAlert
           tone="info"
-          title="확정 플랜 + 실적 연결 시 달성 KPI가 표시됩니다"
+          title={plan ? "성과 시트를 올리면 달성 KPI가 채워집니다" : "플랜을 먼저 작성하세요"}
           action={
             <Link href={`${basePath}/plan`} className="rounded-lg bg-card/70 px-2.5 py-1 text-[11px] font-semibold text-ink-2 hover:bg-card">
               {plan ? "플랜 편집" : "플랜 만들기"} →
@@ -283,7 +278,7 @@ export default async function PromotionDetail({
           }
         >
           {plan
-            ? `플랜 v${plan.version} · ${plan.status === "confirmed" ? "확정됨" : "draft"} · 예상 매출 ${won(plan.expected_revenue_total)}`
+            ? `플랜 v${plan.version} · ${plan.status === "confirmed" ? "확정됨" : "draft"} · 예상 매출 ${won(plan.expected_revenue_total)} — 아래 '성과 추가'에서 동기간 매출을 업로드하세요.`
             : "옵션·예상 세트수로 예상 성과를 미리 계산하세요."}
         </InlineAlert>
       )}
@@ -294,7 +289,7 @@ export default async function PromotionDetail({
 
       {/* 6단계 — 캠페인에 직접 성과 추가 (라플라스 양식 → 자동 분류) */}
       <div className="mt-4">
-        <PerformanceUpload promotionId={id} hasActuals={hasSelfActuals} />
+        <PerformanceUpload promotionId={id} hasActuals={hasActuals} />
       </div>
 
       {/* Layer C — 심층 분석 (탭, URL 보존, 선택 탭만 렌더) */}
@@ -304,8 +299,9 @@ export default async function PromotionDetail({
         {view === "overview" && (
           <div>
             {!hasBaseline && (
-              <div className="mb-4 rounded-lg bg-warning-soft px-4 py-3 text-sm text-warning">
-                직전 8주 baseline 데이터가 부족합니다. <strong>일별 매출 추이</strong>를 충분히 업로드하면 증분이 정확해집니다.
+              <div className="mb-4 rounded-lg bg-info-soft px-4 py-3 text-sm text-info">
+                baseline(직전 8주 일평균)이 얕아 증분 정확도가 낮을 수 있습니다 — <strong>차단되지 않으며</strong>,
+                일별 매출 추이가 쌓이면 자동으로 정확해집니다.
               </div>
             )}
             <MeasurementBanner summary={summary} rows={rows} />
@@ -462,60 +458,39 @@ export default async function PromotionDetail({
               </div>
             </div>
 
-            {plan && (
-              // N13 P3: 정상 경로는 ②실적·⑤가이드를 같은 코드로 업로드해 자동 결속하는 것.
-              // 비교 대상 연결/병합은 코드가 어긋난 레거시 보정용 → 보정·관리자 도구로 격하.
-              // 결속이 이미 충족(linkedActualName)이면 접어두고, 미충족일 때만 펼쳐 노출.
-              <details
-                className="mb-4 rounded-2xl card-soft p-5 [&_summary]:cursor-pointer"
-                open={!linkedActualName}
-              >
-                <summary className="flex flex-wrap items-center justify-between gap-2">
-                  <span className="flex items-center gap-2">
-                    <h2 className="inline text-sm font-semibold text-ink-2">
-                      비교 대상 연결 <span className="font-normal text-ink-4">· 보정·관리자용</span>
-                    </h2>
-                    {!plan.actual_promotion_id && (
-                      <span className="rounded-full bg-warning-soft px-2 py-0.5 text-[11px] font-medium text-warning">
-                        비교 대상 미지정
-                      </span>
-                    )}
-                  </span>
-                  <Link href={`/promotions/${id}/edit`} className="text-xs text-ink-4 hover:text-brand-600 hover:underline">
-                    중복 캠페인 정리(병합) →
-                  </Link>
-                </summary>
-                {linkedActualName ? (
-                  <p className="mt-2 text-xs text-ink-3">
-                    비교 구도: <strong className="text-ink">이 캠페인의 플랜</strong> ↔{" "}
-                    <strong className="text-brand-700">{linkedActualName}</strong> 실적.
-                    정상 결속됨 — 코드가 어긋났을 때만 아래에서 보정하세요.
-                  </p>
-                ) : (
-                  <p className="mt-2 text-xs text-ink-4">
-                    정상 경로는 실적(②)·가이드(⑤)를 <strong>같은 캠페인 코드</strong>로 올려 자동
-                    결속하는 것입니다. 코드가 달라 자동 결속이 안 된 경우에만, 비교할 실적 캠페인을 직접 지정하세요.
-                  </p>
-                )}
-                <ActualsLink promotionId={id} currentLinkId={plan.actual_promotion_id} candidates={candidates} />
-              </details>
+            {hasActuals ? (
+              <>
+                <Achievement
+                  promotionId={id}
+                  summary={achSummary}
+                  rows={achRows}
+                  options={achOptions}
+                  optionInfos={optionInfos}
+                  diagnosticRows={diagnosticRows}
+                  skuMappings={skuMappings}
+                  hideSummaryCards
+                />
+
+                <OptionContribution
+                  rows={optionContribs}
+                  groundTruth={promo.contribution_amount ?? null}
+                />
+              </>
+            ) : (
+              <div className="rounded-2xl card-soft p-6 text-center">
+                <p className="text-sm font-medium text-ink">아직 성과가 없습니다.</p>
+                <p className="mx-auto mt-1 max-w-md text-sm text-ink-4">
+                  캠페인 종료 후 <strong>성과 개요</strong> 탭의 '성과 추가'에서 동기간 매출 시트를 올리면
+                  옵션/SKU별 달성률과 구독 제외 분석이 여기 표시됩니다.
+                </p>
+                <Link
+                  href={`${basePath}`}
+                  className="mt-4 inline-block rounded-full bg-brand-500 px-5 py-2.5 text-sm font-semibold text-white hover:bg-brand-600"
+                >
+                  성과 추가로 가기 →
+                </Link>
+              </div>
             )}
-
-            <Achievement
-              promotionId={id}
-              summary={achSummary}
-              rows={achRows}
-              options={achOptions}
-              optionInfos={optionInfos}
-              diagnosticRows={diagnosticRows}
-              skuMappings={skuMappings}
-              hideSummaryCards
-            />
-
-            <OptionContribution
-              rows={optionContribs}
-              groundTruth={promo.contribution_amount ?? null}
-            />
           </div>
         )}
 

--- a/promo-analytics/lib/__tests__/campaign-workflow.test.ts
+++ b/promo-analytics/lib/__tests__/campaign-workflow.test.ts
@@ -4,8 +4,7 @@ import { deriveWorkflow, deriveActions, type WorkflowInput } from "@/lib/campaig
 const base: WorkflowInput = {
   hasPlan: false,
   planConfirmed: false,
-  hasActualLink: false,
-  hasActualData: false,
+  hasActuals: false,
   unmatchedCount: 0,
   expectedContribution: 1000,
   hasBaseline: true,
@@ -26,20 +25,24 @@ describe("deriveWorkflow", () => {
     const s = step({ ...base, hasPlan: true }, "confirm");
     expect(s.status).toBe("warning");
   });
-  it("확정 + 실적 미연결 → '실적 연결'이 blocked", () => {
+  it("확정 + 성과 없음 → '성과 업로드'가 current (진행 중)", () => {
     const s = step({ ...base, hasPlan: true, planConfirmed: true }, "link");
-    expect(s.status).toBe("blocked");
+    expect(s.status).toBe("current");
   });
-  it("실적 연결 + 미매칭 존재 → '매칭 검증'이 warning", () => {
+  it("확정 + 종료 + 성과 없음 → '성과 업로드'가 warning", () => {
+    const s = step({ ...base, hasPlan: true, planConfirmed: true, isEnded: true }, "link");
+    expect(s.status).toBe("warning");
+  });
+  it("성과 있음 + 미매칭 존재 → '매칭 검증'이 warning", () => {
     const s = step(
-      { ...base, hasPlan: true, planConfirmed: true, hasActualLink: true, hasActualData: true, unmatchedCount: 3 },
+      { ...base, hasPlan: true, planConfirmed: true, hasActuals: true, unmatchedCount: 3 },
       "match",
     );
     expect(s.status).toBe("warning");
   });
-  it("모든 매칭 정상 → '매칭 검증'이 complete, '결과 검토'가 current", () => {
+  it("성과 있음 + 매칭 정상 → '매칭 검증' complete, '결과 검토' current", () => {
     const w = deriveWorkflow({
-      ...base, hasPlan: true, planConfirmed: true, hasActualLink: true, hasActualData: true, unmatchedCount: 0,
+      ...base, hasPlan: true, planConfirmed: true, hasActuals: true, unmatchedCount: 0,
     });
     expect(w.find((s) => s.id === "match")!.status).toBe("complete");
     expect(w.find((s) => s.id === "review")!.status).toBe("current");
@@ -51,16 +54,23 @@ describe("deriveWorkflow", () => {
 });
 
 describe("deriveActions", () => {
-  it("기대공헌 0 이하면 danger 조치 노출", () => {
+  it("성과 0이면 '미매칭' 조치는 안 뜬다", () => {
     const acts = deriveActions(
-      { ...base, hasPlan: true, planConfirmed: true, hasActualLink: true, hasActualData: true, expectedContribution: -100 },
+      { ...base, hasPlan: true, planConfirmed: true, hasActuals: false, unmatchedCount: 5 },
+      { promotionId: "p1" },
+    );
+    expect(acts.some((a) => a.id === "unmatched")).toBe(false);
+  });
+  it("성과 있고 기대공헌 0 이하면 danger 조치 노출", () => {
+    const acts = deriveActions(
+      { ...base, hasPlan: true, planConfirmed: true, hasActuals: true, expectedContribution: -100 },
       { promotionId: "p1" },
     );
     expect(acts.some((a) => a.id === "contrib" && a.tone === "danger")).toBe(true);
   });
-  it("문제 없으면 조치 비어있음(또는 baseline만)", () => {
+  it("문제 없으면 조치 비어있음", () => {
     const acts = deriveActions(
-      { ...base, hasPlan: true, planConfirmed: true, hasActualLink: true, hasActualData: true, unmatchedCount: 0 },
+      { ...base, hasPlan: true, planConfirmed: true, hasActuals: true, unmatchedCount: 0 },
       { promotionId: "p1" },
     );
     expect(acts.length).toBe(0);

--- a/promo-analytics/lib/campaign-workflow.ts
+++ b/promo-analytics/lib/campaign-workflow.ts
@@ -1,5 +1,6 @@
 // PR2: 캠페인 생애주기 상태 머신 + 조치 도출 (순수 함수 — 테스트 대상).
-// 데이터 준비 → 플랜 작성 → 플랜 확정 → 실적 연결 → 매칭 검증 → 결과 검토 → 회고 완료
+// 새 모델(한 캠페인=플랜+성과): 데이터 준비 → 플랜 작성 → 플랜 확정 → 성과 업로드 →
+// 매칭 검증 → 결과 검토 → 회고. '실적 연결'(옛 교차연결)은 제거 — 성과는 이 캠페인에 직접 올린다.
 import type { WorkflowStatus } from "@/lib/status";
 
 export type StepId = "data" | "plan" | "confirm" | "link" | "match" | "review" | "retro";
@@ -7,9 +8,8 @@ export type StepId = "data" | "plan" | "confirm" | "link" | "match" | "review" |
 export type WorkflowInput = {
   hasPlan: boolean;
   planConfirmed: boolean;
-  hasActualLink: boolean; // 비교 대상(실적) 지정됨
-  hasActualData: boolean; // 확정 플랜 + 실적 매칭 결과 존재
-  unmatchedCount: number; // 미매칭 SKU 수
+  hasActuals: boolean; // 이 캠페인에 성과(실적 매출) 데이터가 실제로 있는지
+  unmatchedCount: number; // 미매칭 SKU 수 (성과가 있을 때만 의미)
   expectedContribution: number | null;
   hasBaseline: boolean;
   notesCount: number;
@@ -29,10 +29,10 @@ const ORDER: { id: StepId; label: string; view?: string }[] = [
   { id: "data", label: "데이터 준비", view: "overview" },
   { id: "plan", label: "플랜 작성" },
   { id: "confirm", label: "플랜 확정" },
-  { id: "link", label: "실적 연결", view: "skus" },
+  { id: "link", label: "성과 업로드", view: "overview" },
   { id: "match", label: "매칭 검증", view: "skus" },
   { id: "review", label: "결과 검토", view: "overview" },
-  { id: "retro", label: "회고 완료", view: "sources" },
+  { id: "retro", label: "회고", view: "sources" },
 ];
 
 export function deriveWorkflow(i: WorkflowInput): WorkflowStep[] {
@@ -40,8 +40,8 @@ export function deriveWorkflow(i: WorkflowInput): WorkflowStep[] {
     data: i.hasBaseline,
     plan: i.hasPlan,
     confirm: i.planConfirmed,
-    link: i.hasActualLink,
-    match: i.hasActualData && i.unmatchedCount === 0,
+    link: i.hasActuals,
+    match: i.hasActuals && i.unmatchedCount === 0,
     review: i.notesCount > 0, // 검토는 회고로 완료 처리
     retro: i.notesCount > 0,
   };
@@ -64,8 +64,8 @@ export function deriveWorkflow(i: WorkflowInput): WorkflowStep[] {
       // 활성 단계 — 문제성이면 warning/blocked, 아니면 current
       if (s.id === "data") {
         status = "warning";
-        description = "직전 8주 baseline이 부족합니다. 일별 매출을 더 올리면 증분이 정확해집니다.";
-        actionLabel = "일별 매출 업로드";
+        description = "baseline이 얕습니다 — 일별 매출 추이가 쌓일수록 증분이 정확해집니다(차단 아님).";
+        actionLabel = "데이터 업로드";
       } else if (s.id === "confirm" && i.hasPlan) {
         status = "warning";
         description = "draft 플랜입니다. 확정해야 달성률 집계에 포함됩니다.";
@@ -74,10 +74,13 @@ export function deriveWorkflow(i: WorkflowInput): WorkflowStep[] {
         status = "blocked";
         description = "플랜을 먼저 확정하세요.";
       } else if (s.id === "link") {
-        status = "blocked";
-        description = "비교할 실적 캠페인이 연결되지 않았습니다.";
-        actionLabel = "실적 연결";
-      } else if (s.id === "match" && i.hasActualData && i.unmatchedCount > 0) {
+        // 성과 업로드 대기 — 종료된 캠페인이면 더 강하게(warning)
+        status = i.isEnded ? "warning" : "current";
+        description = i.isEnded
+          ? "캠페인이 끝났습니다. 동기간 성과 시트를 올리면 달성률이 채워집니다."
+          : "캠페인 종료 후 성과 시트를 올리면 옵션/SKU 달성률이 자동 분류됩니다.";
+        actionLabel = "성과 올리기";
+      } else if (s.id === "match" && i.hasActuals && i.unmatchedCount > 0) {
         status = "warning";
         description = `미매칭 SKU ${i.unmatchedCount}개 — 보정이 필요합니다.`;
         actionLabel = "매칭 보정";
@@ -101,7 +104,7 @@ const COMPLETE_DESC: Record<StepId, string> = {
   data: "측정 데이터 준비됨",
   plan: "플랜 작성됨",
   confirm: "플랜 확정됨",
-  link: "실적 연결됨",
+  link: "성과 업로드됨",
   match: "모든 SKU 매칭 정상",
   review: "결과 검토 완료",
   retro: "회고 메모 작성됨",
@@ -110,7 +113,7 @@ const CURRENT_DESC: Record<StepId, string> = {
   data: "측정 데이터 확인",
   plan: "옵션·예상 세트수로 플랜을 작성하세요.",
   confirm: "플랜을 확정하세요.",
-  link: "비교할 실적 캠페인을 연결하세요.",
+  link: "성과 시트를 올리세요.",
   match: "SKU·옵션 매칭을 검증하세요.",
   review: "달성 결과를 검토하세요.",
   retro: "성과 원인·회고를 남기세요.",
@@ -119,7 +122,7 @@ const CURRENT_ACTION: Record<StepId, string> = {
   data: "데이터 보기",
   plan: "플랜 만들기",
   confirm: "플랜 확정",
-  link: "실적 연결",
+  link: "성과 올리기",
   match: "매칭 검증",
   review: "결과 보기",
   retro: "회고 작성",
@@ -147,17 +150,13 @@ export function deriveActions(
   } else if (!i.planConfirmed) {
     a.push({ id: "draft", tone: "warning", title: "draft 플랜 — 확정 필요", body: "확정해야 달성률 집계·홈 페이싱 알림에 포함됩니다.", actionLabel: "플랜 편집", href: `/promotions/${ctx.promotionId}/plan` });
   }
-  if (i.planConfirmed && !i.hasActualLink) {
-    a.push({ id: "no-link", tone: "warning", title: "실적 연결 필요", body: "비교할 실적 캠페인을 지정하면 달성률이 채워집니다.", actionLabel: "실적 연결", view: "skus" });
-  }
-  if (i.hasActualData && i.unmatchedCount > 0) {
+  // 성과 매칭 보정은 '성과가 실제로 있을 때만' 노출 (성과 0인데 미매칭 노티 X)
+  if (i.hasActuals && i.unmatchedCount > 0) {
     a.push({ id: "unmatched", tone: "warning", title: `미매칭 SKU ${i.unmatchedCount}개`, body: "자동 매칭이 빗나간 항목을 보정하세요.", actionLabel: "매칭 보정", view: "skus" });
   }
-  if (i.hasActualData && i.expectedContribution != null && i.expectedContribution <= 0) {
-    a.push({ id: "contrib", tone: "danger", title: "기대 공헌이익이 0 이하", body: "플랜의 원가·판매가(세트가) 적재를 확인하세요.", actionLabel: "플랜 확인", href: `/promotions/${ctx.promotionId}/plan` });
-  }
-  if (!i.hasBaseline) {
-    a.push({ id: "baseline", tone: "info", title: "baseline 데이터 부족", body: "일별 매출을 더 올리면 증분 측정이 정확해집니다.", actionLabel: "데이터 업로드", href: `/upload` });
+  if (i.hasActuals && i.expectedContribution != null && i.expectedContribution <= 0) {
+    a.push({ id: "contrib", tone: "danger", title: "기대 공헌이익이 0 이하", body: "플랜의 원가·옵션 단가 적재를 확인하세요.", actionLabel: "플랜 확인", href: `/promotions/${ctx.promotionId}/plan` });
   }
   return a;
 }
+


### PR DESCRIPTION
## 재설계 Phase 1 — 캠페인 상세를 자가완결 모델로 정리

피드백 직접 반영: "성과가 없는데 왜 **비교대상연결·실적연결 필요·미매칭 SKU**가 뜨나."

### 근본 원인
워크플로가 `hasActualData = '확정 플랜 존재'`를 기준으로 삼아, **성과(실 매출)가 0인데도** 매칭/실적연결 관련 UI가 떴습니다. → **'성과 실재(hasActuals = 실 매출 > 0)' 기준**으로 재정의.

### 변경
- **워크플로**: `실적 연결`(옛 교차연결) → **`성과 업로드`**. 매칭/미매칭은 **성과 있을 때만**. baseline 단계 문구 완화(차단 아님 명시). `deriveActions`에서 실적연결·baseline 나그 제거.
- **캠페인 상세**: **`비교 대상 연결` 섹션 삭제**. 달성 KPI·SKU/옵션 달성 분석은 **성과 있을 때만** 노출, 없으면 **'성과 추가' 안내**만. 미매칭 카운트도 성과 0이면 0. baseline 배너 완화.

### 검증
`campaign-workflow` 테스트 갱신, 전체 **51 통과**. `tsc`·`build` OK.

> Phase 1/4. 다음: Phase 2 플랜 에디터(옵션 단가 구동·쿠폰 콤마·SKU 정리) → Phase 3 IA(캠페인 통합·대시보드 슬림·시뮬레이터 결합) → Phase 4 서브상품 자동 예측.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_