### PR TITLE
플랜 Excel 내보내기 — 파일명 + 목적·쿠폰·캠페인명 보강

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
@@ -88,6 +88,9 @@ export default function PlanEditor({
   rateCard,
   qtyHint,
   purposes,
+  campaignName,
+  startDate,
+  endDate,
 }: {
   promotionId: string;
   plan: CampaignPlan | null;
@@ -95,6 +98,9 @@ export default function PlanEditor({
   rateCard: RateCard | null;
   qtyHint?: QtyHint;
   purposes?: string[];
+  campaignName?: string;
+  startDate?: string;
+  endDate?: string;
 }) {
   const router = useRouter();
   const [options, setOptions] = useState<OptState[]>(() => toState(initialOptions));
@@ -366,8 +372,12 @@ export default function PlanEditor({
       };
     });
     downloadPlanXlsx(
-      `plan-v${plan!.version}.xlsx`,
-      `플랜 v${plan!.version}`,
+      {
+        campaign: campaignName || `플랜 v${plan!.version}`,
+        period: startDate && endDate ? `${startDate} ~ ${endDate}` : "",
+        version: `v${plan!.version}`,
+        purposes: purposes ?? [],
+      },
       exOptions,
       {
         revenue: planTotals.expected_revenue_total,

--- a/promo-analytics/app/(dash)/promotions/[id]/plan/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/page.tsx
@@ -182,6 +182,9 @@ export default async function PlanPage({
         rateCard={(rc as RateCard) ?? null}
         qtyHint={qtyHint}
         purposes={(promo.purposes as string[] | null) ?? []}
+        campaignName={promo.name as string}
+        startDate={promo.start_date as string}
+        endDate={promo.end_date as string}
       />
 
       {plan && (

--- a/promo-analytics/lib/__tests__/plan-export.test.ts
+++ b/promo-analytics/lib/__tests__/plan-export.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from "vitest";
 import * as XLSX from "xlsx";
-import { buildPlanWorkbook, type ExportOption, type ExportSummary } from "../plan-export";
+import { buildPlanWorkbook, planFileName, type ExportOption, type ExportSummary } from "../plan-export";
+
+const meta = {
+  campaign: "[BETTER HABITS] 활력을 키우는 습관 — 가격 가이드(플랜)",
+  period: "2026-06-08 ~ 2026-06-14",
+  version: "v2",
+  purposes: ["세일즈", "브랜딩"],
+};
 
 const options: ExportOption[] = [
   {
@@ -26,7 +33,7 @@ const summary: ExportSummary = {
 };
 
 describe("buildPlanWorkbook", () => {
-  const wb = buildPlanWorkbook("슈퍼클린", options, summary, { min: 50000, ratePct: 5, max: 5000 });
+  const wb = buildPlanWorkbook(meta, options, summary, { min: 50000, ratePct: 5, max: 5000 });
   // 워크북을 바이너리로 쓰고 다시 읽어 셀을 검증(왕복)
   const out = XLSX.write(wb, { type: "array", bookType: "xlsx" });
   const buf = (out instanceof Uint8Array ? out.buffer : out) as ArrayBuffer;
@@ -53,12 +60,31 @@ describe("buildPlanWorkbook", () => {
     expect(r2[5]).toBe(19900); // 단가
   });
 
-  it("요약 시트: 구매건수·판매수량·공헌률·쿠폰", () => {
+  it("요약 시트: 캠페인·기간·목적·지표·쿠폰 모두 포함", () => {
     const aoa = XLSX.utils.sheet_to_json(rb.Sheets["요약"], { header: 1 }) as (string | number)[][];
     const map = new Map(aoa.map((r) => [r[0], r[1]]));
+    expect(map.get("캠페인")).toBe(meta.campaign);
+    expect(map.get("기간")).toBe("2026-06-08 ~ 2026-06-14");
+    expect(map.get("목적")).toBe("세일즈, 브랜딩");
     expect(map.get("구매건수(세트)")).toBe(400);
     expect(map.get("판매수량(SKU)")).toBe(2000);
     expect(map.get("공헌이익률(%)")).toBe(30.8);
-    expect(map.get("쿠폰 할인율(%)")).toBe(5);
+    expect(map.get("추가할인쿠폰")).toContain("5%");
+  });
+
+  it("쿠폰 없으면 '없음'", () => {
+    const wb2 = buildPlanWorkbook(meta, options, summary, null);
+    const aoa = XLSX.utils.sheet_to_json(wb2.Sheets["요약"], { header: 1 }) as (string | number)[][];
+    const map = new Map(aoa.map((r) => [r[0], r[1]]));
+    expect(map.get("추가할인쿠폰")).toBe("없음");
+  });
+
+  it("파일명 = 플랜명-기간.xlsx (경로문자 정리)", () => {
+    expect(planFileName(meta)).toBe(
+      "[BETTER HABITS] 활력을 키우는 습관 — 가격 가이드(플랜)-2026-06-08~2026-06-14.xlsx",
+    );
+    expect(planFileName({ ...meta, campaign: "여름/세일" })).toBe(
+      "여름 세일-2026-06-08~2026-06-14.xlsx",
+    );
   });
 });

--- a/promo-analytics/lib/plan-export.ts
+++ b/promo-analytics/lib/plan-export.ts
@@ -30,6 +30,13 @@ export type ExportSummary = {
 };
 export type ExportCoupon = { min: number; ratePct: number; max: number } | null;
 
+export type ExportMeta = {
+  campaign: string; // 플랜(캠페인)명
+  period: string; // "2026-06-08 ~ 2026-06-14"
+  version: string; // "v2"
+  purposes: string[]; // 목적
+};
+
 const PLAN_HEADER = [
   "옵션명",
   "메인",
@@ -47,7 +54,7 @@ const PLAN_HEADER = [
 
 /** 플랜 데이터 → 워크북 (플랜·요약 시트). 값 기반이라 다시 올려도 어긋남이 없다. */
 export function buildPlanWorkbook(
-  title: string,
+  meta: ExportMeta,
   options: ExportOption[],
   summary: ExportSummary,
   coupon: ExportCoupon,
@@ -78,21 +85,24 @@ export function buildPlanWorkbook(
   }
   const planWs = XLSX.utils.aoa_to_sheet(rows);
 
-  // 요약 시트
+  // 요약 시트 — 캠페인·기간·목적 + 핵심 지표 + 추가할인쿠폰(없으면 '없음')
+  const couponText =
+    coupon && coupon.ratePct > 0
+      ? `${coupon.min.toLocaleString("ko-KR")}원 이상 ${coupon.ratePct}% (최대 ${coupon.max.toLocaleString("ko-KR")}원)`
+      : "없음";
   const sum: (string | number)[][] = [
     ["항목", "값"],
-    ["캠페인", title],
+    ["캠페인", meta.campaign],
+    ["기간", meta.period],
+    ["플랜 버전", meta.version],
+    ["목적", meta.purposes.length ? meta.purposes.join(", ") : "—"],
     ["예상 매출액", Math.round(summary.revenue)],
     ["구매건수(세트)", summary.order_count],
     ["판매수량(SKU)", summary.sku_units],
     ["예상 공헌이익액", Math.round(summary.contribution)],
     ["공헌이익률(%)", summary.contribution_rate != null ? +(summary.contribution_rate * 100).toFixed(1) : ""],
+    ["추가할인쿠폰", couponText],
   ];
-  if (coupon && coupon.ratePct > 0) {
-    sum.push(["쿠폰 기준액(원 이상)", coupon.min]);
-    sum.push(["쿠폰 할인율(%)", coupon.ratePct]);
-    sum.push(["쿠폰 최대할인(원)", coupon.max]);
-  }
   const sumWs = XLSX.utils.aoa_to_sheet(sum);
 
   const wb = XLSX.utils.book_new();
@@ -101,14 +111,23 @@ export function buildPlanWorkbook(
   return wb;
 }
 
+/** 파일명 = '플랜명-기간.xlsx' (경로 불가 문자만 정리, 한글·괄호·대시는 유지) */
+export function planFileName(meta: ExportMeta): string {
+  const base = `${meta.campaign}-${meta.period.replace(/\s+/g, "")}`;
+  const safe = base
+    .replace(/[/\\:*?"<>|\n\r\t]+/g, " ")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+  return `${safe || "플랜"}.xlsx`;
+}
+
 /** 브라우저에서 xlsx 다운로드 트리거 */
 export function downloadPlanXlsx(
-  filename: string,
-  title: string,
+  meta: ExportMeta,
   options: ExportOption[],
   summary: ExportSummary,
   coupon: ExportCoupon,
 ): void {
-  const wb = buildPlanWorkbook(title, options, summary, coupon);
-  XLSX.writeFile(wb, filename);
+  const wb = buildPlanWorkbook(meta, options, summary, coupon);
+  XLSX.writeFile(wb, planFileName(meta));
 }


### PR DESCRIPTION
## Excel 내보내기 보강 — 파일명 + 누락 항목

첨부 파일(`66496327-planv2.xlsx`) 확인 후 피드백 반영.

### 1. 파일명: `플랜명-기간.xlsx`
- 기존 `plan-v2.xlsx` → **`[BETTER HABITS] 활력을 키우는 습관 — 가격 가이드(플랜)-2026-06-08~2026-06-14.xlsx`**
- 경로 불가 문자(`/ \ : * ? " < > |`)만 정리, 한글·괄호·대시는 유지.

### 2. 요약 시트에 누락 항목 추가
- **캠페인명·기간·플랜버전·목적** 추가 (기존엔 "플랜 v2"만)
- **추가할인쿠폰**: 있으면 `5만원 이상 5% (최대 5천원)`, 없으면 **'없음'** 으로 항상 표기
- 기존 유지: 예상매출·구매건수(세트)·판매수량(SKU)·공헌이익액·공헌이익률
- 플랜 시트(옵션명·예상세트수·옵션단가·할인율·예상매출·예상공헌 + SKU구성·세트당수량·원가·소비자가) 그대로

### 검증
왕복 테스트 **5건**(목적·기간·쿠폰없음·파일명 정리 포함), 전체 **59 통과**, `tsc`·`build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_