### PR TITLE
성과 표 정렬 + 진단표 워딩 (피드백 4·6 일부)

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/OptionContribution.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/OptionContribution.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import { won, pct } from "@/lib/format";
+import { useTableSort } from "@/lib/table-sort";
 
 // N13 P2: 옵션 단위 실측 공헌 분해 (sale_option_contribution RPC).
 // 매출−수수료−원가−물류(매출×12%)−광고(실제 광고비 매출비중 배분) = 옵션 공헌.
@@ -36,6 +39,11 @@ export default function OptionContribution({
   rows: OptionContribRow[];
   groundTruth: number | null;
 }) {
+  const { sorted, toggle, arrow } = useTableSort<OptionContribRow>(
+    rows ?? [],
+    "contribution",
+    "desc",
+  );
   if (!rows || rows.length === 0) return null;
   const sum = rows.reduce((s, r) => s + (r.contribution ?? 0), 0);
   const revSum = rows.reduce((s, r) => s + (r.revenue ?? 0), 0);
@@ -72,20 +80,20 @@ export default function OptionContribution({
       <div className="mt-3 overflow-x-auto">
         <table className="w-full min-w-[720px] text-left text-xs">
           <thead className="text-ink-4">
-            <tr className="border-b border-line">
-              <th className="py-1.5 pr-3">옵션</th>
-              <th className="py-1.5 pr-3">매칭</th>
-              <th className="py-1.5 pr-3 text-right">매출</th>
-              <th className="py-1.5 pr-3 text-right">수수료</th>
-              <th className="py-1.5 pr-3 text-right">원가</th>
-              <th className="py-1.5 pr-3 text-right">물류</th>
-              <th className="py-1.5 pr-3 text-right">광고</th>
-              <th className="py-1.5 pr-3 text-right">공헌이익</th>
-              <th className="py-1.5 text-right">공헌률</th>
+            <tr className="border-b border-line [&_th]:cursor-pointer [&_th]:select-none [&_th:hover]:text-ink-2">
+              <th className="py-1.5 pr-3" onClick={() => toggle("label")}>옵션{arrow("label")}</th>
+              <th className="py-1.5 pr-3" onClick={() => toggle("match_source")}>매칭{arrow("match_source")}</th>
+              <th className="py-1.5 pr-3 text-right" onClick={() => toggle("revenue")}>매출{arrow("revenue")}</th>
+              <th className="py-1.5 pr-3 text-right" onClick={() => toggle("fee")}>수수료{arrow("fee")}</th>
+              <th className="py-1.5 pr-3 text-right" onClick={() => toggle("cost")}>원가{arrow("cost")}</th>
+              <th className="py-1.5 pr-3 text-right" onClick={() => toggle("logistics")}>물류{arrow("logistics")}</th>
+              <th className="py-1.5 pr-3 text-right" onClick={() => toggle("ad_alloc")}>광고{arrow("ad_alloc")}</th>
+              <th className="py-1.5 pr-3 text-right" onClick={() => toggle("contribution")}>공헌이익{arrow("contribution")}</th>
+              <th className="py-1.5 text-right" onClick={() => toggle("contribution_rate")}>공헌률{arrow("contribution_rate")}</th>
             </tr>
           </thead>
           <tbody>
-            {rows.map((r) => (
+            {sorted.map((r) => (
               <tr key={r.sale_option_id} className="border-b border-line/60">
                 <td className="py-1.5 pr-3">
                   <span className="text-ink-2">{r.label ?? r.option_code ?? "—"}</span>

--- a/promo-analytics/app/(dash)/promotions/[id]/SkuMatchPanel.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/SkuMatchPanel.tsx
@@ -5,6 +5,7 @@ import { won, wonShort, num } from "@/lib/format";
 import { cn } from "@/lib/cn";
 import { StatusBadge } from "@/components/ui";
 import { useOptimisticMutation } from "@/hooks/useOptimisticMutation";
+import { useTableSort } from "@/lib/table-sort";
 
 // promo.sku_match_diagnostic() 반환 행
 export type DiagnosticRow = {
@@ -163,6 +164,7 @@ export default function SkuMatchPanel({
         (r) => r.base_name.includes(query.trim()) || (r.dr_code ?? "").includes(query.trim()),
       )
     : localRows;
+  const { sorted: sortedRows, toggle: sortBy, arrow } = useTableSort<DiagnosticRow>(filtered, null, "desc");
 
   return (
     <section className="mt-5">
@@ -177,7 +179,7 @@ export default function SkuMatchPanel({
             <span className="rounded-full bg-warning-soft px-2 py-0.5 text-warning">플랜 미매칭 {planOnly.length}</span>
           )}
           {actualOnly.length > 0 && (
-            <span className="rounded-full bg-soft px-2 py-0.5 text-ink-3">실적 미매칭 {actualOnly.length}</span>
+            <span className="rounded-full bg-soft px-2 py-0.5 text-ink-3">성과 미매칭 {actualOnly.length}</span>
           )}
         </div>
       </div>
@@ -186,7 +188,7 @@ export default function SkuMatchPanel({
       {planOnly.length > 0 && (
         <div className="mt-3 overflow-hidden rounded-xl card-soft">
           <div className="border-b border-line bg-warning-soft/60 px-4 py-2.5 text-xs font-medium text-warning">
-            플랜에 있는데 실적과 매칭 안 된 SKU {planOnly.length}개 — 추천순으로 골라 바로 연동하세요.
+            플랜에 있는데 성과와 매칭 안 된 SKU {planOnly.length}개 — 추천순으로 골라 바로 연동하세요.
           </div>
           <ul className="divide-y divide-line/70">
             {planOnly.map((p) => {
@@ -211,11 +213,11 @@ export default function SkuMatchPanel({
                   <div className="flex min-w-0 flex-1 items-center gap-2">
                     <select
                       value={pick}
-                      aria-label={`${p.base_name}에 연결할 실적 SKU`}
+                      aria-label={`${p.base_name}에 연결할 성과 SKU`}
                       onChange={(e) => setPicks((s) => ({ ...s, [p.product_id]: e.target.value }))}
                       className="w-full min-w-0 flex-1 truncate rounded-xl border border-line bg-card px-3 py-2 text-sm text-ink-2 focus:outline-none"
                     >
-                      <option value="">실적 SKU 선택…</option>
+                      <option value="">성과 SKU 선택…</option>
                       {candidates.map((c, i) => (
                         <option key={c.product_id} value={c.product_id}>
                           {i === 0 && bestScore >= 500 ? "★ " : ""}
@@ -290,18 +292,18 @@ export default function SkuMatchPanel({
             <div className="mt-3 overflow-x-auto">
               <table className="w-full min-w-[640px] text-xs">
                 <thead className="text-left text-ink-4">
-                  <tr>
-                    <th className="px-2 py-2 font-medium">상태</th>
-                    <th className="px-2 py-2 font-medium">SKU</th>
-                    <th className="px-2 py-2 text-right font-medium">기대수량</th>
-                    <th className="px-2 py-2 text-right font-medium">기대매출</th>
-                    <th className="px-2 py-2 text-right font-medium">실수량</th>
-                    <th className="px-2 py-2 text-right font-medium">실매출</th>
+                  <tr className="[&_th]:cursor-pointer [&_th]:select-none [&_th:hover]:text-ink-2">
+                    <th className="px-2 py-2 font-medium" onClick={() => sortBy("side")}>상태{arrow("side")}</th>
+                    <th className="px-2 py-2 font-medium" onClick={() => sortBy("base_name")}>SKU{arrow("base_name")}</th>
+                    <th className="px-2 py-2 text-right font-medium" onClick={() => sortBy("expected_qty")}>기대수량{arrow("expected_qty")}</th>
+                    <th className="px-2 py-2 text-right font-medium" onClick={() => sortBy("expected_revenue")}>기대매출{arrow("expected_revenue")}</th>
+                    <th className="px-2 py-2 text-right font-medium" onClick={() => sortBy("actual_qty")}>성과수량{arrow("actual_qty")}</th>
+                    <th className="px-2 py-2 text-right font-medium" onClick={() => sortBy("actual_revenue")}>성과매출{arrow("actual_revenue")}</th>
                     <th className="px-2 py-2 text-center font-medium">정기구독</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {filtered.map((r) => (
+                  {sortedRows.map((r) => (
                     <tr key={`${r.product_id}:${r.is_subscription}`} className="border-t border-line/60">
                       <td className="px-2 py-2">
                         <SideBadge side={r.side} isMapped={r.is_mapped} />
@@ -323,10 +325,10 @@ export default function SkuMatchPanel({
                       </td>
                     </tr>
                   ))}
-                  {filtered.length === 0 && (
+                  {sortedRows.length === 0 && (
                     <tr>
                       <td colSpan={7} className="px-2 py-6 text-center text-ink-4">
-                        {query ? "검색 결과가 없습니다." : "플랜·실적 모두 없습니다."}
+                        {query ? "검색 결과가 없습니다." : "플랜·성과 모두 없습니다."}
                       </td>
                     </tr>
                   )}
@@ -391,5 +393,5 @@ function SubscriptionCell({
 function SideBadge({ side, isMapped }: { side: DiagnosticRow["side"]; isMapped: boolean }) {
   if (side === "both" || isMapped) return <StatusBadge tone="success" label={isMapped ? "수동 연동" : "자동 매칭"} />;
   if (side === "plan") return <StatusBadge tone="warning" label="플랜만" />;
-  return <StatusBadge tone="neutral" label="실적만" />;
+  return <StatusBadge tone="neutral" label="성과만" />;
 }

--- a/promo-analytics/lib/__tests__/table-sort.test.ts
+++ b/promo-analytics/lib/__tests__/table-sort.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { sortRows } from "../table-sort";
+
+type Row = { name: string; rev: number | null };
+const rows: Row[] = [
+  { name: "가", rev: 100 },
+  { name: "나", rev: null },
+  { name: "다", rev: 50 },
+  { name: "라", rev: 300 },
+];
+
+describe("sortRows", () => {
+  it("숫자 내림차순 — null은 바닥", () => {
+    const r = sortRows(rows, "rev", "desc").map((x) => x.rev);
+    expect(r).toEqual([300, 100, 50, null]);
+  });
+  it("숫자 오름차순 — null은 여전히 바닥", () => {
+    const r = sortRows(rows, "rev", "asc").map((x) => x.rev);
+    expect(r).toEqual([50, 100, 300, null]);
+  });
+  it("문자열 ko 로캘 정렬", () => {
+    const r = sortRows(rows, "name", "asc").map((x) => x.name);
+    expect(r).toEqual(["가", "나", "다", "라"]);
+  });
+  it("key=null이면 원본 순서 유지", () => {
+    expect(sortRows(rows, null, "desc")).toBe(rows);
+  });
+  it("원본 배열을 변형하지 않음", () => {
+    const before = rows.map((x) => x.rev);
+    sortRows(rows, "rev", "asc");
+    expect(rows.map((x) => x.rev)).toEqual(before);
+  });
+});

--- a/promo-analytics/lib/table-sort.ts
+++ b/promo-analytics/lib/table-sort.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+// 모든 성과 표 공용 정렬. 순수 sortRows(테스트 대상) + useTableSort 훅.
+export type SortDir = "asc" | "desc";
+
+/** key 기준 정렬 사본 반환. null/undefined는 항상 바닥. 숫자는 수치, 그 외는 ko 로캘 비교. */
+export function sortRows<T>(rows: T[], key: keyof T | null, dir: SortDir): T[] {
+  if (key == null) return rows;
+  const arr = [...rows];
+  arr.sort((a, b) => {
+    const av = a[key];
+    const bv = b[key];
+    const an = av == null;
+    const bn = bv == null;
+    if (an && bn) return 0;
+    if (an) return 1; // null은 방향과 무관하게 바닥
+    if (bn) return -1;
+    let c: number;
+    if (typeof av === "number" && typeof bv === "number") c = av - bv;
+    else c = String(av).localeCompare(String(bv), "ko");
+    return dir === "asc" ? c : -c;
+  });
+  return arr;
+}
+
+export function useTableSort<T>(
+  rows: T[],
+  initialKey: keyof T | null = null,
+  initialDir: SortDir = "desc",
+) {
+  const [key, setKey] = useState<keyof T | null>(initialKey);
+  const [dir, setDir] = useState<SortDir>(initialDir);
+  const sorted = useMemo(() => sortRows(rows, key, dir), [rows, key, dir]);
+  const toggle = (k: keyof T) => {
+    if (k === key) setDir((d) => (d === "asc" ? "desc" : "asc"));
+    else {
+      setKey(k);
+      setDir("desc");
+    }
+  };
+  // 헤더에 붙일 화살표 (활성 컬럼만)
+  const arrow = (k: keyof T) => (k === key ? (dir === "asc" ? " ▲" : " ▼") : "");
+  return { sorted, toggle, arrow, sortKey: key, sortDir: dir };
+}


### PR DESCRIPTION
## 성과 표 정렬 + 진단표 워딩 (피드백 4 일부 · 6 일부)

- **(4)** 공용 정렬 훅(`lib/table-sort`: 순수 `sortRows` + `useTableSort`). 헤더 클릭으로 오름/내림 토글, null은 항상 바닥. **옵션별 공헌이익 분해표·SKU 진단표**에 적용.
- **(6)** SkuMatchPanel `실적`→`성과` 워딩(미매칭/연결/상태 배지/컬럼).

### 검증
`sortRows` 단위 테스트 5건, 전체 **64 통과**, `tsc`·`build` OK.

> 이번 피드백은 규모가 커서 순차 진행합니다. **남은 항목**: 함께구매 표 정렬(메인/서브 재구성과 함께) · 전역 `실적→성과` 워딩 · (1) SKU 품절 처리 · (2) 플랜만/성과만 결과 · (3) 메인/서브 성과 재구성 · (5) 목적분석 평이화·플랜대비 · (7) 메인 지정 일원화+메타편집 폐지+실공헌/광고 입력 · (8) 채널별 수수료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_