### PR TITLE
채널 수수료 → 공헌이익 mult 반영 + 엑셀 (피드백 8 — 2단계)

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
@@ -8,7 +8,7 @@ import type { CampaignPlan, RateCard } from "@/lib/types";
 import {
   computeOptionTotals,
   computePlanTotals,
-  rateCardMult,
+  effectiveMult,
   type PlanItemInput,
   type CouponSpec,
 } from "@/lib/plan";
@@ -91,6 +91,8 @@ export default function PlanEditor({
   campaignName,
   startDate,
   endDate,
+  channel,
+  channelFee,
 }: {
   promotionId: string;
   plan: CampaignPlan | null;
@@ -101,6 +103,8 @@ export default function PlanEditor({
   campaignName?: string;
   startDate?: string;
   endDate?: string;
+  channel?: string | null;
+  channelFee?: number | null;
 }) {
   const router = useRouter();
   const [options, setOptions] = useState<OptState[]>(() => toState(initialOptions));
@@ -135,7 +139,7 @@ export default function PlanEditor({
   const mult = confirmed
     ? plan?.rate_card_snapshot?.mult ?? 0.715
     : rateCard
-      ? rateCardMult(rateCard)
+      ? effectiveMult(rateCard, channelFee)
       : 0.715;
 
   // ── 작성 중 자동 임시저장 (item 11) ──────────
@@ -469,6 +473,7 @@ export default function PlanEditor({
         period: startDate && endDate ? `${startDate} ~ ${endDate}` : "",
         version: `v${plan!.version}`,
         purposes: purposes ?? [],
+        channel: channel ?? null,
       },
       exOptions,
       {

--- a/promo-analytics/app/(dash)/promotions/[id]/plan/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/page.tsx
@@ -25,10 +25,21 @@ export default async function PlanPage({
 
   const { data: promo } = await supabase
     .from("promotions")
-    .select("id, name, start_date, end_date, purposes")
+    .select("id, name, start_date, end_date, purposes, channel")
     .eq("id", id)
     .single();
   if (!promo) notFound();
+
+  // 채널 수수료 — 공헌이익 mult에 반영(없으면 레이트카드 fee)
+  let channelFee: number | null = null;
+  if (promo.channel) {
+    const { data: cf } = await supabase
+      .from("channel_fees")
+      .select("fee_rate")
+      .eq("channel", promo.channel as string)
+      .maybeSingle();
+    channelFee = (cf?.fee_rate as number | undefined) ?? null;
+  }
 
   // 편집 대상 = 최신 버전 플랜
   const { data: plans } = await supabase
@@ -166,6 +177,8 @@ export default async function PlanPage({
         campaignName={promo.name as string}
         startDate={promo.start_date as string}
         endDate={promo.end_date as string}
+        channel={(promo.channel as string | null) ?? null}
+        channelFee={channelFee}
       />
     </div>
   );

--- a/promo-analytics/app/api/promotions/[id]/plan/route.ts
+++ b/promo-analytics/app/api/promotions/[id]/plan/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import { computeOptionTotals, rateCardMult, type PlanItemInput } from "@/lib/plan";
+import { computeOptionTotals, effectiveMult, type PlanItemInput } from "@/lib/plan";
 
 export const runtime = "nodejs";
 
@@ -69,7 +69,22 @@ export async function PATCH(
       .order("effective_from", { ascending: false })
       .limit(1)
       .maybeSingle();
-    const mult = rc ? rateCardMult(rc) : 0.715;
+    // 채널 수수료 override (없으면 레이트카드 fee)
+    const { data: promoRow } = await supabase
+      .from("promotions")
+      .select("channel")
+      .eq("id", id)
+      .maybeSingle();
+    let channelFee: number | null = null;
+    if (promoRow?.channel) {
+      const { data: cf } = await supabase
+        .from("channel_fees")
+        .select("fee_rate")
+        .eq("channel", promoRow.channel as string)
+        .maybeSingle();
+      channelFee = (cf?.fee_rate as number | undefined) ?? null;
+    }
+    const mult = rc ? effectiveMult(rc, channelFee) : 0.715;
 
     const productIds = [
       ...new Set(options.flatMap((o) => o.items.map((it) => it.product_id))),

--- a/promo-analytics/lib/plan-export.ts
+++ b/promo-analytics/lib/plan-export.ts
@@ -35,6 +35,7 @@ export type ExportMeta = {
   period: string; // "2026-06-08 ~ 2026-06-14"
   version: string; // "v2"
   purposes: string[]; // 목적
+  channel?: string | null; // 판매 채널
 };
 
 const PLAN_HEADER = [
@@ -95,6 +96,7 @@ export function buildPlanWorkbook(
     ["캠페인", meta.campaign],
     ["기간", meta.period],
     ["플랜 버전", meta.version],
+    ["판매 채널", meta.channel || "—"],
     ["목적", meta.purposes.length ? meta.purposes.join(", ") : "—"],
     ["예상 매출액", Math.round(summary.revenue)],
     ["구매건수(세트)", summary.order_count],

--- a/promo-analytics/lib/plan.ts
+++ b/promo-analytics/lib/plan.ts
@@ -15,6 +15,15 @@ export function rateCardMult(rc: {
   return 1 - (rc.fee_rate + rc.ad_rate + rc.logistics_rate + rc.reward_rate);
 }
 
+/** 채널 수수료 override 반영 mult — 채널 fee 가 있으면 레이트카드 fee 대신 사용 (피드백 8) */
+export function effectiveMult(
+  rc: { fee_rate: number; ad_rate: number; logistics_rate: number; reward_rate: number },
+  channelFeeRate: number | null | undefined,
+): number {
+  const fee = channelFeeRate != null ? channelFeeRate : rc.fee_rate;
+  return 1 - (fee + rc.ad_rate + rc.logistics_rate + rc.reward_rate);
+}
+
 /** 단가 ↔ 소비자가 대비 할인율 양방향 바인딩 헬퍼 */
 export function priceFromDiscount(consumerPrice: number, discount: number): number {
   return Math.round(consumerPrice * (1 - discount));

--- a/promo-analytics/supabase/migrations/0052_confirm_plan_channel_fee.sql
+++ b/promo-analytics/supabase/migrations/0052_confirm_plan_channel_fee.sql
@@ -1,0 +1,122 @@
+-- 0052: 확정 시 채널 수수료를 공헌이익 mult에 반영 (피드백 8 — 2단계)
+--
+-- confirm_plan 이 mult 동결 시, 캠페인 채널의 수수료(channel_fees)가 있으면 그것으로,
+-- 없으면 레이트카드 fee_rate 를 쓴다. 채널이 모두 동일값으로 시드된 상태에서는 동작 불변.
+-- (현재 운영본 정의 그대로 + v_fee override 만 추가)
+
+create or replace function promo.confirm_plan(p_plan_id uuid)
+ returns void
+ language plpgsql
+ set search_path to ''
+as $function$
+declare
+  v_promo uuid;
+  v_rc record;
+  v_fee numeric;
+  v_mult numeric;
+  v_snapshot jsonb;
+  v_opt_count int;
+  v_bad_opt int;
+  v_rev_total numeric;
+  v_contrib_total numeric;
+  v_cmin numeric;
+  v_crate numeric;
+  v_cmax numeric;
+begin
+  select promotion_id, coalesce(coupon_min_order,0), coalesce(coupon_rate,0), coalesce(coupon_max,0)
+    into v_promo, v_cmin, v_crate, v_cmax
+  from promo.campaign_plans where id = p_plan_id;
+  if v_promo is null then
+    raise exception 'plan % not found', p_plan_id;
+  end if;
+
+  select count(*) into v_opt_count
+  from promo.campaign_plan_options
+  where campaign_plan_id = p_plan_id and expected_option_qty > 0;
+  if v_opt_count = 0 then
+    raise exception '확정하려면 예상 세트수가 1 이상인 옵션이 최소 1개 필요합니다';
+  end if;
+
+  select count(*) into v_bad_opt
+  from promo.campaign_plan_options o
+  where o.campaign_plan_id = p_plan_id
+    and not exists (
+      select 1 from promo.campaign_plan_option_items i
+      where i.campaign_plan_option_id = o.id
+    );
+  if v_bad_opt > 0 then
+    raise exception '구성 SKU가 없는 옵션이 % 개 있습니다', v_bad_opt;
+  end if;
+
+  select * into v_rc from promo.rate_card where is_current order by effective_from desc limit 1;
+  if v_rc is null then
+    raise exception 'current rate_card 가 없습니다';
+  end if;
+  -- 채널 수수료 override: 캠페인 채널의 수수료가 있으면 그것으로, 없으면 레이트카드 fee
+  select cf.fee_rate into v_fee
+  from promo.promotions pr
+  left join promo.channel_fees cf on cf.channel = pr.channel
+  where pr.id = v_promo;
+  v_fee := coalesce(v_fee, v_rc.fee_rate);
+  v_mult := 1 - (v_fee + v_rc.ad_rate + v_rc.logistics_rate + v_rc.reward_rate);
+  v_snapshot := jsonb_build_object(
+    'fee_rate', v_fee, 'ad_rate', v_rc.ad_rate,
+    'logistics_rate', v_rc.logistics_rate, 'reward_rate', v_rc.reward_rate,
+    'mult', v_mult, 'rate_card_id', v_rc.id, 'snapped_at', now()
+  );
+
+  update promo.campaign_plan_option_items i
+  set frozen_consumer_price = p.consumer_price,
+      frozen_regular_price  = p.regular_price,
+      frozen_cost           = p.cost,
+      updated_at = now()
+  from promo.products p
+  where i.product_id = p.id
+    and i.campaign_plan_option_id in (
+      select id from promo.campaign_plan_options where campaign_plan_id = p_plan_id
+    );
+
+  update promo.campaign_plan_options o
+  set set_price = agg.set_price,
+      consumer_total = agg.consumer_total,
+      regular_total = agg.regular_total,
+      discount_rate_consumer = case when agg.consumer_total > 0 then 1 - agg.set_price/agg.consumer_total else null end,
+      discount_rate_regular  = case when agg.regular_total  > 0 then 1 - agg.set_price/agg.regular_total  else null end,
+      expected_revenue = agg.net_price * o.expected_option_qty,
+      expected_contribution = (agg.net_price * v_mult - agg.cost_total) * o.expected_option_qty,
+      updated_at = now()
+  from (
+    select a.oid, a.set_price, a.consumer_total, a.regular_total, a.cost_total,
+           a.set_price - (
+             case when v_crate > 0 and a.set_price >= v_cmin
+                  then round(least(a.set_price * v_crate,
+                                   case when v_cmax > 0 then v_cmax else a.set_price * v_crate end))
+                  else 0 end
+           ) as net_price
+    from (
+      select i.campaign_plan_option_id as oid,
+             sum(i.sku_qty_per_option * i.unit_sale_price)                   as set_price,
+             sum(i.sku_qty_per_option * coalesce(i.frozen_consumer_price,0)) as consumer_total,
+             sum(i.sku_qty_per_option * coalesce(i.frozen_regular_price,0))  as regular_total,
+             sum(i.sku_qty_per_option * coalesce(i.frozen_cost,0))           as cost_total
+      from promo.campaign_plan_option_items i
+      group by i.campaign_plan_option_id
+    ) a
+  ) agg
+  where o.id = agg.oid and o.campaign_plan_id = p_plan_id;
+
+  select coalesce(sum(expected_revenue),0), coalesce(sum(expected_contribution),0)
+  into v_rev_total, v_contrib_total
+  from promo.campaign_plan_options where campaign_plan_id = p_plan_id;
+
+  update promo.campaign_plans
+  set is_current = false, updated_at = now()
+  where promotion_id = v_promo and is_current and id <> p_plan_id;
+
+  update promo.campaign_plans
+  set status='confirmed', confirmed_at=now(), rate_card_id=v_rc.id,
+      rate_card_snapshot=v_snapshot, expected_revenue_total=v_rev_total,
+      expected_contribution_total=v_contrib_total, is_current=true, updated_at=now()
+  where id = p_plan_id;
+end;
+$function$;


### PR DESCRIPTION
## 채널 수수료 → 공헌이익 mult 반영 + 엑셀 (피드백 8 — 2단계)

채널 수수료가 **공헌이익 계산에 실제 반영**(채널 fee 있으면 레이트카드 fee 대신). 모든 채널이 0.045로 시드돼 **값을 바꾸기 전엔 동작 불변(안전)**.

### 변경
- **`lib/plan.effectiveMult(rc, channelFee)`** 헬퍼.
- **0052 `confirm_plan`**: 동결 mult에 채널 fee override(없으면 레이트카드 fee). 현재 운영본 정의 그대로 + `v_fee`만 추가. **검증**: 채널 null→0.045, 채널 지정→채널 fee.
- **플랜 에디터(draft 라이브 mult)·플랜 저장 API**: `effectiveMult` 사용(`promotions.channel`→`channel_fees`).
- **엑셀 내보내기 요약**에 `판매 채널` 행 추가.

### 검증
prod `confirm_plan` 적용·override 로직 SQL 검증, `tsc`·**64 테스트**·`build` 통과.

> 예: 29CM 수수료를 30%로 설정하면 그 캠페인의 공헌 mult가 `1−(0.30+0.10+0.12+0.02)=0.46`으로 자동 반영됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_