### PR TITLE
플랜 Excel 내보내기 (로드맵 3.1)

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
@@ -17,6 +17,7 @@ import { validatePlan } from "@/lib/plan-validation";
 import { InlineAlert, Dialog, DialogContent, DialogHeader, DialogFooter, Button } from "@/components/ui";
 import PlanTemplatePanel from "./PlanTemplatePanel";
 import SubProductSuggest, { type Bench } from "./SubProductSuggest";
+import { downloadPlanXlsx, type ExportOption } from "@/lib/plan-export";
 
 export type EditorItem = {
   product_id: string;
@@ -344,6 +345,41 @@ export default function PlanEditor({
     setBusy(false);
   }
 
+  function exportXlsx() {
+    const exOptions: ExportOption[] = options.map((o, i) => {
+      const t = optionResults[i];
+      return {
+        label: o.option_label || `옵션 ${i + 1}`,
+        is_main: o.is_main,
+        expected_option_qty: o.expected_option_qty,
+        net_price: t.net_price,
+        discount_rate_consumer: t.discount_rate_consumer_net ?? t.discount_rate_consumer,
+        expected_revenue: t.expected_revenue,
+        expected_contribution: t.expected_contribution,
+        items: o.items.map((it) => ({
+          base_name: it.base_name,
+          sku_qty: it.sku_qty_per_option,
+          unit_price: it.unit_sale_price,
+          cost: it.cost,
+          consumer_price: it.consumer_price,
+        })),
+      };
+    });
+    downloadPlanXlsx(
+      `plan-v${plan!.version}.xlsx`,
+      `플랜 v${plan!.version}`,
+      exOptions,
+      {
+        revenue: planTotals.expected_revenue_total,
+        order_count: expOrderCount,
+        sku_units: expSkuUnits,
+        contribution: planTotals.expected_contribution_total,
+        contribution_rate: contribRate,
+      },
+      couponSpec ? { min: coupon.min, ratePct: coupon.ratePct, max: coupon.max } : null,
+    );
+  }
+
   async function onClone() {
     setBusy(true);
     setMsg(null);
@@ -563,6 +599,14 @@ export default function PlanEditor({
 
       {/* 액션 */}
       <div className="mt-6 flex flex-wrap gap-2">
+        <button
+          onClick={exportXlsx}
+          disabled={options.length === 0}
+          className="rounded-xl border border-line px-4 py-2 text-sm font-medium text-ink-2 hover:bg-soft disabled:opacity-50"
+          title="현재 플랜을 Excel로 내려받기"
+        >
+          ⬇ Excel 내보내기
+        </button>
         {confirmed ? (
           <button
             onClick={onClone}

--- a/promo-analytics/lib/__tests__/plan-export.test.ts
+++ b/promo-analytics/lib/__tests__/plan-export.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import * as XLSX from "xlsx";
+import { buildPlanWorkbook, type ExportOption, type ExportSummary } from "../plan-export";
+
+const options: ExportOption[] = [
+  {
+    label: "모래 4묶음 세트",
+    is_main: true,
+    expected_option_qty: 400,
+    net_price: 63500,
+    discount_rate_consumer: 0.458,
+    expected_revenue: 24130000,
+    expected_contribution: 7431563,
+    items: [
+      { base_name: "퓨저나이트 슈퍼볼 4.3kg", sku_qty: 4, unit_price: 10900, cost: 8000, consumer_price: 21800 },
+      { base_name: "바이바이배드 500ml", sku_qty: 1, unit_price: 19900, cost: 9000, consumer_price: 30000 },
+    ],
+  },
+];
+const summary: ExportSummary = {
+  revenue: 24130000,
+  order_count: 400,
+  sku_units: 2000,
+  contribution: 7431563,
+  contribution_rate: 0.308,
+};
+
+describe("buildPlanWorkbook", () => {
+  const wb = buildPlanWorkbook("슈퍼클린", options, summary, { min: 50000, ratePct: 5, max: 5000 });
+  // 워크북을 바이너리로 쓰고 다시 읽어 셀을 검증(왕복)
+  const out = XLSX.write(wb, { type: "array", bookType: "xlsx" });
+  const buf = (out instanceof Uint8Array ? out.buffer : out) as ArrayBuffer;
+  const rb = XLSX.read(buf, { type: "array" });
+
+  it("요약·플랜 시트가 있다", () => {
+    expect(rb.SheetNames).toContain("요약");
+    expect(rb.SheetNames).toContain("플랜");
+  });
+
+  it("플랜 시트: 옵션 첫 행에 옵션단가·예상매출, SKU 행에 단가/원가", () => {
+    const aoa = XLSX.utils.sheet_to_json(rb.Sheets["플랜"], { header: 1 }) as (string | number)[][];
+    expect(aoa[0]).toContain("옵션단가");
+    // 첫 데이터 행(옵션 첫 SKU) — 옵션명·옵션단가·예상매출 채워짐
+    const r1 = aoa[1];
+    expect(r1[0]).toBe("모래 4묶음 세트");
+    expect(r1[3]).toBe("퓨저나이트 슈퍼볼 4.3kg");
+    expect(r1[8]).toBe(63500); // 옵션단가
+    expect(r1[10]).toBe(24130000); // 예상매출
+    // 둘째 SKU 행 — 옵션 레벨은 비고 SKU 값만
+    const r2 = aoa[2];
+    expect(r2[0]).toBe("");
+    expect(r2[3]).toBe("바이바이배드 500ml");
+    expect(r2[5]).toBe(19900); // 단가
+  });
+
+  it("요약 시트: 구매건수·판매수량·공헌률·쿠폰", () => {
+    const aoa = XLSX.utils.sheet_to_json(rb.Sheets["요약"], { header: 1 }) as (string | number)[][];
+    const map = new Map(aoa.map((r) => [r[0], r[1]]));
+    expect(map.get("구매건수(세트)")).toBe(400);
+    expect(map.get("판매수량(SKU)")).toBe(2000);
+    expect(map.get("공헌이익률(%)")).toBe(30.8);
+    expect(map.get("쿠폰 할인율(%)")).toBe(5);
+  });
+});

--- a/promo-analytics/lib/plan-export.ts
+++ b/promo-analytics/lib/plan-export.ts
@@ -1,0 +1,114 @@
+import * as XLSX from "xlsx";
+
+// 플랜 Excel 내보내기 (로드맵 3.1). 순수 빌더(buildPlanWorkbook)는 테스트 대상,
+// downloadPlanXlsx는 브라우저 다운로드 래퍼. 1차는 값 기반(어긋남 0) — 라이브 수식·
+// SKU마스터 XLOOKUP·가져오기 왕복은 후속.
+
+export type ExportItem = {
+  base_name: string;
+  sku_qty: number;
+  unit_price: number;
+  cost: number | null;
+  consumer_price: number | null;
+};
+export type ExportOption = {
+  label: string;
+  is_main: boolean;
+  expected_option_qty: number;
+  net_price: number; // 쿠폰 적용 후 옵션 단가
+  discount_rate_consumer: number | null;
+  expected_revenue: number;
+  expected_contribution: number;
+  items: ExportItem[];
+};
+export type ExportSummary = {
+  revenue: number;
+  order_count: number; // 구매건수(세트)
+  sku_units: number; // 판매수량(SKU)
+  contribution: number;
+  contribution_rate: number | null;
+};
+export type ExportCoupon = { min: number; ratePct: number; max: number } | null;
+
+const PLAN_HEADER = [
+  "옵션명",
+  "메인",
+  "예상세트수",
+  "SKU",
+  "세트당수량",
+  "단가",
+  "원가",
+  "소비자가",
+  "옵션단가",
+  "할인율(%)",
+  "예상매출",
+  "예상공헌",
+];
+
+/** 플랜 데이터 → 워크북 (플랜·요약 시트). 값 기반이라 다시 올려도 어긋남이 없다. */
+export function buildPlanWorkbook(
+  title: string,
+  options: ExportOption[],
+  summary: ExportSummary,
+  coupon: ExportCoupon,
+): XLSX.WorkBook {
+  // 플랜 시트 — 옵션×SKU 한 행. 옵션 레벨 값은 옵션 첫 행에만 채워 가독성↑(가져오기 시 직전 값 상속).
+  const rows: (string | number)[][] = [PLAN_HEADER];
+  for (const o of options) {
+    const disc = o.discount_rate_consumer != null ? +(o.discount_rate_consumer * 100).toFixed(1) : "";
+    o.items.forEach((it, i) => {
+      rows.push([
+        i === 0 ? o.label : "",
+        i === 0 ? (o.is_main ? "Y" : "") : "",
+        i === 0 ? o.expected_option_qty : "",
+        it.base_name,
+        it.sku_qty,
+        it.unit_price,
+        it.cost ?? "",
+        it.consumer_price ?? "",
+        i === 0 ? Math.round(o.net_price) : "",
+        i === 0 ? disc : "",
+        i === 0 ? Math.round(o.expected_revenue) : "",
+        i === 0 ? Math.round(o.expected_contribution) : "",
+      ]);
+    });
+    if (o.items.length === 0) {
+      rows.push([o.label, o.is_main ? "Y" : "", o.expected_option_qty, "", "", "", "", "", Math.round(o.net_price), "", Math.round(o.expected_revenue), Math.round(o.expected_contribution)]);
+    }
+  }
+  const planWs = XLSX.utils.aoa_to_sheet(rows);
+
+  // 요약 시트
+  const sum: (string | number)[][] = [
+    ["항목", "값"],
+    ["캠페인", title],
+    ["예상 매출액", Math.round(summary.revenue)],
+    ["구매건수(세트)", summary.order_count],
+    ["판매수량(SKU)", summary.sku_units],
+    ["예상 공헌이익액", Math.round(summary.contribution)],
+    ["공헌이익률(%)", summary.contribution_rate != null ? +(summary.contribution_rate * 100).toFixed(1) : ""],
+  ];
+  if (coupon && coupon.ratePct > 0) {
+    sum.push(["쿠폰 기준액(원 이상)", coupon.min]);
+    sum.push(["쿠폰 할인율(%)", coupon.ratePct]);
+    sum.push(["쿠폰 최대할인(원)", coupon.max]);
+  }
+  const sumWs = XLSX.utils.aoa_to_sheet(sum);
+
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, sumWs, "요약");
+  XLSX.utils.book_append_sheet(wb, planWs, "플랜");
+  return wb;
+}
+
+/** 브라우저에서 xlsx 다운로드 트리거 */
+export function downloadPlanXlsx(
+  filename: string,
+  title: string,
+  options: ExportOption[],
+  summary: ExportSummary,
+  coupon: ExportCoupon,
+): void {
+  const wb = buildPlanWorkbook(title, options, summary, coupon);
+  XLSX.writeFile(wb, filename);
+}


### PR DESCRIPTION
## 플랜 Excel 내보내기 (로드맵 3.1)

완성된 플랜을 **xlsx로 내려받기** — MD가 오프라인에서 검토/공유. 값 기반이라 어긋남 0(가져오기 왕복의 토대).

### 변경
- **`lib/plan-export.ts`**: `buildPlanWorkbook`(순수·테스트 대상) + `downloadPlanXlsx`(브라우저 다운로드).
  - **플랜 시트**: 옵션×SKU — 옵션단가·할인율·예상매출/공헌 + SKU 수량·단가·원가·소비자가.
  - **요약 시트**: 예상매출/구매건수(세트)/판매수량(SKU)/공헌이익·률 + 쿠폰.
- **PlanEditor**: `⬇ Excel 내보내기` 버튼(옵션 단가 구동 값 그대로).

### 검증
**왕복 테스트 3건**(xlsx write→read로 셀 내용 확인), 전체 **57 통과**, `tsc`·`build` OK.

> 후속(로드맵 3.2~): 라이브 수식 · SKU마스터 XLOOKUP · **Excel 가져오기**(템플릿 → 플랜 자동 생성) 왕복.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_