### PR TITLE
플랜 메인/서브 → 성과 자동 연결 (피드백 7 핵심)

### DIFF
--- a/promo-analytics/app/api/promotions/[id]/plan/route.ts
+++ b/promo-analytics/app/api/promotions/[id]/plan/route.ts
@@ -163,6 +163,14 @@ export async function PATCH(
       }
     }
 
+    // 메인 상품 = 메인 옵션(is_main)의 SKU들 — 플랜에서 나눈 메인/서브를 성과 측정에 직접 연결.
+    // (별도 '메타/메인 편집' 없이 플랜이 단일 출처). 메인 옵션이 없으면 null = 전체 메인.
+    const mainIds = [
+      ...new Set(
+        options.filter((o) => o.is_main).flatMap((o) => o.items.map((it) => it.product_id)),
+      ),
+    ];
+
     const { error: upErr } = await supabase
       .from("campaign_plans")
       .update({
@@ -171,10 +179,14 @@ export async function PATCH(
         coupon_min_order: couponSpec?.min_order_amount ?? 0,
         coupon_rate: couponSpec?.discount_rate ?? 0,
         coupon_max: couponSpec?.max_discount_amount ?? 0,
+        main_product_ids: mainIds.length > 0 ? mainIds : null,
         updated_at: new Date().toISOString(),
       })
       .eq("id", plan_id);
     if (upErr) throw upErr;
+
+    // 메인 지정이 메인/함께구매 분해에 영향 → 사전계산 롤업 갱신
+    await supabase.rpc("refresh_rollups", { p_force: true });
 
     return NextResponse.json({ ok: true });
   } catch (e) {


### PR DESCRIPTION
## 플랜 메인/서브 → 성과 측정 자동 연결 (피드백 7 핵심 버그)

**버그**: 성과 측정 RPC는 `campaign_plans.main_product_ids`를 읽는데, 플랜 옵션의 `is_main`이 거기로 연결돼 있지 않아 성과 개요가 **'메인 미지정'** 으로 표기. (메타/메인 편집은 `promotions` 쪽에 써서 측정엔 무효였음.)

**수정**: 플랜 저장 시 **메인 옵션(`is_main`)의 SKU들로 `campaign_plans.main_product_ids` 자동 설정**(없으면 `null`=전체 메인) + 메인/함께구매 분해 롤업 갱신. → **플랜이 메인 지정의 단일 출처**.

### 검증
`tsc`·`build` 통과.

> 후속(피드백 7 나머지): 메타/메인 편집 페이지 폐지 · 성과 연결에 실공헌이익액·실광고비 직접 입력.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_