### PR TITLE
재설계 Phase 4: 서브상품 자동 예측 (벤치마크 추천)

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
@@ -16,6 +16,7 @@ import { won, pct, num } from "@/lib/format";
 import { validatePlan } from "@/lib/plan-validation";
 import { InlineAlert, Dialog, DialogContent, DialogHeader, DialogFooter, Button } from "@/components/ui";
 import PlanTemplatePanel from "./PlanTemplatePanel";
+import SubProductSuggest, { type Bench } from "./SubProductSuggest";
 
 export type EditorItem = {
   product_id: string;
@@ -216,6 +217,33 @@ export default function PlanEditor({
         is_main: false,
         match_patterns: [],
         items: [],
+      },
+    ]);
+  };
+  // Phase 4 — 벤치마크 추천 서브상품을 옵션단가·예상수량·원가 prefilled로 한 번에 추가
+  const addSubOption = (b: Bench) => {
+    setDirty(true);
+    setOptions((prev) => [
+      ...prev,
+      {
+        key: uid(),
+        option_label: b.base_name,
+        expected_option_qty: Math.round(b.avg_qty) || 0,
+        is_main: false,
+        match_patterns: [],
+        items: [
+          {
+            key: uid(),
+            product_id: b.product_id,
+            base_name: b.base_name,
+            sku_qty_per_option: 1,
+            unit_sale_price: Math.round(b.avg_unit_price) || 0,
+            source_config_id: null,
+            consumer_price: b.consumer_price,
+            regular_price: b.regular_price,
+            cost: b.cost,
+          },
+        ],
       },
     ]);
   };
@@ -493,13 +521,19 @@ export default function PlanEditor({
       </div>
 
       {!confirmed && (
-        <button
-          onClick={addOption}
-          disabled={busy}
-          className="mt-4 rounded-xl border border-dashed border-neutral-300 px-4 py-2 text-sm font-medium text-neutral-600 hover:bg-neutral-50 disabled:opacity-50"
-        >
-          + 옵션 추가
-        </button>
+        <>
+          <SubProductSuggest
+            existingProductIds={options.flatMap((o) => o.items.map((it) => it.product_id))}
+            onAdd={addSubOption}
+          />
+          <button
+            onClick={addOption}
+            disabled={busy}
+            className="mt-4 rounded-xl border border-dashed border-neutral-300 px-4 py-2 text-sm font-medium text-neutral-600 hover:bg-neutral-50 disabled:opacity-50"
+          >
+            + 빈 옵션 추가
+          </button>
+        </>
       )}
 
       {/* SKU 단위 예상 수량 롤업 */}

--- a/promo-analytics/app/(dash)/promotions/[id]/plan/SubProductSuggest.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/SubProductSuggest.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { won, pct } from "@/lib/format";
+
+// Phase 4 — 서브상품 자동 예측. 과거 캠페인 벤치마크(자주/최근 판매)로 옵션단가·예상수량·
+// 원가를 prefilled한 서브 옵션을 한 번에 추가 → 노가다 제거.
+export type Bench = {
+  product_id: string;
+  base_name: string;
+  category: string | null;
+  campaigns: number;
+  avg_qty: number;
+  avg_unit_price: number;
+  consumer_price: number | null;
+  regular_price: number | null;
+  cost: number | null;
+  avg_discount: number | null;
+};
+
+export default function SubProductSuggest({
+  existingProductIds,
+  onAdd,
+}: {
+  existingProductIds: string[];
+  onAdd: (b: Bench) => void;
+}) {
+  const [rows, setRows] = useState<Bench[] | null>(null);
+  const [recent, setRecent] = useState(false);
+  const [open, setOpen] = useState(false);
+  const existing = useMemo(() => new Set(existingProductIds), [existingProductIds]);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      const supabase = createClient();
+      const { data } = await supabase.rpc("sub_product_benchmarks", {
+        p_months: recent ? 3 : null,
+        p_category: null,
+        p_exclude_skeys: null,
+      });
+      if (alive) setRows((data as Bench[]) ?? []);
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [recent]);
+
+  const list = (rows ?? []).filter((r) => !existing.has(r.product_id)).slice(0, 10);
+
+  return (
+    <div className="mt-4 rounded-2xl card-soft p-5">
+      <button type="button" onClick={() => setOpen((o) => !o)} className="flex w-full items-center justify-between">
+        <span className="text-sm font-semibold text-ink-2">
+          서브 상품 추천 <span className="font-normal text-ink-4">· 과거 캠페인 자주 판매</span>
+        </span>
+        <span className="text-ink-4">{open ? "▲" : "▼"}</span>
+      </button>
+      {open && (
+        <>
+          <div className="mt-2 flex items-center justify-between">
+            <p className="text-xs text-ink-4">
+              누르면 평균 단가·예상수량·원가가 채워진 서브 옵션이 추가됩니다. 가격·수량은 수정하세요.
+            </p>
+            <label className="flex shrink-0 items-center gap-1.5 text-[11px] text-ink-3">
+              <input type="checkbox" checked={recent} onChange={(e) => setRecent(e.target.checked)} />
+              최근 3개월만
+            </label>
+          </div>
+          {rows == null ? (
+            <p className="mt-3 text-xs text-ink-4">불러오는 중…</p>
+          ) : list.length === 0 ? (
+            <p className="mt-3 text-xs text-ink-4">추천할 서브 상품이 없습니다(이미 모두 추가됨).</p>
+          ) : (
+            <ul className="mt-3 grid gap-2 sm:grid-cols-2">
+              {list.map((r) => (
+                <li key={r.product_id}>
+                  <button
+                    type="button"
+                    onClick={() => onAdd(r)}
+                    className="flex w-full items-start justify-between gap-2 rounded-xl border border-line bg-card p-3 text-left transition hover:border-brand-300 hover:bg-brand-50/50"
+                  >
+                    <span className="min-w-0">
+                      <span className="block truncate text-sm font-medium text-ink">{r.base_name}</span>
+                      <span className="mt-0.5 block text-[11px] text-ink-4">
+                        {r.campaigns}회 등장 · 평균 {Math.round(r.avg_qty)}개 · 단가 {won(r.avg_unit_price)}
+                        {r.avg_discount != null ? ` · 할인 ${pct(r.avg_discount)}` : ""}
+                      </span>
+                    </span>
+                    <span className="shrink-0 text-[11px] font-semibold text-brand-600">+ 추가</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/promo-analytics/supabase/migrations/0048_sub_product_benchmarks.sql
+++ b/promo-analytics/supabase/migrations/0048_sub_product_benchmarks.sql
@@ -1,0 +1,79 @@
+-- 0048: 서브상품 자동 예측 벤치마크 (재설계 Phase 4)
+--
+-- 과거 캠페인 실적옵션을 집계해 '자주/최근 함께 판매된 상품'을 옵션단가·할인율·예상수량·
+-- 원가와 함께 추천 → 플랜 작성 시 서브상품을 한 번에 채워 노가다를 줄인다.
+-- 데이터 현실: products.category가 16%만 채워져 카테고리 매칭이 약함 → 빈도 기반을 1차로,
+-- 카테고리/최근N개월은 선택 필터. 구독 옵션 제외.
+--   p_months   : null=전 기간, N=최근 N개월
+--   p_category : null=전체, 값=해당 카테고리만
+--   p_exclude_skeys : 이미 플랜에 담은 정규화 SKU키 제외(옵션)
+
+drop function if exists promo.sub_product_benchmarks(int, text, text[]);
+
+create function promo.sub_product_benchmarks(
+  p_months int default null,
+  p_category text default null,
+  p_exclude_skeys text[] default null
+)
+returns table(
+  product_id uuid,
+  base_name text,
+  category text,
+  campaigns int,
+  avg_qty numeric,          -- 등장 캠페인당 평균 판매수량
+  avg_unit_price numeric,   -- 평균 단가(매출/수량)
+  consumer_price numeric,
+  regular_price numeric,
+  cost numeric,
+  avg_discount numeric,     -- 소비자가 대비 평균 할인율(0~1)
+  total_revenue numeric
+)
+language sql stable security definer set search_path = ''
+as $$
+  with opt as (
+    select o.label, o.revenue, o.quantity, o.promotion_id
+    from promo.promotion_sale_options o
+    join promo.promotions p on p.id = o.promotion_id
+    where not o.is_subscription and o.quantity > 0
+      and (p_months is null or p.start_date >= (current_date - make_interval(months => p_months)))
+  ),
+  keyed as (
+    select promo.normalize_sku_name(label) as skey, revenue, quantity, promotion_id from opt
+  ),
+  agg as (
+    select skey,
+      count(distinct promotion_id) as campaigns,
+      sum(quantity) as total_qty,
+      sum(revenue) as total_revenue
+    from keyed
+    group by skey
+  ),
+  prod as (
+    select promo.normalize_sku_name(base_name) as skey,
+      (array_agg(id order by coalesce(consumer_price,0) desc))[1] as product_id,
+      (array_agg(base_name order by coalesce(consumer_price,0) desc))[1] as base_name,
+      (array_agg(category order by coalesce(consumer_price,0) desc nulls last))[1] as category,
+      max(consumer_price) as consumer_price,
+      max(regular_price) as regular_price,
+      max(cost) as cost
+    from promo.products
+    group by 1
+  )
+  select pr.product_id, pr.base_name, pr.category,
+    a.campaigns::int,
+    round(a.total_qty / nullif(a.campaigns,0), 1) as avg_qty,
+    round(a.total_revenue / nullif(a.total_qty,0)) as avg_unit_price,
+    pr.consumer_price, pr.regular_price, pr.cost,
+    case when pr.consumer_price > 0
+         then round(1 - (a.total_revenue / nullif(a.total_qty,0)) / pr.consumer_price, 3)
+         else null end as avg_discount,
+    a.total_revenue
+  from agg a
+  join prod pr on pr.skey = a.skey
+  where (p_category is null or pr.category = p_category)
+    and (p_exclude_skeys is null or a.skey <> all(p_exclude_skeys))
+  order by a.campaigns desc, a.total_revenue desc;
+$$;
+
+grant execute on all functions in schema promo to authenticated;
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## 재설계 Phase 4 — 서브상품 자동 예측

피드백: "메인 외 서브 상품을 노가다로 다 추가해야 하는 문제" 해소. 과거 캠페인 벤치마크로 서브 옵션을 **prefilled 한 번에 추가**.

### 변경
- **0048 `sub_product_benchmarks(p_months, p_category, p_exclude)` RPC**(prod 적용·검증): 실적옵션(구독 제외)을 정규화 SKU로 집계 → 등장 캠페인수·평균 판매수량·평균 단가·할인율·**원가·상시가** 반환.
  - 실데이터 검증: 마스터 8.3kg **18캠페인·평균 1,027개·단가 19,420(할인 57.7%)** 등 합리적.
  - 카테고리가 16%만 채워져 **빈도 기반을 1차**로, 카테고리/최근 N개월은 선택 필터.
- **SubProductSuggest** 패널: 추천 목록(자주 판매 / 최근 3개월 토글) → 누르면 **옵션단가·예상수량·원가**가 채워진 서브 옵션 추가. 총매출·공헌은 라이브 합계로 즉시 반영(시뮬레이션).
- **PlanEditor**: draft에 패널 노출 + `addSubOption`. 이미 담은 상품은 추천에서 제외.

### 검증
prod RPC 적용·실데이터 검증, `tsc`·**54 테스트**·`build` 통과.

> 데이터 메모: `products.category`가 16%만 채워져 카테고리 매칭은 추후 카테고리 보강 시 강화됨(현재는 빈도 기반으로 충분히 유용).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_