### PR TITLE
재설계 Phase 3-IA: 사이드바 슬림화 + 캠페인 허브

### DIFF
--- a/promo-analytics/app/(dash)/AppShell.tsx
+++ b/promo-analytics/app/(dash)/AppShell.tsx
@@ -7,10 +7,7 @@ import CommandPalette from "./CommandPalette";
 
 const NAV = [
   { href: "/", label: "대시보드", icon: "M3.5 12l8.5-8 8.5 8M5.5 10.5V19a1 1 0 001 1h3.5v-5h3v5H18a1 1 0 001-1v-8.5" },
-  { href: "/predict", label: "성과 시뮬레이터", icon: "M4 18l5-5 3 3 7-8M21 8v4m0-4h-4" },
-  { href: "/prescribe", label: "캠페인 추천", icon: "M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 104 0M9 5a2 2 0 014 0m-3 8l2 2 3-4" },
-  { href: "/plans", label: "플랜 보드", icon: "M9 4h6a1 1 0 011 1v1H8V5a1 1 0 011-1zM6 7h12a1 1 0 011 1v11a1 1 0 01-1 1H6a1 1 0 01-1-1V8a1 1 0 011-1zm3 4h6m-6 4h4" },
-  { href: "/library", label: "히스토리 비교/분석", icon: "M4 7h16M4 12h16M4 17h10" },
+  { href: "/plans", label: "캠페인", icon: "M9 4h6a1 1 0 011 1v1H8V5a1 1 0 011-1zM6 7h12a1 1 0 011 1v11a1 1 0 01-1 1H6a1 1 0 01-1-1V8a1 1 0 011-1zm3 4h6m-6 4h4" },
   { href: "/upload", label: "데이터 업로드", icon: "M12 16V4m0 0l-4 4m4-4l4 4M5 20h14" },
   { href: "/settings", label: "설정", icon: "M10.3 4.3a1 1 0 011.4 0l.7.7a1 1 0 00.9.3l1-.2a1 1 0 011.2.9l.1 1a1 1 0 00.6.8l.9.4a1 1 0 01.5 1.3l-.4.9a1 1 0 000 .9l.4.9a1 1 0 01-.5 1.3l-.9.4a1 1 0 00-.6.8l-.1 1a1 1 0 01-1.2.9l-1-.2a1 1 0 00-.9.3l-.7.7a1 1 0 01-1.4 0M12 9a3 3 0 100 6 3 3 0 000-6z" },
 ];

--- a/promo-analytics/app/(dash)/plans/page.tsx
+++ b/promo-analytics/app/(dash)/plans/page.tsx
@@ -1,9 +1,17 @@
+import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 import PlansBoard, { type PlanRow, type PlanOption } from "./PlansBoard";
 
 export const dynamic = "force-dynamic";
 
 type PlansBundle = { plans: PlanRow[]; options: PlanOption[] };
+
+// 캠페인 허브 — 리스트(플랜 보드) + 새 캠페인 + 히스토리·예측·추천 진입을 한곳에 모음.
+const SUB = [
+  { href: "/library", label: "히스토리 분석" },
+  { href: "/predict", label: "성과 예측" },
+  { href: "/prescribe", label: "캠페인 추천" },
+];
 
 export default async function PlansPage() {
   const supabase = await createClient();
@@ -13,11 +21,33 @@ export default async function PlansPage() {
 
   return (
     <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
-      <h1 className="text-xl font-semibold">플랜 보드</h1>
-      <p className="mt-1 text-sm text-neutral-500">
-        실적과 분리된 캠페인 플랜 전체를 모아 보고, 우리 팀의 계획 성향을 분석합니다.
-        플랜은 ⑤ 가이드 시트 업로드로 쌓입니다.
-      </p>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold text-ink">캠페인</h1>
+          <p className="mt-1 text-sm text-ink-3">
+            캠페인 플랜 전체를 모아 보고 계획 성향을 분석합니다. 새 캠페인은 여기서 만듭니다.
+          </p>
+        </div>
+        <Link
+          href="/campaigns/new"
+          className="shrink-0 rounded-full bg-brand-500 px-5 py-2.5 text-sm font-semibold text-white shadow-soft transition duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-0.5 hover:bg-brand-600 hover:shadow-float"
+        >
+          + 새 캠페인
+        </Link>
+      </div>
+
+      <nav className="mt-4 flex flex-wrap gap-1.5">
+        {SUB.map((s) => (
+          <Link
+            key={s.href}
+            href={s.href}
+            className="rounded-full border border-line bg-card px-3.5 py-1.5 text-xs font-medium text-ink-3 transition hover:text-ink hover:shadow-soft"
+          >
+            {s.label} →
+          </Link>
+        ))}
+      </nav>
+
       <div className="mt-6">
         <PlansBoard plans={plans} options={options} />
       </div>


### PR DESCRIPTION
## 재설계 Phase 3-IA — 사이드바 슬림화 + 캠페인 허브 통합

흩어진 메뉴를 **'캠페인'** 으로 모음(기능 유지, 위치만 이동).

### 변경
- **사이드바 4개로 슬림화**: 대시보드 · **캠페인** · 데이터 업로드 · 설정. (성과 시뮬레이터·캠페인 추천·히스토리·플랜보드를 개별 항목에서 제거)
- **`/plans` = '캠페인' 허브**: `+ 새 캠페인` 버튼 + 히스토리/성과예측/추천 **보조 링크**. 낡은 안내문구('⑤ 가이드로만 쌓임') 정정.
- **기능 삭제 없음** — `/predict`·`/prescribe`·`/library` 라우트 유지, 접근성 보존.

### 검증
`tsc`·`build` 통과.

> 후속(측정 영향 있어 신중 진행): 메타·메인 편집 페이지 폐기 + 메인상품을 플랜 '메인'으로 일원화 · 예측/추천 단일엔진 UI · 대시보드 슬림 · Phase 4 서브상품 자동 예측.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_