### PR TITLE
SKU 품절(미판매) 제외 처리 (피드백 1)

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/Achievement.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/Achievement.tsx
@@ -9,7 +9,7 @@ import type {
   PlanVsActualOption,
 } from "@/lib/types";
 import { won, wonShort, pct, num } from "@/lib/format";
-import SkuMatchPanel, { type DiagnosticRow, type SkuMapping } from "./SkuMatchPanel";
+import SkuMatchPanel, { type DiagnosticRow, type SkuMapping, type ExcludedSku } from "./SkuMatchPanel";
 
 // N7 P3: 달성 & 매칭을 한 블록으로 통합.
 // - 상단: SKU 기준 총 달성률 카드 (1차 진실)
@@ -23,6 +23,7 @@ export default function Achievement({
   optionInfos,
   diagnosticRows,
   skuMappings,
+  excludedSkus,
   hideSummaryCards,
 }: {
   promotionId: string;
@@ -32,6 +33,7 @@ export default function Achievement({
   optionInfos: string[];
   diagnosticRows: DiagnosticRow[];
   skuMappings: SkuMapping[];
+  excludedSkus?: ExcludedSku[];
   hideSummaryCards?: boolean; // Layer A 히어로 KPI와 중복 방지
 }) {
   const [tab, setTab] = useState<"sku" | "option">("sku");
@@ -252,7 +254,7 @@ export default function Achievement({
                 <span className="ml-1 font-normal text-ink-4">(자동 매칭이 빗나간 경우에만)</span>
               </summary>
               <div className="border-t border-line/70 px-4 pb-2">
-                <SkuMatchPanel promotionId={promotionId} rows={diagnosticRows} mappings={skuMappings} />
+                <SkuMatchPanel promotionId={promotionId} rows={diagnosticRows} mappings={skuMappings} excludedSkus={excludedSkus} />
               </div>
             </details>
           )}

--- a/promo-analytics/app/(dash)/promotions/[id]/SkuMatchPanel.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/SkuMatchPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import { won, wonShort, num } from "@/lib/format";
 import { cn } from "@/lib/cn";
 import { StatusBadge } from "@/components/ui";
@@ -50,19 +51,26 @@ function confidence(score: number): { label: string; tone: "success" | "info" | 
   return null;
 }
 
+export type ExcludedSku = { product_id: string; base_name: string };
+
 export default function SkuMatchPanel({
   promotionId,
   rows,
   mappings,
+  excludedSkus = [],
 }: {
   promotionId: string;
   rows: DiagnosticRow[];
   mappings: SkuMapping[];
+  excludedSkus?: ExcludedSku[];
 }) {
+  const router = useRouter();
   const { run, pending } = useOptimisticMutation();
   // optimistic 로컬 상태 — 서버 reconcile(props 변경) 시 재동기화
   const [localRows, setLocalRows] = useState(rows);
   const [localMaps, setLocalMaps] = useState(mappings);
+  const [localExcluded, setLocalExcluded] = useState<ExcludedSku[]>(excludedSkus);
+  const [soldoutBusy, setSoldoutBusy] = useState<string | null>(null);
   const [picks, setPicks] = useState<Record<string, string>>({});
   const [query, setQuery] = useState("");
   const [showAll, setShowAll] = useState(false);
@@ -70,6 +78,47 @@ export default function SkuMatchPanel({
 
   useEffect(() => setLocalRows(rows), [rows]);
   useEffect(() => setLocalMaps(mappings), [mappings]);
+  useEffect(() => setLocalExcluded(excludedSkus), [excludedSkus]);
+
+  // 품절(미판매) 처리 — 플랜·성과·미매칭에서 제외. 해제하면 복원.
+  async function markSoldout(p: { product_id: string; base_name: string }) {
+    if (soldoutBusy) return;
+    setSoldoutBusy(p.product_id);
+    setLocalRows((rs) => rs.filter((r) => r.product_id !== p.product_id)); // optimistic
+    setLocalExcluded((e) => [...e, { product_id: p.product_id, base_name: p.base_name }]);
+    try {
+      const res = await fetch(`/api/promotions/${promotionId}/excluded-skus`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ product_id: p.product_id }),
+      });
+      if (!res.ok) throw new Error();
+      router.refresh();
+    } catch {
+      setLocalExcluded((e) => e.filter((x) => x.product_id !== p.product_id));
+      setLocalRows(rows); // rollback
+    } finally {
+      setSoldoutBusy(null);
+    }
+  }
+  async function restoreSoldout(pid: string) {
+    if (soldoutBusy) return;
+    setSoldoutBusy(pid);
+    setLocalExcluded((e) => e.filter((x) => x.product_id !== pid)); // optimistic
+    try {
+      const res = await fetch(`/api/promotions/${promotionId}/excluded-skus`, {
+        method: "DELETE",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ product_id: pid }),
+      });
+      if (!res.ok) throw new Error();
+      router.refresh();
+    } catch {
+      setLocalExcluded(excludedSkus); // rollback
+    } finally {
+      setSoldoutBusy(null);
+    }
+  }
 
   const matched = localRows.filter((r) => r.side === "both" || r.is_mapped);
   const planOnly = localRows.filter((r) => r.side === "plan" && !r.is_mapped);
@@ -255,10 +304,40 @@ export default function SkuMatchPanel({
                     >
                       {busy ? "…" : "연동"}
                     </button>
+                    <button
+                      onClick={() => markSoldout(p)}
+                      disabled={soldoutBusy === p.product_id || busy}
+                      title="품절·미판매로 처리 — 플랜·성과·미매칭에서 제외"
+                      className="shrink-0 rounded-full border border-line px-3 py-2 text-xs font-medium text-ink-3 hover:bg-soft disabled:opacity-40"
+                    >
+                      {soldoutBusy === p.product_id ? "…" : "품절"}
+                    </button>
                   </div>
                 </li>
               );
             })}
+          </ul>
+        </div>
+      )}
+
+      {/* 품절(미판매) 처리됨 — 플랜·성과·미매칭에서 제외, 복원 가능 */}
+      {localExcluded.length > 0 && (
+        <div className="mt-3 rounded-xl card-soft px-4 py-3">
+          <h4 className="text-xs font-semibold text-ink-2">품절·미판매 제외 {localExcluded.length}건</h4>
+          <p className="mt-0.5 text-[11px] text-ink-4">플랜·성과·매칭 집계에서 빠집니다.</p>
+          <ul className="mt-1.5 space-y-1 text-xs">
+            {localExcluded.map((e) => (
+              <li key={e.product_id} className="flex items-center justify-between gap-2">
+                <span className="min-w-0 truncate text-ink-2">{e.base_name}</span>
+                <button
+                  onClick={() => restoreSoldout(e.product_id)}
+                  disabled={soldoutBusy === e.product_id}
+                  className="shrink-0 text-[11px] text-ink-4 hover:text-brand-700 disabled:opacity-40"
+                >
+                  복원
+                </button>
+              </li>
+            ))}
           </ul>
         </div>
       )}

--- a/promo-analytics/app/(dash)/promotions/[id]/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/page.tsx
@@ -116,6 +116,20 @@ export default async function PromotionDetail({
   ].sort();
   const diagnosticRows = bundle?.rollup?.diagnostic ?? [];
   const skuMappings = bundle?.mappings ?? [];
+  // 품절(미판매) 제외 목록 — 플랜·성과·미매칭에서 빠진 SKU (복원용으로 표시)
+  const { data: exData } = await supabase
+    .from("promotion_excluded_skus")
+    .select("product_id, products(base_name)")
+    .eq("promotion_id", id);
+  const excludedSkus = (
+    (exData ?? []) as {
+      product_id: string;
+      products: { base_name: string } | { base_name: string }[] | null;
+    }[]
+  ).map((r) => {
+    const pr = Array.isArray(r.products) ? r.products[0] : r.products;
+    return { product_id: r.product_id, base_name: pr?.base_name ?? r.product_id };
+  });
   const sources = bundle?.sources ?? [];
 
   // 목적별 핵심 지표 (S5.4)
@@ -473,6 +487,7 @@ export default async function PromotionDetail({
                   optionInfos={optionInfos}
                   diagnosticRows={diagnosticRows}
                   skuMappings={skuMappings}
+                  excludedSkus={excludedSkus}
                   hideSummaryCards
                 />
 

--- a/promo-analytics/app/api/promotions/[id]/excluded-skus/route.ts
+++ b/promo-analytics/app/api/promotions/[id]/excluded-skus/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export const runtime = "nodejs";
+
+// 품절(미판매) SKU 제외 토글 (피드백 1). 제외하면 플랜·성과·미매칭에서 빠진다.
+// POST = 제외 추가, DELETE = 제외 해제. 변경 후 롤업 갱신.
+async function mutate(
+  id: string,
+  product_id: string,
+  op: "add" | "remove",
+): Promise<{ error?: string }> {
+  const supabase = await createClient();
+  if (op === "add") {
+    const { error } = await supabase
+      .from("promotion_excluded_skus")
+      .upsert({ promotion_id: id, product_id }, { onConflict: "promotion_id,product_id" });
+    if (error) return { error: error.message };
+  } else {
+    const { error } = await supabase
+      .from("promotion_excluded_skus")
+      .delete()
+      .eq("promotion_id", id)
+      .eq("product_id", product_id);
+    if (error) return { error: error.message };
+  }
+  await supabase.rpc("refresh_rollups", { p_force: true });
+  return {};
+}
+
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const { product_id } = (await req.json()) as { product_id?: string };
+  if (!product_id) return NextResponse.json({ error: "product_id 필요" }, { status: 400 });
+  const { error } = await mutate(id, product_id, "add");
+  if (error) return NextResponse.json({ error }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}
+
+export async function DELETE(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const { product_id } = (await req.json()) as { product_id?: string };
+  if (!product_id) return NextResponse.json({ error: "product_id 필요" }, { status: 400 });
+  const { error } = await mutate(id, product_id, "remove");
+  if (error) return NextResponse.json({ error }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}

--- a/promo-analytics/supabase/migrations/0050_sku_exclusion.sql
+++ b/promo-analytics/supabase/migrations/0050_sku_exclusion.sql
@@ -1,0 +1,169 @@
+-- 0050: SKU 품절(미판매) 제외 (피드백 1)
+--
+-- 매출 0(품절·미판매)인 플랜 SKU를 '품절 처리'하면 플랜·성과(달성률)·미매칭에서 모두 제외.
+-- → 매칭 검증을 완료할 수 있고, 안 팔린 품절품이 달성률을 끌어내리지 않는다.
+-- plan_vs_actual / sku_match_diagnostic 의 plan_raw 에서 동일 기준(promotion_id+product_id)으로 빠진다.
+-- (두 함수는 현재 운영본 정의를 그대로 옮기고 plan_raw WHERE 에 not exists 필터만 추가)
+
+create table if not exists promo.promotion_excluded_skus (
+  promotion_id uuid not null references promo.promotions(id) on delete cascade,
+  product_id   uuid not null references promo.products(id) on delete cascade,
+  created_at   timestamptz not null default now(),
+  primary key (promotion_id, product_id)
+);
+alter table promo.promotion_excluded_skus enable row level security;
+drop policy if exists promotion_excluded_skus_auth on promo.promotion_excluded_skus;
+create policy promotion_excluded_skus_auth on promo.promotion_excluded_skus
+  for all to authenticated using (true) with check (true);
+
+create or replace function promo.plan_vs_actual(p_id uuid)
+ returns table(product_id uuid, base_name text, expected_qty numeric, expected_revenue numeric, expected_contribution numeric, actual_qty numeric, actual_revenue numeric, actual_contribution numeric, ach_qty numeric, ach_revenue numeric, ach_contribution numeric, status text)
+ language sql stable set search_path to '' as $function$
+  with plan as (
+    select id, (rate_card_snapshot->>'mult')::numeric as mult,
+      coalesce(actual_promotion_id, promotion_id) as actual_pid
+    from promo.campaign_plans
+    where promotion_id = p_id and is_current and status = 'confirmed' limit 1
+  ),
+  plan_raw as (
+    select i.product_id, pr.base_name,
+      promo.normalize_sku_name(pr.base_name) as match_key,
+      o.expected_option_qty * i.sku_qty_per_option as eq,
+      o.expected_option_qty * i.sku_qty_per_option * i.unit_sale_price as er,
+      o.expected_option_qty * i.sku_qty_per_option *
+        (i.unit_sale_price * (select mult from plan) - coalesce(i.frozen_cost,0)) as ec
+    from promo.campaign_plan_options o
+    join promo.campaign_plan_option_items i on i.campaign_plan_option_id = o.id
+    left join promo.products pr on pr.id = i.product_id
+    where o.campaign_plan_id = (select id from plan)
+      and not exists (select 1 from promo.promotion_excluded_skus x
+        where x.promotion_id = p_id and x.product_id = i.product_id)
+  ),
+  exp as (
+    select match_key,
+      (array_agg(product_id order by product_id))[1] as product_id,
+      (array_agg(base_name order by base_name))[1] as base_name,
+      sum(eq) as expected_qty, sum(er) as expected_revenue, sum(ec) as expected_contribution
+    from plan_raw group by match_key
+  ),
+  mapped_sales as (
+    select coalesce(m.plan_product_id, ps.product_id) as product_id, pr.base_name,
+      promo.normalize_sku_name(pr.base_name) as match_key, ps.quantity, ps.revenue, ps.cost
+    from promo.promotion_sales ps
+    left join promo.promotion_sku_mappings m
+      on m.promotion_id = ps.promotion_id and m.actual_product_id = ps.product_id
+    left join promo.products pr on pr.id = coalesce(m.plan_product_id, ps.product_id)
+    where ps.promotion_id = (select actual_pid from plan)
+      and ps.product_id is not null and exists (select 1 from plan)
+  ),
+  act as (
+    select match_key,
+      (array_agg(product_id order by product_id))[1] as product_id,
+      (array_agg(base_name order by base_name))[1] as base_name,
+      sum(quantity) as actual_qty, sum(revenue) as actual_revenue,
+      sum(revenue) * (select mult from plan) - sum(coalesce(cost,0)) as actual_contribution
+    from mapped_sales group by match_key
+  ),
+  j as (
+    select coalesce(e.product_id, a.product_id) as product_id,
+      coalesce(e.base_name, a.base_name) as base_name,
+      coalesce(e.expected_qty,0) as expected_qty,
+      coalesce(e.expected_revenue,0) as expected_revenue,
+      coalesce(e.expected_contribution,0) as expected_contribution,
+      coalesce(a.actual_qty,0) as actual_qty,
+      coalesce(a.actual_revenue,0) as actual_revenue,
+      coalesce(a.actual_contribution,0) as actual_contribution,
+      (e.match_key is not null and (coalesce(e.expected_qty,0) > 0 or coalesce(e.expected_revenue,0) > 0)) as has_exp,
+      (a.match_key is not null and (coalesce(a.actual_qty,0) <> 0 or coalesce(a.actual_revenue,0) <> 0)) as has_act
+    from exp e full outer join act a on a.match_key = e.match_key
+  )
+  select product_id, base_name, expected_qty, expected_revenue, expected_contribution,
+    actual_qty, actual_revenue, actual_contribution,
+    case when expected_qty > 0 then actual_qty/expected_qty else null end as ach_qty,
+    case when expected_revenue > 0 then actual_revenue/expected_revenue else null end as ach_revenue,
+    case when expected_contribution > 0 then actual_contribution/expected_contribution else null end as ach_contribution,
+    case when has_exp and has_act then 'matched' when has_exp and not has_act then 'unsold' else 'unplanned' end as status
+  from j where has_exp or has_act;
+$function$;
+
+create or replace function promo.sku_match_diagnostic(p_id uuid)
+ returns table(side text, product_id uuid, base_name text, dr_code text, expected_qty numeric, expected_revenue numeric, actual_qty numeric, actual_revenue numeric, is_mapped boolean, is_subscription boolean, is_subscription_override boolean)
+ language sql stable set search_path to '' as $function$
+  with current_plan as (
+    select id, coalesce(actual_promotion_id, promotion_id) as actual_pid
+    from promo.campaign_plans where promotion_id = p_id and is_current
+    order by version desc limit 1
+  ),
+  plan_raw as (
+    select cpoi.product_id, pr.base_name, pr.dr_code,
+      promo.normalize_sku_name(pr.base_name) as match_key,
+      cpo.expected_option_qty * cpoi.sku_qty_per_option as q,
+      cpo.expected_option_qty * cpoi.sku_qty_per_option * cpoi.unit_sale_price as r
+    from promo.campaign_plan_options cpo
+    join promo.campaign_plan_option_items cpoi on cpoi.campaign_plan_option_id = cpo.id
+    left join promo.products pr on pr.id = cpoi.product_id
+    where cpo.campaign_plan_id = (select id from current_plan)
+      and not exists (select 1 from promo.promotion_excluded_skus x
+        where x.promotion_id = p_id and x.product_id = cpoi.product_id)
+  ),
+  plan_skus as (
+    select match_key,
+      (array_agg(product_id order by product_id))[1] as product_id,
+      (array_agg(base_name order by base_name))[1] as base_name,
+      (array_agg(dr_code order by dr_code) filter (where dr_code is not null))[1] as dr_code,
+      sum(q) as expected_qty, sum(r) as expected_revenue
+    from plan_raw group by match_key
+  ),
+  mapped_sales as (
+    select coalesce(m.plan_product_id, ps.product_id) as product_id,
+      (m.plan_product_id is not null) as is_mapped,
+      pr.base_name, pr.dr_code, promo.normalize_sku_name(pr.base_name) as match_key,
+      (coalesce(pr.is_subscription, false)
+        or promo.is_subscription_positive(ps.option_info)) as is_sub,
+      ps.quantity, ps.revenue
+    from promo.promotion_sales ps
+    left join promo.promotion_sku_mappings m
+      on m.promotion_id = ps.promotion_id and m.actual_product_id = ps.product_id
+    left join promo.products pr on pr.id = coalesce(m.plan_product_id, ps.product_id)
+    where ps.promotion_id = coalesce((select actual_pid from current_plan), p_id)
+      and ps.product_id is not null
+  ),
+  actual_skus as (
+    select match_key, is_sub,
+      (array_agg(product_id order by product_id))[1] as product_id,
+      (array_agg(base_name order by base_name))[1] as base_name,
+      (array_agg(dr_code order by dr_code) filter (where dr_code is not null))[1] as dr_code,
+      bool_or(is_mapped) as is_mapped, sum(quantity) as actual_qty, sum(revenue) as actual_revenue
+    from mapped_sales group by match_key, is_sub
+  ),
+  combined as (
+    select coalesce(p.product_id, a.product_id) as product_id,
+      coalesce(p.base_name, a.base_name) as base_name,
+      coalesce(p.dr_code, a.dr_code) as dr_code,
+      coalesce(p.expected_qty, 0) as expected_qty,
+      coalesce(p.expected_revenue, 0) as expected_revenue,
+      coalesce(a.actual_qty, 0) as actual_qty,
+      coalesce(a.actual_revenue, 0) as actual_revenue,
+      coalesce(a.is_mapped, false) as is_mapped,
+      coalesce(a.is_sub, false) as is_subscription,
+      case when p.match_key is not null and a.match_key is not null then 'both'
+        when p.match_key is not null then 'plan' else 'actual' end as side
+    from plan_skus p
+    full outer join actual_skus a
+      on a.match_key = p.match_key and coalesce(a.is_sub, false) = false
+  )
+  select c.side, c.product_id, c.base_name, c.dr_code,
+    c.expected_qty, c.expected_revenue, c.actual_qty, c.actual_revenue, c.is_mapped,
+    c.is_subscription,
+    coalesce(sp.is_subscription, false) as is_subscription_override
+  from combined c
+  left join promo.products sp on sp.id = c.product_id
+  order by
+    case c.side when 'both' then 0 when 'plan' then 1 else 2 end,
+    c.is_subscription,
+    coalesce(c.expected_revenue, 0) desc, coalesce(c.actual_revenue, 0) desc;
+$function$;
+
+grant execute on all functions in schema promo to authenticated;
+grant all on all tables in schema promo to authenticated;
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## SKU 품절(미판매) 제외 처리 (피드백 1)

매출 0(품절·미판매)인 플랜 SKU를 **'품절' 처리**하면 **플랜·성과(달성률)·미매칭에서 모두 제외** → 매칭 검증 완료 가능, 안 팔린 품절품이 달성률을 끌어내리지 않음.

### 변경
- **0050**: `promotion_excluded_skus` 테이블(RLS) + `plan_vs_actual`·`sku_match_diagnostic`의 `plan_raw`에 `not exists` 제외 필터. *(현재 운영본 정의를 그대로 옮기고 필터만 추가 — 구독 처리 등 기존 로직 보존)*
  - **실데이터 검증(벌크UP 세일)**: 포캣트릿 북어 제외 시 **미매칭 2→1, unsold 2→1, 기대매출 −29만** 정확 반영. 테스트 데이터는 정리함.
- **API** `/excluded-skus`: POST(제외)/DELETE(복원) + 롤업 갱신.
- **SkuMatchPanel**: 미매칭 행에 **`품절`** 버튼 + **`품절·미판매 제외 N건`** 복원 목록(optimistic).
- **Achievement·page**: `excludedSkus` threading.

### 검증
prod 마이그레이션 적용·**실데이터 검증**, `tsc`·테스트·`build` 통과. 측정 RPC는 현재 본문 기준으로 최소 수정(롤백 안전성 확인).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_