### PR TITLE
Excel 가져오기 — 양식 업로드로 플랜 자동 채우기 (로드맵 3.2)

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
@@ -18,6 +18,8 @@ import { InlineAlert, Dialog, DialogContent, DialogHeader, DialogFooter, Button 
 import PlanLoadPanel from "./PlanLoadPanel";
 import SubProductSuggest, { type Bench } from "./SubProductSuggest";
 import { downloadPlanXlsx, type ExportOption } from "@/lib/plan-export";
+import { parsePlanWorkbook } from "@/lib/plan-import";
+import { ensureProducts } from "@/lib/products";
 
 export type EditorItem = {
   product_id: string;
@@ -487,6 +489,64 @@ export default function PlanEditor({
     );
   }
 
+  // Excel 가져오기 (로드맵 3.2) — 내보낸 양식의 '플랜' 시트를 파싱해 옵션을 추가
+  async function importXlsx(file: File) {
+    setBusy(true);
+    setMsg(null);
+    try {
+      const buf = await file.arrayBuffer();
+      const { options: parsed } = parsePlanWorkbook(buf);
+      if (parsed.length === 0)
+        throw new Error("'플랜' 시트를 찾지 못했습니다 — 내보낸 양식인지 확인하세요.");
+      const supabase = createClient();
+      const names = [...new Set(parsed.flatMap((o) => o.items.map((it) => it.base_name)))];
+      const idMap = await ensureProducts(supabase, names);
+      const ids = [...new Set([...idMap.values()])];
+      const econ: Record<string, { consumer_price: number | null; regular_price: number | null; cost: number | null }> = {};
+      if (ids.length > 0) {
+        const { data: prods } = await supabase
+          .from("products")
+          .select("id, consumer_price, regular_price, cost")
+          .in("id", ids);
+        for (const p of prods ?? [])
+          econ[p.id as string] = {
+            consumer_price: p.consumer_price as number | null,
+            regular_price: p.regular_price as number | null,
+            cost: p.cost as number | null,
+          };
+      }
+      const editorOpts: EditorOption[] = parsed.map((o) => ({
+        option_label: o.option_label,
+        expected_option_qty: o.expected_option_qty,
+        is_main: o.is_main,
+        match_patterns: [],
+        frozen: null,
+        items: o.items
+          .map((it) => {
+            const pid = idMap.get(it.base_name) ?? "";
+            const e = econ[pid];
+            return {
+              product_id: pid,
+              base_name: it.base_name,
+              sku_qty_per_option: it.sku_qty_per_option,
+              unit_sale_price: it.unit_sale_price,
+              source_config_id: null,
+              consumer_price: e?.consumer_price ?? null,
+              regular_price: e?.regular_price ?? null,
+              cost: e?.cost ?? it.cost ?? null,
+            };
+          })
+          .filter((it) => it.product_id),
+      }));
+      loadPlanOptions(editorOpts);
+      setMsg({ kind: "ok", text: `엑셀에서 옵션 ${editorOpts.length}개를 불러왔습니다. 검토 후 저장하세요.` });
+    } catch (e) {
+      setMsg({ kind: "err", text: e instanceof Error ? e.message : "가져오기 실패" });
+    } finally {
+      setBusy(false);
+    }
+  }
+
   async function onClone() {
     setBusy(true);
     setMsg(null);
@@ -703,6 +763,25 @@ export default function PlanEditor({
         >
           ⬇ Excel 내보내기
         </button>
+        {!confirmed && (
+          <label
+            className={`cursor-pointer rounded-xl border border-line px-4 py-2 text-sm font-medium text-ink-2 hover:bg-soft ${busy ? "pointer-events-none opacity-50" : ""}`}
+            title="내보낸 양식의 엑셀을 올려 옵션을 한 번에 채우기"
+          >
+            ⬆ Excel 가져오기
+            <input
+              type="file"
+              accept=".xlsx,.xls"
+              className="hidden"
+              disabled={busy}
+              onChange={(e) => {
+                const f = e.target.files?.[0];
+                if (f) importXlsx(f);
+                e.target.value = "";
+              }}
+            />
+          </label>
+        )}
         {confirmed ? (
           <button
             onClick={onClone}

--- a/promo-analytics/lib/__tests__/plan-import.test.ts
+++ b/promo-analytics/lib/__tests__/plan-import.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import * as XLSX from "xlsx";
+import { buildPlanWorkbook, type ExportOption } from "../plan-export";
+import { parsePlanWorkbook } from "../plan-import";
+
+const options: ExportOption[] = [
+  {
+    label: "모래 4묶음 세트",
+    is_main: true,
+    expected_option_qty: 400,
+    net_price: 63500,
+    discount_rate_consumer: 0.458,
+    expected_revenue: 24130000,
+    expected_contribution: 7431563,
+    items: [
+      { base_name: "퓨저나이트 슈퍼볼 4.3kg", sku_qty: 4, unit_price: 10900, cost: 8000, consumer_price: 21800 },
+      { base_name: "바이바이배드 500ml", sku_qty: 1, unit_price: 19900, cost: 9000, consumer_price: 30000 },
+    ],
+  },
+  {
+    label: "단품",
+    is_main: false,
+    expected_option_qty: 120,
+    net_price: 12900,
+    discount_rate_consumer: 0.3,
+    expected_revenue: 1548000,
+    expected_contribution: 400000,
+    items: [{ base_name: "포캣트릿 닭가슴살 25g", sku_qty: 1, unit_price: 12900, cost: 4000, consumer_price: 18000 }],
+  },
+];
+
+describe("parsePlanWorkbook (내보내기↔가져오기 왕복)", () => {
+  const wb = buildPlanWorkbook(
+    { campaign: "테스트", period: "2026-06-08 ~ 2026-06-14", version: "v1", purposes: ["세일즈"], channel: "공식몰" },
+    options,
+    { revenue: 25678000, order_count: 520, sku_units: 2120, contribution: 7831563, contribution_rate: 0.305 },
+    null,
+  );
+  const out = XLSX.write(wb, { type: "array", bookType: "xlsx" });
+  const buf = (out instanceof Uint8Array ? out.buffer : out) as ArrayBuffer;
+  const { options: parsed } = parsePlanWorkbook(buf);
+
+  it("옵션 수·라벨·메인·예상세트수 복원", () => {
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0].option_label).toBe("모래 4묶음 세트");
+    expect(parsed[0].is_main).toBe(true);
+    expect(parsed[0].expected_option_qty).toBe(400);
+    expect(parsed[1].is_main).toBe(false);
+  });
+
+  it("SKU 구성·세트당수량·단가·원가 복원", () => {
+    expect(parsed[0].items).toHaveLength(2);
+    expect(parsed[0].items[0]).toMatchObject({
+      base_name: "퓨저나이트 슈퍼볼 4.3kg",
+      sku_qty_per_option: 4,
+      unit_sale_price: 10900,
+      cost: 8000,
+    });
+    expect(parsed[0].items[1].base_name).toBe("바이바이배드 500ml");
+    expect(parsed[1].items[0].base_name).toBe("포캣트릿 닭가슴살 25g");
+  });
+
+  it("플랜 시트 헤더가 없으면 빈 옵션", () => {
+    const wb2 = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb2, XLSX.utils.aoa_to_sheet([["관계없는", "시트"]]), "기타");
+    const o2 = XLSX.write(wb2, { type: "array", bookType: "xlsx" });
+    const b2 = (o2 instanceof Uint8Array ? o2.buffer : o2) as ArrayBuffer;
+    expect(parsePlanWorkbook(b2).options).toEqual([]);
+  });
+});

--- a/promo-analytics/lib/plan-import.ts
+++ b/promo-analytics/lib/plan-import.ts
@@ -1,0 +1,88 @@
+import * as XLSX from "xlsx";
+
+// 플랜 Excel 가져오기 (로드맵 3.2). 내보내기(plan-export)와 같은 양식의 '플랜' 시트를 파싱해
+// 옵션·SKU 구성을 복원한다. 순수 함수(parsePlanWorkbook)는 테스트 대상.
+// 옵션 레벨 값(옵션명·메인·예상세트수)은 각 옵션 첫 행에만 있고, 이후 빈 옵션명 행은 직전 옵션의 SKU.
+
+export type ParsedPlanItem = {
+  base_name: string;
+  sku_qty_per_option: number;
+  unit_sale_price: number;
+  cost: number | null;
+};
+export type ParsedPlanOption = {
+  option_label: string;
+  is_main: boolean;
+  expected_option_qty: number;
+  items: ParsedPlanItem[];
+};
+
+const HEADERS = {
+  option: "옵션명",
+  main: "메인",
+  qty: "예상세트수",
+  sku: "SKU",
+  setQty: "세트당수량",
+  unit: "단가",
+  cost: "원가",
+} as const;
+
+function colIndex(header: (string | number)[], name: string): number {
+  return header.findIndex((h) => String(h).trim() === name);
+}
+function num(v: unknown): number {
+  if (typeof v === "number") return v;
+  const n = Number(String(v ?? "").replace(/[^0-9.-]/g, ""));
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** 플랜 시트 → 옵션 목록. '플랜' 시트가 없으면 첫 시트를 시도. */
+export function parsePlanWorkbook(buf: ArrayBuffer): { options: ParsedPlanOption[] } {
+  const wb = XLSX.read(buf, { type: "array" });
+  const sheetName = wb.SheetNames.includes("플랜") ? "플랜" : wb.SheetNames[0];
+  const ws = wb.Sheets[sheetName];
+  if (!ws) return { options: [] };
+  const aoa = XLSX.utils.sheet_to_json<(string | number)[]>(ws, { header: 1, blankrows: false });
+  if (aoa.length < 2) return { options: [] };
+
+  const header = aoa[0];
+  const ci = {
+    option: colIndex(header, HEADERS.option),
+    main: colIndex(header, HEADERS.main),
+    qty: colIndex(header, HEADERS.qty),
+    sku: colIndex(header, HEADERS.sku),
+    setQty: colIndex(header, HEADERS.setQty),
+    unit: colIndex(header, HEADERS.unit),
+    cost: colIndex(header, HEADERS.cost),
+  };
+  if (ci.option < 0 || ci.sku < 0) return { options: [] };
+
+  const options: ParsedPlanOption[] = [];
+  let current: ParsedPlanOption | null = null;
+  for (let r = 1; r < aoa.length; r++) {
+    const row = aoa[r];
+    const label = String(row[ci.option] ?? "").trim();
+    const sku = String(row[ci.sku] ?? "").trim();
+    if (label) {
+      current = {
+        option_label: label,
+        is_main: String(row[ci.main] ?? "").trim().toUpperCase() === "Y",
+        expected_option_qty: ci.qty >= 0 ? Math.round(num(row[ci.qty])) : 0,
+        items: [],
+      };
+      options.push(current);
+    }
+    if (sku && current) {
+      current.items.push({
+        base_name: sku,
+        sku_qty_per_option: ci.setQty >= 0 ? num(row[ci.setQty]) : 0,
+        unit_sale_price: ci.unit >= 0 ? Math.round(num(row[ci.unit])) : 0,
+        cost:
+          ci.cost >= 0 && String(row[ci.cost] ?? "").trim() !== ""
+            ? num(row[ci.cost])
+            : null,
+      });
+    }
+  }
+  return { options: options.filter((o) => o.items.length > 0 || o.option_label) };
+}


### PR DESCRIPTION
## Excel 가져오기 (로드맵 3.2 — 왕복 완성)

내보낸 **같은 양식**의 엑셀을 올리면 옵션·SKU 구성을 한 번에 복원.

- **`lib/plan-import.parsePlanWorkbook`**(순수·테스트): '플랜' 시트를 옵션 단위로 파싱(옵션명 행=새 옵션, 빈 옵션명 행=직전 옵션의 SKU). **왕복 테스트 3건**(내보내기↔가져오기 일치).
- **PlanEditor**: `⬆ Excel 가져오기` 버튼 → 파싱 → `ensureProducts`로 SKU 매칭 → 옵션 append. 단가는 엑셀값, 원가·소비자가는 products 라이브.

### 검증
전체 **67 테스트**·`tsc`·`build` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_