### PR TITLE
재설계 Phase 3-C1: 예측 공헌이익 증분/전체 분리 + null 보존

### DIFF
--- a/promo-analytics/app/(dash)/predict/Simulator.tsx
+++ b/promo-analytics/app/(dash)/predict/Simulator.tsx
@@ -80,7 +80,7 @@ export default function Simulator({ cases, options }: { cases: CaseFeature[]; op
       out.push({
         discount: d,
         uplift: Math.round(p.expected_uplift),
-        contribution: Math.round(p.expected_contribution),
+        contribution: Math.round(p.expected_uplift_contribution ?? 0),
       });
     }
     return out;
@@ -262,10 +262,18 @@ export default function Simulator({ cases, options }: { cases: CaseFeature[]; op
               <CountUp value={curUplift} format={won} />
             </Mini>
             <Mini
-              label="예상 공헌이익"
-              sub={pred.expected_contribution_rate != null ? `이익률 ${pct(pred.expected_contribution_rate)}` : undefined}
+              label="예상 공헌이익 (기여)"
+              sub={
+                pred.expected_total_contribution != null
+                  ? `전체 ${wonShort(pred.expected_total_contribution)}${pred.expected_contribution_rate != null ? ` · 이익률 ${pct(pred.expected_contribution_rate)}` : ""}`
+                  : "데이터 부족"
+              }
             >
-              <CountUp value={pred.expected_contribution} format={wonShort} />
+              {pred.expected_uplift_contribution != null ? (
+                <CountUp value={pred.expected_uplift_contribution} format={wonShort} />
+              ) : (
+                <span className="text-neutral-400">—</span>
+              )}
             </Mini>
             <Mini label="예상 범위">{`${wonShort(pred.low)}~${wonShort(pred.high)}`}</Mini>
           </div>
@@ -416,14 +424,14 @@ export default function Simulator({ cases, options }: { cases: CaseFeature[]; op
             <div className="mt-1 flex flex-wrap gap-x-5 gap-y-1 text-xs text-neutral-600">
               <span>배수 <strong className="text-neutral-900">{pred.lift_ratio != null ? `${pred.lift_ratio.toFixed(1)}배` : "—"}</strong></span>
               <span>증분 <strong className="text-neutral-900">{wonShort(pred.expected_uplift)}</strong></span>
-              <span>공헌이익 <strong className="text-neutral-900">{wonShort(pred.expected_contribution)}</strong></span>
+              <span>공헌이익(기여) <strong className="text-neutral-900">{wonShort(pred.expected_uplift_contribution ?? 0)}</strong></span>
             </div>
           </div>
 
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
             {scenarioRows.map(({ s, p }) => {
               const dUplift = diffPct(pred.expected_uplift, p.expected_uplift);
-              const dContrib = diffPct(pred.expected_contribution, p.expected_contribution);
+              const dContrib = diffPct(pred.expected_uplift_contribution ?? 0, p.expected_uplift_contribution ?? 0);
               return (
                 <div key={s.id} className="rounded-2xl bg-neutral-50 p-4">
                   <div className="flex items-start justify-between gap-1">
@@ -447,7 +455,7 @@ export default function Simulator({ cases, options }: { cases: CaseFeature[]; op
                   </div>
                   <div className="mt-2 space-y-1 text-xs text-neutral-500">
                     <CompareRow label="증분" value={wonShort(p.expected_uplift)} delta={dUplift} />
-                    <CompareRow label="공헌이익" value={wonShort(p.expected_contribution)} delta={dContrib} />
+                    <CompareRow label="공헌이익(기여)" value={wonShort(p.expected_uplift_contribution ?? 0)} delta={dContrib} />
                   </div>
                   <button
                     onClick={() => applyScenario(s)}

--- a/promo-analytics/lib/__tests__/predict.test.ts
+++ b/promo-analytics/lib/__tests__/predict.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { predict, type CaseFeature, type PredictionSpec } from "../predict";
+
+function mkCase(over: Partial<CaseFeature> = {}): CaseFeature {
+  return {
+    id: "c1",
+    name: "과거 캠페인",
+    start_date: "2026-01-01",
+    end_date: "2026-01-04",
+    promo_type: "할인",
+    season_tag: "여름",
+    discount_rate: 0.5,
+    duration_days: 4,
+    uplift_per_day: 500000,
+    total_uplift: 2000000,
+    contribution: 600000,
+    contribution_rate: 0.3,
+    halo_share: 0.2,
+    baseline_daily: 1000000,
+    actual_daily: 1500000,
+    qty_per_day: 100,
+    orders_per_day: 50,
+    purposes: [{ purpose: "세일즈", weight: 1 }],
+    ach_revenue: 1,
+    ach_contribution: 1,
+    has_confirmed_plan: true,
+    reliability: 1,
+    ...over,
+  };
+}
+
+const spec: PredictionSpec = {
+  promo_type: "할인",
+  season_tag: "여름",
+  discount_rate: 0.5,
+  duration_days: 4,
+};
+
+describe("predict — 공헌이익 증분/전체 분리", () => {
+  it("증분 공헌 = 증분일평균×일수×율, 전체 공헌 = 행사일평균×일수×율 (서로 다름)", () => {
+    const p = predict(spec, [mkCase()]);
+    // 증분 500k/일 × 4일 × 0.3 = 600,000
+    expect(p.expected_uplift_contribution).toBeCloseTo(600000, 0);
+    // 전체 (1.0M+0.5M)/일 × 4일 × 0.3 = 1,800,000
+    expect(p.expected_total_contribution).toBeCloseTo(1800000, 0);
+    // 둘은 명확히 다르다 (예전엔 전체를 증분처럼 표기하던 버그)
+    expect(p.expected_total_contribution!).toBeGreaterThan(p.expected_uplift_contribution!);
+  });
+
+  it("과거 공헌율이 전부 null이면 공헌이익은 0이 아니라 null('데이터 부족')", () => {
+    const p = predict(spec, [mkCase({ contribution_rate: null })]);
+    expect(p.expected_contribution_rate).toBeNull();
+    expect(p.expected_uplift_contribution).toBeNull();
+    expect(p.expected_total_contribution).toBeNull();
+  });
+
+  it("콜드스타트(유사 사례 없음)에서도 동일 규칙", () => {
+    // 전혀 다른 promo_type/season/discount → 유사도 낮아 콜드스타트 경로
+    const far = mkCase({ promo_type: "사은품", season_tag: "겨울", discount_rate: 0.0, duration_days: 30, contribution_rate: null });
+    const p = predict(spec, [far]);
+    expect(p.expected_total_contribution).toBeNull(); // cr null 보존
+  });
+});

--- a/promo-analytics/lib/predict.ts
+++ b/promo-analytics/lib/predict.ts
@@ -46,7 +46,8 @@ export type Prediction = {
   expected_promo_daily: number; // 행사 일평균(예상)
   lift_ratio: number | null; // 평소 대비 배수
   expected_contribution_rate: number | null; // 예상 공헌이익률
-  expected_contribution: number; // 예상 공헌이익(기간)
+  expected_uplift_contribution: number | null; // 증분(기여) 공헌이익 = 증분일평균×일수×율
+  expected_total_contribution: number | null; // 전체 예상 공헌이익 = 행사일평균×일수×율 (baseline 포함)
   confidence: "높음" | "보통" | "낮음";
   confidence_score: number; // 0~1
   comparables: Comparable[];
@@ -95,6 +96,20 @@ function wavg(items: Comparable[], pick: (c: Comparable) => number | null): numb
     w += cw;
   }
   return w > 0 ? s / w : 0;
+}
+
+// null 보존 가중평균 — 유효값이 하나도 없으면 0이 아니라 null('데이터 부족')을 반환.
+function wavgN(items: Comparable[], pick: (c: Comparable) => number | null): number | null {
+  let s = 0, w = 0, any = false;
+  for (const c of items) {
+    const v = pick(c);
+    if (v == null) continue;
+    any = true;
+    const cw = caseWeight(c);
+    s += v * cw;
+    w += cw;
+  }
+  return any && w > 0 ? s / w : null;
 }
 
 // 두 케이스/스펙의 유사도 (0~1)
@@ -153,7 +168,11 @@ export function predict(spec: PredictionSpec, cases: CaseFeature[]): Prediction 
     const avgPerDay = mean((c) => c.uplift_per_day);
     const baseDaily = mean((c) => c.baseline_daily);
     const promoDaily = baseDaily + avgPerDay;
-    const cr = mean((c) => c.contribution_rate);
+    // 공헌율은 null 보존 — 유효 사례가 없으면 '데이터 부족'(null)
+    const crVals = valid
+      .map((c) => c.contribution_rate)
+      .filter((x): x is number => x != null);
+    const cr = crVals.length ? crVals.reduce((a, b) => a + b, 0) / crVals.length : null;
     const expected = avgPerDay * spec.duration_days;
     return {
       expected_uplift: expected,
@@ -163,8 +182,9 @@ export function predict(spec: PredictionSpec, cases: CaseFeature[]): Prediction 
       expected_baseline_daily: baseDaily,
       expected_promo_daily: promoDaily,
       lift_ratio: baseDaily > 0 ? promoDaily / baseDaily : null,
-      expected_contribution_rate: cr || null,
-      expected_contribution: promoDaily * spec.duration_days * cr,
+      expected_contribution_rate: cr,
+      expected_uplift_contribution: cr != null ? avgPerDay * spec.duration_days * cr : null,
+      expected_total_contribution: cr != null ? promoDaily * spec.duration_days * cr : null,
       confidence: "낮음",
       confidence_score: 0.2,
       comparables: [],
@@ -201,7 +221,7 @@ export function predict(spec: PredictionSpec, cases: CaseFeature[]): Prediction 
 
   const baseDaily = wavg(top, (c) => c.baseline_daily);
   const promoDaily = baseDaily + perDay;
-  const cr = wavg(top, (c) => c.contribution_rate);
+  const cr = wavgN(top, (c) => c.contribution_rate);
 
   return {
     expected_uplift: expected,
@@ -211,8 +231,9 @@ export function predict(spec: PredictionSpec, cases: CaseFeature[]): Prediction 
     expected_baseline_daily: baseDaily,
     expected_promo_daily: promoDaily,
     lift_ratio: baseDaily > 0 ? promoDaily / baseDaily : null,
-    expected_contribution_rate: cr || null,
-    expected_contribution: promoDaily * spec.duration_days * cr,
+    expected_contribution_rate: cr,
+    expected_uplift_contribution: cr != null ? perDay * spec.duration_days * cr : null,
+    expected_total_contribution: cr != null ? promoDaily * spec.duration_days * cr : null,
     confidence,
     confidence_score: cScore,
     comparables: top,


### PR DESCRIPTION
## 재설계 Phase 3-C1 — 예측 계산식 정정 (감사 기반)

IA 재편 전, 감사에서 발견한 **계산식 결함**을 먼저 못박습니다.

### 정정
- **라벨 오류 (치명)**: `expected_contribution`이 실제로는 `(baseline+증분)×일수×율 = 전체`인데 UI엔 **증분 공헌처럼** 표기돼 수배 과대. → **`expected_uplift_contribution`(증분)**·**`expected_total_contribution`(전체)** 로 분리, 양쪽 명확 표기.
- **null 은폐**: 과거 공헌율이 전부 없으면 `wavg`가 0을 반환 → `₩0`(이익 0)으로 오인. → **`wavgN`(null 보존)** 으로 교체, `cr` 없으면 공헌이익 **null('데이터 부족')**.
- **Simulator**: 공헌이익(기여)을 주값, **전체는 보조** 표기. 할인율 곡선·시나리오 비교도 증분 기준.

### 검증
`predict.test` 3케이스 신규(증분≠전체, null 보존, 콜드스타트), 전체 **54 통과**. `tsc`·`build` OK.

> Phase 3 C1/완료. 다음: **C2 엔진 융합**(시뮬레이터+추천 단일화, 추천 경로의 동일 결함·목적무시 정정) → **C3 작성화면 임베드 + 메타 솎기** → **IA 정리**(캠페인 통합·대시보드 슬림·메타편집 폐기).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_