### PR TITLE
fix: 품절 처리 후 미매칭 카드 잔존 버그 + 미매칭 뱃지 정정

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/SkuMatchPanel.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/SkuMatchPanel.tsx
@@ -84,7 +84,7 @@ export default function SkuMatchPanel({
   async function markSoldout(p: { product_id: string; base_name: string }) {
     if (soldoutBusy) return;
     setSoldoutBusy(p.product_id);
-    setLocalRows((rs) => rs.filter((r) => r.product_id !== p.product_id)); // optimistic
+    // 낙관적: 제외 목록에 추가 → visibleRows 필터로 매칭 카드/진단표에서 즉시 사라짐
     setLocalExcluded((e) => [...e, { product_id: p.product_id, base_name: p.base_name }]);
     try {
       const res = await fetch(`/api/promotions/${promotionId}/excluded-skus`, {
@@ -95,8 +95,7 @@ export default function SkuMatchPanel({
       if (!res.ok) throw new Error();
       router.refresh();
     } catch {
-      setLocalExcluded((e) => e.filter((x) => x.product_id !== p.product_id));
-      setLocalRows(rows); // rollback
+      setLocalExcluded((e) => e.filter((x) => x.product_id !== p.product_id)); // rollback
     } finally {
       setSoldoutBusy(null);
     }
@@ -120,9 +119,15 @@ export default function SkuMatchPanel({
     }
   }
 
-  const matched = localRows.filter((r) => r.side === "both" || r.is_mapped);
-  const planOnly = localRows.filter((r) => r.side === "plan" && !r.is_mapped);
-  const actualOnly = localRows.filter((r) => r.side === "actual" && !r.is_mapped);
+  // 품절 제외된 SKU는 저장 롤업 갱신(cron) 전에도 즉시 화면에서 빠지도록 클라이언트에서 필터
+  const excludedSet = useMemo(() => new Set(localExcluded.map((e) => e.product_id)), [localExcluded]);
+  const visibleRows = useMemo(
+    () => localRows.filter((r) => !excludedSet.has(r.product_id)),
+    [localRows, excludedSet],
+  );
+  const matched = visibleRows.filter((r) => r.side === "both" || r.is_mapped);
+  const planOnly = visibleRows.filter((r) => r.side === "plan" && !r.is_mapped);
+  const actualOnly = visibleRows.filter((r) => r.side === "actual" && !r.is_mapped);
   const planOnlyRevenue = planOnly.reduce((s, r) => s + (r.expected_revenue ?? 0), 0);
   const actualOnlyRevenue = actualOnly.reduce((s, r) => s + (r.actual_revenue ?? 0), 0);
   const nameOf = useMemo(() => {
@@ -211,10 +216,10 @@ export default function SkuMatchPanel({
   }
 
   const filtered = query.trim()
-    ? localRows.filter(
+    ? visibleRows.filter(
         (r) => r.base_name.includes(query.trim()) || (r.dr_code ?? "").includes(query.trim()),
       )
-    : localRows;
+    : visibleRows;
   const { sorted: sortedRows, toggle: sortBy, arrow } = useTableSort<DiagnosticRow>(filtered, null, "desc");
 
   return (
@@ -230,7 +235,9 @@ export default function SkuMatchPanel({
             <span className="rounded-full bg-warning-soft px-2 py-0.5 text-warning">플랜 미매칭 {planOnly.length}</span>
           )}
           {actualOnly.length > 0 && (
-            <span className="rounded-full bg-soft px-2 py-0.5 text-ink-3">성과 미매칭 {actualOnly.length}</span>
+            <span className="rounded-full bg-soft px-2 py-0.5 text-ink-3" title="계획에 없던 동반구매 — 보정 불필요, 함께 구매 성과로 집계됩니다">
+              계획 외 판매 {actualOnly.length}
+            </span>
           )}
         </div>
       </div>

--- a/promo-analytics/app/(dash)/promotions/[id]/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/page.tsx
@@ -175,8 +175,17 @@ export default async function PromotionDetail({
   // 새 모델: 성과는 이 캠페인에 직접 올린다. 성과(실 매출)가 실제로 있을 때만
   // 매칭·달성 관련 UI를 노출한다 (성과 0인데 미매칭/성과연결 노티 X).
   const hasActuals = (achSummary?.campaign_revenue_total ?? 0) > 0;
+  // '보정 필요'는 플랜에 있으나 성과와 매칭 안 된 SKU(planOnly)만 — 품절 제외분은 빼고,
+  // actualOnly(성과만=계획에 없던 동반구매)는 정상이라 보정 대상이 아니다.
+  const excludedIdSet = new Set(excludedSkus.map((e) => e.product_id));
   const unmatchedCount = hasActuals
-    ? diagnosticRows.filter((r) => r.side !== "both" && !r.is_mapped && !r.is_subscription).length
+    ? diagnosticRows.filter(
+        (r) =>
+          r.side === "plan" &&
+          !r.is_mapped &&
+          !r.is_subscription &&
+          !excludedIdSet.has(r.product_id),
+      ).length
     : 0;
   const wfInput = {
     hasPlan: !!plan,

--- a/promo-analytics/app/api/promotions/[id]/excluded-skus/route.ts
+++ b/promo-analytics/app/api/promotions/[id]/excluded-skus/route.ts
@@ -4,7 +4,9 @@ import { createClient } from "@/lib/supabase/server";
 export const runtime = "nodejs";
 
 // 품절(미판매) SKU 제외 토글 (피드백 1). 제외하면 플랜·성과·미매칭에서 빠진다.
-// POST = 제외 추가, DELETE = 제외 해제. 변경 후 롤업 갱신.
+// POST = 제외 추가, DELETE = 제외 해제.
+// 저장 롤업 갱신은 promotion_excluded_skus 트리거(mark_rollups_dirty)→cron 이 처리하고,
+// 매칭 패널은 excludedSkus 로 즉시 필터링한다(무거운 동기 refresh_rollups 호출 제거).
 async function mutate(
   id: string,
   product_id: string,
@@ -24,7 +26,6 @@ async function mutate(
       .eq("product_id", product_id);
     if (error) return { error: error.message };
   }
-  await supabase.rpc("refresh_rollups", { p_force: true });
   return {};
 }
 

--- a/promo-analytics/supabase/migrations/0053_excluded_skus_dirty_trigger.sql
+++ b/promo-analytics/supabase/migrations/0053_excluded_skus_dirty_trigger.sql
@@ -1,0 +1,10 @@
+-- 0053: 품절 제외 변경 시 롤업 dirty 표시 (cron 재빌드 트리거)
+--
+-- promotion_excluded_skus 에 mark_rollups_dirty 트리거가 없어, 품절 제외 후에도 저장 롤업
+-- (campaign_rollups.diagnostic / pva_summary)이 갱신되지 않아 미매칭 카드가 계속 떴던 버그 수정.
+-- 다른 측정 테이블과 동일하게 변경 시 rollup_state.version 을 올려 cron(2분) 재빌드가 반영한다.
+
+drop trigger if exists promotion_excluded_skus_dirty on promo.promotion_excluded_skus;
+create trigger promotion_excluded_skus_dirty
+after insert or update or delete on promo.promotion_excluded_skus
+for each statement execute function promo.mark_rollups_dirty();


### PR DESCRIPTION
## 버그: 품절 눌러도 미매칭 연동 카드가 계속 뜸

**원인**: `promotion_excluded_skus`에 롤업 dirty 트리거가 없어 **저장 롤업**(`campaign_rollups.diagnostic`)이 갱신되지 않음. 매칭 패널은 그 저장 진단을 읽어 품절 SKU가 계속 표시됨. (API의 `refresh_rollups(true)`는 전 캠페인 전체 재빌드라 advisory-lock no-op/서버리스 타임아웃으로 불안정.)

### 수정
- **0053**: `promotion_excluded_skus` 트리거 → `mark_rollups_dirty`. 검증: 제외 토글 시 `rollup_state.version` bump·`dirty=true` → cron(2분) 재빌드.
- **SkuMatchPanel**: 제외 SKU를 `excludedSkus`로 **즉시 클라이언트 필터(visibleRows)** — 롤업 타이밍과 무관하게 매칭 카드/진단표에서 바로 사라짐. 복원도 즉시.
- **excluded-skus API**: 무거운 동기 `refresh_rollups` 호출 제거(트리거가 처리).
- **'보정 필요' 뱃지**: `planOnly`(조치 대상)만 + 품절 제외. `actualOnly`(성과만=계획 외 **동반구매**)는 보정 대상 아님 → 뱃지 라벨 **'계획 외 판매'** 로 명확화.

### 검증
prod 트리거 적용·실데이터 검증(벌크UP 저장 롤업 planOnly **0**, 제외 2건 반영), `tsc`·`build` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_