### PR TITLE
성과 화면 개선 (피드백 7 b·c · 5)

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/PerformanceUpload.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/PerformanceUpload.tsx
@@ -12,14 +12,48 @@ import { ensureProducts } from "@/lib/products";
 export default function PerformanceUpload({
   promotionId,
   hasActuals,
+  contributionAmount,
+  adSpend,
 }: {
   promotionId: string;
   hasActuals: boolean;
+  contributionAmount?: number | null;
+  adSpend?: number | null;
 }) {
   const router = useRouter();
   const inputRef = useRef<HTMLInputElement>(null);
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState<{ kind: "ok" | "err"; text: string } | null>(null);
+
+  // 전체 실공헌이익액·실광고비 직접 입력 — 옵션 분해의 기준값(groundTruth)·광고 배분에 반영
+  const [contrib, setContrib] = useState(contributionAmount != null ? String(contributionAmount) : "");
+  const [ad, setAd] = useState(adSpend != null ? String(adSpend) : "");
+  const [econBusy, setEconBusy] = useState(false);
+  const [econMsg, setEconMsg] = useState<{ kind: "ok" | "err"; text: string } | null>(null);
+
+  async function saveEcon() {
+    setEconBusy(true);
+    setEconMsg(null);
+    try {
+      const res = await fetch(`/api/promotions/${promotionId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          contribution_amount: contrib.trim() ? Number(contrib.replace(/[^0-9.-]/g, "")) : null,
+          ad_spend: ad.trim() ? Number(ad.replace(/[^0-9.-]/g, "")) : null,
+        }),
+      });
+      if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error ?? "저장 실패");
+      const supabase = createClient();
+      await supabase.rpc("refresh_rollups", { p_force: true });
+      setEconMsg({ kind: "ok", text: "저장됐습니다. 옵션 분해·광고 배분에 반영됩니다." });
+      router.refresh();
+    } catch (e) {
+      setEconMsg({ kind: "err", text: e instanceof Error ? e.message : "저장 실패" });
+    } finally {
+      setEconBusy(false);
+    }
+  }
 
   async function onFile(file: File) {
     setBusy(true);
@@ -108,6 +142,51 @@ export default function PerformanceUpload({
           {msg.text}
         </div>
       )}
+
+      {/* 전체 실공헌이익액·실광고비 직접 입력 (성과의 최종 ground truth) */}
+      <div className="mt-4 border-t border-line/70 pt-4">
+        <h3 className="text-xs font-semibold text-ink-2">실 공헌이익·광고비 (직접 입력)</h3>
+        <p className="mt-0.5 text-[11px] text-ink-4">
+          기간 내 공식몰 <b>전체</b> 실공헌이익액(정기구독 포함)·실광고비. 옵션별 공헌이익 분해의 기준값과
+          광고 배분에 반영돼 <b>최종 성과</b>를 정확히 보여줍니다.
+        </p>
+        <div className="mt-2 grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <label className="block">
+            <span className="block text-[11px] font-medium text-ink-4">전체 실공헌이익액 (₩)</span>
+            <input
+              value={contrib}
+              onChange={(e) => setContrib(e.target.value)}
+              inputMode="numeric"
+              placeholder="예: 60613475"
+              className="mt-1 w-full rounded-xl border border-line bg-card px-3 py-2 text-sm tabular-nums text-ink outline-none focus:border-brand-400"
+            />
+          </label>
+          <label className="block">
+            <span className="block text-[11px] font-medium text-ink-4">실 광고비 (₩)</span>
+            <input
+              value={ad}
+              onChange={(e) => setAd(e.target.value)}
+              inputMode="numeric"
+              placeholder="예: 6890000"
+              className="mt-1 w-full rounded-xl border border-line bg-card px-3 py-2 text-sm tabular-nums text-ink outline-none focus:border-brand-400"
+            />
+          </label>
+        </div>
+        <div className="mt-2 flex items-center gap-3">
+          <button
+            onClick={saveEcon}
+            disabled={econBusy}
+            className="rounded-full bg-brand-500 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-600 disabled:opacity-50"
+          >
+            {econBusy ? "저장 중…" : "저장"}
+          </button>
+          {econMsg && (
+            <span className={`text-xs ${econMsg.kind === "ok" ? "text-success" : "text-danger"}`}>
+              {econMsg.text}
+            </span>
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/promo-analytics/app/(dash)/promotions/[id]/PurposeBlock.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/PurposeBlock.tsx
@@ -26,7 +26,7 @@ export default function PurposeBlock({ rows }: { rows: PurposeMetricRow[] }) {
                 {r.purpose}
               </span>
               <span className="shrink-0 rounded-full bg-neutral-100 px-2 py-0.5 text-[11px] text-neutral-500">
-                가중치 {r.weight}
+                중요도 {r.weight}
               </span>
             </div>
             <div className="mt-3 space-y-1.5 text-sm">
@@ -46,10 +46,10 @@ export default function PurposeBlock({ rows }: { rows: PurposeMetricRow[] }) {
                 </>
               ) : (
                 <>
-                  <Metric label="증분 매출" value={won(r.uplift)} primary />
-                  <Metric label="공헌이익" value={wonShort(r.contribution)} />
+                  <Metric label="행사로 늘어난 매출" value={won(r.uplift)} primary />
+                  <Metric label="남는 이익(공헌)" value={wonShort(r.contribution)} />
                   {r.uplift_pct != null && (
-                    <Metric label="증분율" value={pct(r.uplift_pct, 0)} />
+                    <Metric label="평소 대비" value={pct(r.uplift_pct, 0)} />
                   )}
                 </>
               )}
@@ -58,8 +58,8 @@ export default function PurposeBlock({ rows }: { rows: PurposeMetricRow[] }) {
         ))}
       </div>
       <p className="mt-2 text-xs text-neutral-400">
-        목적별로 보는 관점이 다릅니다 — 세일즈=증분·공헌, 재고소진=수량 달성률, 브랜딩=구매 건수.
-        가중치는 캠페인 편집에서 조정합니다.
+        목적마다 중요한 숫자가 다릅니다 — 세일즈=행사로 늘어난 매출·이익, 재고소진=수량 달성률,
+        브랜딩=구매 건수. ‘평소 대비’는 행사 안 했을 때 대비 얼마나 더 팔렸는지입니다.
       </p>
     </section>
   );

--- a/promo-analytics/app/(dash)/promotions/[id]/edit/EditForm.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/edit/EditForm.tsx
@@ -4,21 +4,15 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import type { Promotion } from "@/lib/types";
-import { wonShort } from "@/lib/format";
 
-type ProductItem = { product_id: string; base_name: string; revenue: number };
 type Options = { benefitTypes: string[]; seasonalities: string[]; purposes: string[] };
 
 export default function EditForm({
   promo,
-  products,
-  initialMainIds,
   options,
   initialWeights,
 }: {
   promo: Promotion;
-  products: ProductItem[];
-  initialMainIds: string[];
   options: Options;
   initialWeights: Record<string, number>;
 }) {
@@ -44,16 +38,8 @@ export default function EditForm({
   const [giftValue, setGiftValue] = useState(
     promo.benefits?.gift?.value != null ? String(promo.benefits.gift.value) : "",
   );
-  const [contribution, setContribution] = useState(
-    promo.contribution_amount != null ? String(promo.contribution_amount) : "",
-  );
-  const [adSpend, setAdSpend] = useState(
-    promo.ad_spend != null ? String(promo.ad_spend) : "",
-  );
-  const [mainIds, setMainIds] = useState<string[]>(initialMainIds);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
-  const [query, setQuery] = useState("");
 
   function toggleType(t: string) {
     setPromoTypes((p) => (p.includes(t) ? p.filter((x) => x !== t) : [...p, t]));
@@ -67,16 +53,6 @@ export default function EditForm({
     setPurposeWeights((w) => ({ ...w, [p]: Number.isNaN(v) ? 0 : v }));
   }
   const weightSum = purposes.reduce((s, p, i) => s + weightOf(p, i), 0);
-  function toggleMain(id: string) {
-    setMainIds((m) => (m.includes(id) ? m.filter((x) => x !== id) : [...m, id]));
-  }
-  function selectFiltered() {
-    setMainIds((m) => [...new Set([...m, ...filtered.map((p) => p.product_id)])]);
-  }
-  function clearMain() {
-    setMainIds([]);
-  }
-  const allSelected = products.length > 0 && mainIds.length === products.length;
 
   async function save() {
     setSaving(true);
@@ -102,9 +78,6 @@ export default function EditForm({
         start_date: startDate,
         end_date: endDate,
         benefits: Object.keys(benefits).length ? benefits : null,
-        contribution_amount: contribution ? Number(contribution.replace(/[^0-9.-]/g, "")) : null,
-        ad_spend: adSpend ? Number(adSpend.replace(/[^0-9.-]/g, "")) : null,
-        main_product_ids: mainIds,
       }),
     });
     setSaving(false);
@@ -136,15 +109,12 @@ export default function EditForm({
     }
   }
 
-  const filtered = query
-    ? products.filter((p) => p.base_name.includes(query))
-    : products;
-
   return (
     <div className="max-w-3xl">
-      <h1 className="text-xl font-semibold tracking-tight">캠페인 편집</h1>
+      <h1 className="text-xl font-semibold tracking-tight">캠페인 정보 편집</h1>
       <p className="mt-1 text-sm text-neutral-500">
-        기간·목적·혜택을 채우고, 특별 혜택을 준 <strong>메인 상품</strong>을 지정하세요.
+        기간·목적·혜택 등 기본 정보를 수정합니다. <strong>메인/서브</strong>는 플랜에서 옵션으로 나눠
+        지정하고, <strong>실공헌이익·광고비</strong>는 성과 화면에서 입력합니다.
       </p>
 
       <div className="mt-6 space-y-5">
@@ -229,88 +199,6 @@ export default function EditForm({
           </Field>
         </div>
 
-        <div className="grid grid-cols-2 gap-4">
-          <Field label="전체 공헌이익액 (직접 입력)">
-            <input
-              value={contribution}
-              onChange={(e) => setContribution(e.target.value)}
-              inputMode="numeric"
-              placeholder="예: 12000000"
-              className={inputCls}
-            />
-            <p className="mt-1 text-xs text-neutral-400">
-              기간 내 공식몰 <b>전체</b> 공헌이익액(정기구독 포함). 옵션 단위 분해 합과 대조하는
-              기준값으로 쓰입니다.
-            </p>
-          </Field>
-          <Field label="실제 광고비 (직접 입력)">
-            <input
-              value={adSpend}
-              onChange={(e) => setAdSpend(e.target.value)}
-              inputMode="numeric"
-              placeholder="예: 3000000"
-              className={inputCls}
-            />
-            <p className="mt-1 text-xs text-neutral-400">
-              캠페인 실제 광고비. 옵션별 공헌이익 분해 시 매출 비중으로 배분합니다(미입력 시 레이트카드
-              광고율 적용).
-            </p>
-          </Field>
-        </div>
-
-        <Field label={`메인 상품 지정 (${mainIds.length}/${products.length}개 선택)`}>
-          <label className="mb-2 flex cursor-pointer items-center gap-2 rounded-xl bg-brand-50 px-3 py-2 text-sm font-medium text-brand-700">
-            <input
-              type="checkbox"
-              checked={allSelected}
-              onChange={() => (allSelected ? clearMain() : setMainIds(products.map((p) => p.product_id)))}
-              className="accent-brand-500"
-            />
-            전 상품 대상 (전체 선택)
-          </label>
-          <input
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="상품명 검색"
-            className={`mb-2 ${inputCls}`}
-          />
-          <div className="mb-2 flex items-center gap-2 text-xs">
-            <button
-              type="button"
-              onClick={selectFiltered}
-              className="rounded-full border border-neutral-200 px-2.5 py-1 text-neutral-600 hover:bg-neutral-50"
-            >
-              {query ? "검색결과 선택" : "전체 선택"}
-            </button>
-            <button
-              type="button"
-              onClick={clearMain}
-              className="rounded-full border border-neutral-200 px-2.5 py-1 text-neutral-600 hover:bg-neutral-50"
-            >
-              전체 해제
-            </button>
-          </div>
-          <div className="max-h-72 overflow-y-auto rounded-xl border border-neutral-200">
-            {filtered.map((p) => (
-              <label
-                key={p.product_id}
-                className="flex cursor-pointer items-center gap-2 border-b border-neutral-100 px-3 py-2 text-sm last:border-0 hover:bg-neutral-50"
-              >
-                <input
-                  type="checkbox"
-                  checked={mainIds.includes(p.product_id)}
-                  onChange={() => toggleMain(p.product_id)}
-                  className="accent-brand-500"
-                />
-                <span className="flex-1 truncate text-neutral-700">{p.base_name}</span>
-                <span className="text-xs text-neutral-400">{wonShort(p.revenue)}</span>
-              </label>
-            ))}
-            {filtered.length === 0 && (
-              <div className="px-3 py-6 text-center text-sm text-neutral-400">상품이 없습니다.</div>
-            )}
-          </div>
-        </Field>
       </div>
 
       <div className="mt-6 flex items-center gap-2">

--- a/promo-analytics/app/(dash)/promotions/[id]/edit/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/edit/page.tsx
@@ -29,31 +29,6 @@ export default async function EditPromotion({
     .neq("id", id)
     .order("start_date", { ascending: false });
 
-  const { data: sales } = await supabase
-    .from("promotion_sales")
-    .select("product_id, base_name, revenue")
-    .eq("promotion_id", id);
-
-  const { data: mains } = await supabase
-    .from("promotion_main_products")
-    .select("product_id")
-    .eq("promotion_id", id);
-
-  // 캠페인 내 상품 목록 (매출 합으로 정렬, 중복 제거)
-  const agg = new Map<string, { product_id: string; base_name: string; revenue: number }>();
-  for (const s of sales ?? []) {
-    if (!s.product_id) continue;
-    const cur = agg.get(s.product_id);
-    if (cur) cur.revenue += s.revenue ?? 0;
-    else
-      agg.set(s.product_id, {
-        product_id: s.product_id,
-        base_name: s.base_name,
-        revenue: s.revenue ?? 0,
-      });
-  }
-  const products = [...agg.values()].sort((a, b) => b.revenue - a.revenue);
-  const mainIds = (mains ?? []).map((m) => m.product_id);
   const options = await loadOptions(supabase);
 
   // 목적 가중치 (S5) — 저장된 값 로드
@@ -69,8 +44,6 @@ export default async function EditPromotion({
     <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
       <EditForm
         promo={promo}
-        products={products}
-        initialMainIds={mainIds}
         options={options}
         initialWeights={initialWeights}
       />

--- a/promo-analytics/app/(dash)/promotions/[id]/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/page.tsx
@@ -206,7 +206,7 @@ export default async function PromotionDetail({
           href={`/promotions/${id}/edit`}
           className="shrink-0 rounded-xl border border-line px-4 py-2 text-sm font-medium hover:bg-soft"
         >
-          메타·메인상품 편집
+          캠페인 정보 편집
         </Link>
       </header>
 
@@ -289,7 +289,12 @@ export default async function PromotionDetail({
 
       {/* 6단계 — 캠페인에 직접 성과 추가 (라플라스 양식 → 자동 분류) */}
       <div className="mt-4">
-        <PerformanceUpload promotionId={id} hasActuals={hasActuals} />
+        <PerformanceUpload
+          promotionId={id}
+          hasActuals={hasActuals}
+          contributionAmount={promo.contribution_amount ?? null}
+          adSpend={promo.ad_spend ?? null}
+        />
       </div>
 
       {/* Layer C — 심층 분석 (탭, URL 보존, 선택 탭만 렌더) */}


### PR DESCRIPTION
## 성과 화면 개선 (피드백 7 b·c · 5)

- **(7c)** 성과 연결 카드에 **`전체 실공헌이익액·실광고비 직접 입력`** → 옵션 공헌 분해 기준값·광고 배분에 반영, 최종 성과 정확화. 저장 시 롤업 갱신.
- **(7b)** 캠페인 편집에서 **메인 지정**(플랜이 단일 출처)·**실공헌/실광고**(성과화면 이동) 제거 → **`캠페인 정보 편집`** 슬림화.
- **(5)** **목적 분석 탭 평이화**: 가중치→중요도, 증분 매출→행사로 늘어난 매출, 증분율→평소 대비, 안내문 쉬운 말.

> 편집 페이지는 병합·삭제가 있어 **슬림화만** 했습니다(완전 삭제 시 병합·삭제 이전 위치 필요). 목적 탭의 '플랜 대비 목표 달성' 심화는 목표 데이터 plumbing이 필요해 후속.

### 검증
`tsc`·`build` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9