### PR TITLE
목적 분석 '플랜 대비 목표 달성' 심화 (후속 3)

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/PurposeBlock.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/PurposeBlock.tsx
@@ -10,6 +10,15 @@ export type PurposeMetricRow = {
   ach_qty: number | null;
   qty_reliable: boolean;
   order_count: number | null;
+  // 플랜 대비 목표 달성 (achSummary)
+  plan_revenue?: number | null;
+  actual_revenue?: number | null;
+  ach_revenue?: number | null;
+  plan_contribution?: number | null;
+  actual_contribution?: number | null;
+  ach_contribution?: number | null;
+  plan_qty?: number | null;
+  actual_qty?: number | null;
 };
 
 // S5.4: 캠페인 상세 — 목적별 핵심 지표 블록 (가중·구분 표시). 계산은 5.1/측정 함수 단일 출처.
@@ -31,26 +40,32 @@ export default function PurposeBlock({ rows }: { rows: PurposeMetricRow[] }) {
             </div>
             <div className="mt-3 space-y-1.5 text-sm">
               {r.kind === "stock" ? (
-                <Metric
-                  label="수량 달성률"
-                  value={r.ach_qty != null ? pct(r.ach_qty, 0) : "—"}
-                  badge={!r.qty_reliable ? "데이터 부족" : undefined}
-                  primary
-                />
+                <>
+                  <PvA
+                    label="판매 수량"
+                    plan={r.plan_qty}
+                    actual={r.actual_qty}
+                    ach={r.ach_qty}
+                    fmt={(v) => `${num(v)}개`}
+                    badge={!r.qty_reliable ? "데이터 부족" : undefined}
+                    primary
+                  />
+                </>
               ) : r.kind === "branding" ? (
                 <>
                   <Metric label="구매 건수" value={num(r.order_count)} primary />
                   <p className="text-[11px] text-neutral-400">
-                    신규 비중: 회원·수량 데이터 확보 후 제공 예정
+                    브랜딩은 구매 건수로 봅니다(신규 비중은 회원 데이터 확보 후).
                   </p>
                 </>
               ) : (
                 <>
-                  <Metric label="행사로 늘어난 매출" value={won(r.uplift)} primary />
-                  <Metric label="남는 이익(공헌)" value={wonShort(r.contribution)} />
-                  {r.uplift_pct != null && (
-                    <Metric label="평소 대비" value={pct(r.uplift_pct, 0)} />
-                  )}
+                  <PvA label="매출" plan={r.plan_revenue} actual={r.actual_revenue} ach={r.ach_revenue} fmt={(v) => wonShort(v)} primary />
+                  <PvA label="공헌이익" plan={r.plan_contribution} actual={r.actual_contribution} ach={r.ach_contribution} fmt={(v) => wonShort(v)} />
+                  <div className="flex items-center justify-between gap-2 border-t border-neutral-100 pt-1.5">
+                    <span className="text-[11px] text-neutral-400">그중 행사로 늘어난 매출</span>
+                    <span className="text-[11px] font-medium text-neutral-600">{won(r.uplift)}</span>
+                  </div>
                 </>
               )}
             </div>
@@ -58,10 +73,50 @@ export default function PurposeBlock({ rows }: { rows: PurposeMetricRow[] }) {
         ))}
       </div>
       <p className="mt-2 text-xs text-neutral-400">
-        목적마다 중요한 숫자가 다릅니다 — 세일즈=행사로 늘어난 매출·이익, 재고소진=수량 달성률,
-        브랜딩=구매 건수. ‘평소 대비’는 행사 안 했을 때 대비 얼마나 더 팔렸는지입니다.
+        목적마다 보는 숫자가 다릅니다 — 세일즈=매출·공헌 <strong>계획 대비 달성</strong>,
+        재고소진=수량 계획 대비, 브랜딩=구매 건수. ‘행사로 늘어난 매출’은 평소(미행사) 대비 증가분입니다.
       </p>
     </section>
+  );
+}
+
+// 플랜 대비 목표 달성 한 줄 (달성% + 계획→실제)
+function PvA({
+  label,
+  plan,
+  actual,
+  ach,
+  fmt,
+  badge,
+  primary,
+}: {
+  label: string;
+  plan?: number | null;
+  actual?: number | null;
+  ach?: number | null;
+  fmt: (v: number | null) => string;
+  badge?: string;
+  primary?: boolean;
+}) {
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-neutral-500">
+          {label} 달성
+          {badge && (
+            <span className="ml-1 rounded bg-amber-100 px-1 text-[10px] text-amber-700">{badge}</span>
+          )}
+        </span>
+        <span
+          className={`tabular-nums ${primary ? "text-base font-bold text-neutral-900" : "font-semibold text-neutral-800"}`}
+        >
+          {ach != null ? pct(ach, 0) : "—"}
+        </span>
+      </div>
+      <div className="mt-0.5 text-right text-[11px] text-neutral-400">
+        계획 {fmt(plan ?? null)} → 실제 {fmt(actual ?? null)}
+      </div>
+    </div>
   );
 }
 

--- a/promo-analytics/app/(dash)/promotions/[id]/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/page.tsx
@@ -158,6 +158,15 @@ export default async function PromotionDetail({
       ach_qty: achSummary?.ach_qty ?? null,
       qty_reliable: achSummary?.quantity_reliable ?? false,
       order_count: orderCount,
+      // 플랜 대비 목표 달성
+      plan_revenue: achSummary?.expected_revenue_total ?? null,
+      actual_revenue: achSummary?.campaign_revenue_total ?? null,
+      ach_revenue: achSummary?.revenue_ach_total ?? null,
+      plan_contribution: achSummary?.expected_contribution_total ?? null,
+      actual_contribution: achSummary?.contribution_total ?? null,
+      ach_contribution: achSummary?.contribution_ach_total ?? null,
+      plan_qty: achSummary?.expected_qty_total ?? null,
+      actual_qty: achSummary?.main_nonsub_qty ?? null,
     };
   });
 


### PR DESCRIPTION
## 목적 분석 탭 — '플랜 대비 목표 달성'

목적별 카드를 actual 단독 → **계획 대비 달성**으로 심화:
- **세일즈**: 매출/공헌 `계획 X → 실제 Y · 달성 Z%` + 그중 행사로 늘어난 매출(증분)
- **재고소진**: 판매 수량 `계획 → 실제 · 달성%`
- **브랜딩**: 구매 건수

`plan_vs_actual_summary`의 expected/actual/ach 값 사용.

### 검증
`tsc`·**67 테스트**·`build` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_