### PR TITLE
UX: '초과 달성' 표기(그린) + 회고 탭 정리 + 리스트 삭제

### DIFF
--- a/promo-analytics/app/(dash)/page.tsx
+++ b/promo-analytics/app/(dash)/page.tsx
@@ -487,7 +487,7 @@ export default async function Dashboard() {
       <div className="mt-4 grid gap-4 sm:mt-5 sm:gap-5 lg:grid-cols-3 bento-in">
         <Card className="lg:col-span-2">
           <div className="mb-1 flex items-center justify-between">
-            <CardTitle className="mb-0">월별 증분 추세</CardTitle>
+            <CardTitle className="mb-0">월별 초과 달성 추세</CardTitle>
             {trend != null && (
               <span
                 className={`rounded-full px-2.5 py-1 text-xs font-semibold surface-pressed-soft ${
@@ -509,7 +509,7 @@ export default async function Dashboard() {
 
       <div className="mt-4 grid gap-4 sm:mt-5 sm:gap-5 lg:grid-cols-3 bento-in">
         <Card>
-          <CardTitle>혜택 유형별 증분</CardTitle>
+          <CardTitle>혜택 유형별 초과 달성</CardTitle>
           <Concentric data={typeData} />
         </Card>
 

--- a/promo-analytics/app/(dash)/plans/PlansBoard.tsx
+++ b/promo-analytics/app/(dash)/plans/PlansBoard.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { won, wonShort, pct } from "@/lib/format";
 
 // promo.plans_bundle() 반환 형태
@@ -84,6 +85,29 @@ export default function PlansBoard({
 
 // ── 플랜 목록 ─────────────────────────────────────────────────────────────
 function PlanList({ plans }: { plans: PlanRow[] }) {
+  const router = useRouter();
+  const [deleting, setDeleting] = useState<string | null>(null);
+
+  async function del(p: PlanRow) {
+    if (!p.promotion_id) {
+      alert("캠페인에 연결되지 않은 플랜이라 삭제할 수 없습니다.");
+      return;
+    }
+    if (
+      !confirm(
+        `'${p.name ?? p.code ?? "캠페인"}'을(를) 삭제할까요?\n\n성과·플랜·메모가 함께 삭제됩니다. 복구 불가.`,
+      )
+    )
+      return;
+    setDeleting(p.id);
+    const res = await fetch(`/api/promotions/${p.promotion_id}`, { method: "DELETE" });
+    if (res.ok) router.refresh();
+    else {
+      setDeleting(null);
+      alert("삭제 실패");
+    }
+  }
+
   if (plans.length === 0)
     return (
       <p className="mt-6 rounded-2xl border border-dashed border-neutral-300 bg-white px-6 py-12 text-center text-sm text-neutral-400">
@@ -103,6 +127,7 @@ function PlanList({ plans }: { plans: PlanRow[] }) {
             <th className="px-3 py-2.5 text-right font-medium">옵션</th>
             <th className="px-3 py-2.5 font-medium">성과 연결</th>
             <th className="px-3 py-2.5 text-right font-medium">매출 달성률</th>
+            <th className="px-3 py-2.5 font-medium"></th>
           </tr>
         </thead>
         <tbody className="divide-y divide-line/70">
@@ -182,6 +207,16 @@ function PlanList({ plans }: { plans: PlanRow[] }) {
                   }`}
                 >
                   {ach != null ? pct(ach, 0) : "—"}
+                </td>
+                <td className="px-3 py-2.5 text-right">
+                  <button
+                    onClick={() => del(p)}
+                    disabled={deleting === p.id || !p.promotion_id}
+                    title="캠페인 삭제"
+                    className="rounded-lg px-2 py-1 text-xs text-neutral-400 hover:bg-red-50 hover:text-red-600 disabled:opacity-40"
+                  >
+                    {deleting === p.id ? "삭제 중…" : "삭제"}
+                  </button>
                 </td>
               </tr>
             );

--- a/promo-analytics/app/(dash)/promotions/[id]/DetailTabsNav.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/DetailTabsNav.tsx
@@ -9,7 +9,7 @@ export const DETAIL_VIEWS: { id: DetailView; label: string }[] = [
   { id: "skus", label: "SKU·옵션" },
   { id: "trend", label: "매출 흐름" },
   { id: "purpose", label: "목적 분석" },
-  { id: "sources", label: "데이터·회고" },
+  { id: "sources", label: "회고" },
 ];
 
 export function DetailTabsNav({

--- a/promo-analytics/app/(dash)/promotions/[id]/Notes.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/Notes.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import type { PromotionNote } from "@/lib/types";
 
@@ -25,17 +25,23 @@ export default function Notes({
   suggested: string[];
 }) {
   const router = useRouter();
-  const [question, setQuestion] = useState<string>(suggested[0] ?? "");
+  const [question, setQuestion] = useState<string>("");
   const [answer, setAnswer] = useState("");
   const [tags, setTags] = useState<string[]>([]);
   const [saving, setSaving] = useState(false);
+  const answerRef = useRef<HTMLTextAreaElement>(null);
 
   function toggle(tag: string) {
     setTags((t) => (t.includes(tag) ? t.filter((x) => x !== tag) : [...t, tag]));
   }
+  // 제안 클릭 → 주제로 설정하고 바로 답변창에 포커스
+  function pickQuestion(q: string) {
+    setQuestion((cur) => (cur === q ? "" : q));
+    setTimeout(() => answerRef.current?.focus(), 0);
+  }
 
   async function submit() {
-    if (!answer.trim()) return;
+    if (!answer.trim() || saving) return;
     setSaving(true);
     await fetch(`/api/promotions/${promotionId}/notes`, {
       method: "POST",
@@ -44,97 +50,108 @@ export default function Notes({
     });
     setAnswer("");
     setTags([]);
+    setQuestion("");
     setSaving(false);
     router.refresh();
   }
 
   return (
     <div>
-      {suggested.length > 0 && (
-        <div className="mb-3 flex flex-wrap gap-2">
-          {suggested.map((q) => (
+      {/* 작성 카드 */}
+      <div className="rounded-2xl card-soft p-4">
+        {suggested.length > 0 && (
+          <>
+            <div className="mb-1.5 text-[11px] text-ink-4">이런 걸 기록해보세요 — 누르면 답변창으로</div>
+            <div className="mb-3 flex flex-wrap gap-2">
+              {suggested.map((q) => (
+                <button
+                  key={q}
+                  type="button"
+                  onClick={() => pickQuestion(q)}
+                  className={`rounded-full border px-3 py-1 text-xs transition ${
+                    question === q
+                      ? "border-brand-500 bg-brand-50 text-brand-700"
+                      : "border-line text-ink-3 hover:bg-soft"
+                  }`}
+                >
+                  {q}
+                </button>
+              ))}
+            </div>
+          </>
+        )}
+
+        {question && (
+          <div className="mb-2 flex items-start gap-2 rounded-xl bg-brand-50/70 px-3 py-2 text-xs text-brand-800">
+            <span className="mt-0.5 shrink-0 font-semibold">Q.</span>
+            <span className="min-w-0 flex-1">{question}</span>
+            <button type="button" onClick={() => setQuestion("")} className="shrink-0 text-brand-600 hover:underline">
+              지우기
+            </button>
+          </div>
+        )}
+
+        <textarea
+          ref={answerRef}
+          value={answer}
+          onChange={(e) => setAnswer(e.target.value)}
+          onKeyDown={(e) => {
+            if ((e.metaKey || e.ctrlKey) && e.key === "Enter") submit();
+          }}
+          placeholder="무엇이 이 성과를 만들었나요? 원인·가설을 적어두면 다음 예측의 근거가 됩니다."
+          rows={3}
+          className="w-full rounded-xl border border-line bg-card px-3 py-2 text-sm text-ink outline-none focus:border-brand-400"
+        />
+
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {CAUSE_TAGS.map((tag) => (
             <button
-              key={q}
-              onClick={() => setQuestion(q)}
-              className={`rounded-full border px-3 py-1 text-xs transition ${
-                question === q
-                  ? "border-neutral-900 bg-brand-500 text-white"
-                  : "border-neutral-300 text-neutral-600 hover:bg-neutral-50"
+              key={tag}
+              type="button"
+              onClick={() => toggle(tag)}
+              className={`rounded-full border px-2.5 py-1 text-xs transition ${
+                tags.includes(tag)
+                  ? "border-brand-400 bg-brand-50 text-brand-700"
+                  : "border-line text-ink-4 hover:bg-soft"
               }`}
             >
-              {q}
+              {tag}
             </button>
           ))}
         </div>
-      )}
 
-      <input
-        value={question}
-        onChange={(e) => setQuestion(e.target.value)}
-        placeholder="이 성과의 원인을 묻는 질문"
-        className="w-full rounded-xl border border-neutral-200 px-3 py-2 text-sm"
-      />
-      <textarea
-        value={answer}
-        onChange={(e) => setAnswer(e.target.value)}
-        placeholder="원인·가설을 기록하세요. (다음 예측의 근거로 축적됩니다)"
-        rows={2}
-        className="mt-2 w-full rounded-xl border border-neutral-200 px-3 py-2 text-sm"
-      />
-      <div className="mt-2 flex flex-wrap gap-1.5">
-        {CAUSE_TAGS.map((tag) => (
+        <div className="mt-3 flex items-center gap-2">
           <button
-            key={tag}
-            onClick={() => toggle(tag)}
-            className={`rounded-full border px-2.5 py-1 text-xs transition ${
-              tags.includes(tag)
-                ? "border-neutral-700 bg-neutral-100 text-neutral-800"
-                : "border-neutral-200 text-neutral-500 hover:bg-neutral-50"
-            }`}
+            onClick={submit}
+            disabled={saving || !answer.trim()}
+            className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-white hover:bg-brand-600 disabled:opacity-50"
           >
-            {tag}
+            {saving ? "저장 중…" : "기록 추가"}
           </button>
-        ))}
+          <span className="text-[11px] text-ink-4">⌘/Ctrl + Enter</span>
+        </div>
       </div>
-      <button
-        onClick={submit}
-        disabled={saving || !answer.trim()}
-        className="mt-3 rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-white hover:bg-brand-600 disabled:opacity-50"
-      >
-        {saving ? "저장 중…" : "메모 추가"}
-      </button>
 
-      <ul className="mt-5 space-y-3">
+      {/* 기록 목록 */}
+      <ul className="mt-4 space-y-2.5">
         {notes.map((n) => (
-          <li
-            key={n.id}
-            className="rounded-lg border border-neutral-100 bg-neutral-50 p-3"
-          >
-            {n.question && (
-              <div className="text-xs font-medium text-neutral-500">
-                Q. {n.question}
-              </div>
-            )}
-            <div className="mt-0.5 text-sm text-neutral-800">{n.answer}</div>
+          <li key={n.id} className="rounded-xl border border-line bg-soft/50 p-3">
+            {n.question && <div className="text-xs font-medium text-ink-4">Q. {n.question}</div>}
+            <div className="mt-0.5 text-sm text-ink-2">{n.answer}</div>
             <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
               {(n.cause_tags ?? []).map((t) => (
-                <span
-                  key={t}
-                  className="rounded-full bg-white px-2 py-0.5 text-xs text-neutral-500 ring-1 ring-neutral-200"
-                >
+                <span key={t} className="rounded-full bg-card px-2 py-0.5 text-xs text-ink-4 ring-1 ring-line">
                   {t}
                 </span>
               ))}
-              <span className="ml-auto text-xs text-neutral-400">
+              <span className="ml-auto text-xs text-ink-4">
                 {n.author} · {new Date(n.created_at).toLocaleDateString("ko-KR")}
               </span>
             </div>
           </li>
         ))}
         {notes.length === 0 && (
-          <li className="text-sm text-neutral-400">
-            아직 기록된 원인 메모가 없습니다.
-          </li>
+          <li className="py-2 text-sm text-ink-4">아직 기록된 원인 메모가 없습니다.</li>
         )}
       </ul>
     </div>

--- a/promo-analytics/app/(dash)/promotions/[id]/UpliftChart.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/UpliftChart.tsx
@@ -39,14 +39,14 @@ export default function UpliftChart({ data }: { data: Item[] }) {
           tickFormatter={(v: string) => (v.length > 14 ? v.slice(0, 14) + "…" : v)}
         />
         <Tooltip
-          formatter={(v) => [wonShort(Number(v)), "증분"] as [string, string]}
+          formatter={(v) => [wonShort(Number(v)), "초과 달성"] as [string, string]}
           cursor={{ fill: "#f5f5f5" }}
         />
         <Bar dataKey="uplift" radius={[0, 4, 4, 0]}>
           {data.map((d, i) => (
             <Cell
               key={i}
-              fill={d.uplift < 0 ? "#f87171" : d.isMain ? "#171717" : "#9ca3af"}
+              fill={d.uplift < 0 ? "#f87171" : d.isMain ? "#16a34a" : "#9ca3af"}
             />
           ))}
         </Bar>

--- a/promo-analytics/app/(dash)/promotions/[id]/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/page.tsx
@@ -131,7 +131,6 @@ export default async function PromotionDetail({
     const pr = Array.isArray(r.products) ? r.products[0] : r.products;
     return { product_id: r.product_id, base_name: pr?.base_name ?? r.product_id };
   });
-  const sources = bundle?.sources ?? [];
 
   // 목적별 핵심 지표 (S5.4)
   const ewData = bundle?.weights ?? [];
@@ -333,7 +332,7 @@ export default async function PromotionDetail({
           <div>
             {!hasBaseline && (
               <div className="mb-4 rounded-lg bg-info-soft px-4 py-3 text-sm text-info">
-                baseline(직전 8주 일평균)이 얕아 증분 정확도가 낮을 수 있습니다 — <strong>차단되지 않으며</strong>,
+                baseline(직전 8주 일평균)이 얕아 초과 달성 정확도가 낮을 수 있습니다 — <strong>차단되지 않으며</strong>,
                 일별 매출 추이가 쌓이면 자동으로 정확해집니다.
               </div>
             )}
@@ -360,7 +359,7 @@ export default async function PromotionDetail({
 
             <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-5">
               <section className="lg:col-span-3">
-                <h2 className="mb-2 text-sm font-semibold text-ink-2">상품별 증분 측정</h2>
+                <h2 className="mb-2 text-sm font-semibold text-ink-2">상품별 초과 달성</h2>
                 <div className="overflow-x-auto rounded-2xl card-soft">
                   <table className="w-full min-w-[760px] text-sm">
                     <thead className="bg-soft/60 text-left text-xs text-ink-3">
@@ -369,7 +368,7 @@ export default async function PromotionDetail({
                         <th className="px-3 py-2.5 text-right font-medium">baseline/일</th>
                         <th className="px-3 py-2.5 text-right font-medium">성과</th>
                         <th className="px-3 py-2.5 text-right font-medium">기대</th>
-                        <th className="px-3 py-2.5 text-right font-medium">증분 ±95% CI</th>
+                        <th className="px-3 py-2.5 text-right font-medium">초과 달성 ±95% CI</th>
                       </tr>
                     </thead>
                     <tbody className="divide-y divide-line/70">
@@ -401,11 +400,11 @@ export default async function PromotionDetail({
                             </td>
                             <td className="px-3 py-2.5 text-right text-ink-2">{wonShort(r.actual_revenue)}</td>
                             <td className="px-3 py-2.5 text-right text-ink-4">{wonShort(r.expected_revenue)}</td>
-                            <td className={`px-3 py-2.5 text-right font-semibold ${r.uplift_revenue < 0 ? "text-danger" : "text-ink"}`}>
+                            <td className={`px-3 py-2.5 text-right font-semibold ${r.uplift_revenue < 0 ? "text-danger" : "text-success"}`}>
                               <div className="flex items-center justify-end gap-1">
                                 <span>{wonShort(r.uplift_revenue)}</span>
                                 {!significant && r.uplift_ci > 0 && !r.cold_start && (
-                                  <span className="text-[10px] text-ink-4" title="증분이 baseline 변동성 범위 안 — 통계적으로 유의하지 않음">
+                                  <span className="text-[10px] text-ink-4" title="초과 달성이 baseline 변동성 범위 안 — 통계적으로 유의하지 않음">
                                     n.s.
                                   </span>
                                 )}
@@ -433,7 +432,7 @@ export default async function PromotionDetail({
               </section>
 
               <section className="lg:col-span-2">
-                <h2 className="mb-2 text-sm font-semibold text-ink-2">증분 Top 10 (검정=메인 · 회색=후광)</h2>
+                <h2 className="mb-2 text-sm font-semibold text-ink-2">초과 달성 Top 10 (초록=메인 · 회색=후광)</h2>
                 <div className="rounded-2xl card-soft p-4">
                   <UpliftChart data={chartData} />
                 </div>
@@ -444,7 +443,7 @@ export default async function PromotionDetail({
                       {mains.map((m) => (
                         <li key={m.product_id} className="flex justify-between">
                           <span className="truncate text-ink-2">{m.base_name}</span>
-                          <span className="ml-2 shrink-0 text-ink-3">증분 {wonShort(m.uplift_revenue)}</span>
+                          <span className="ml-2 shrink-0 font-semibold text-success">초과 {wonShort(m.uplift_revenue)}</span>
                         </li>
                       ))}
                     </ul>
@@ -542,33 +541,10 @@ export default async function PromotionDetail({
         {view === "purpose" && <PurposeBlock rows={purposeRows} />}
 
         {view === "sources" && (
-          <div className="grid grid-cols-1 gap-6 lg:grid-cols-5">
-            <section className="lg:col-span-2">
-              <h2 className="mb-2 text-sm font-semibold text-ink-2">데이터 출처 (업로드 파일)</h2>
-              {sources.length > 0 ? (
-                <ul className="space-y-1.5 rounded-2xl card-soft p-4 text-sm">
-                  {sources.slice(0, 8).map((s) => (
-                    <li key={s.id} className="flex items-baseline justify-between gap-2">
-                      <span className="min-w-0 truncate text-ink-2" title={s.source_file}>
-                        {s.source_file}
-                      </span>
-                      <span className="shrink-0 text-[11px] text-ink-4">
-                        {s.kind === "plan_guide" ? "플랜" : s.kind === "promotion" ? "성과" : s.kind}
-                        {" · "}
-                        {new Date(s.created_at).toLocaleDateString("ko-KR", { month: "2-digit", day: "2-digit" })}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-              ) : (
-                <p className="rounded-2xl card-soft p-4 text-sm text-ink-4">출처 기록이 없습니다.</p>
-              )}
-            </section>
-            <section className="lg:col-span-3">
-              <h2 className="mb-1 text-sm font-semibold text-ink-2">성과의 원인 — 집요하게 묻기</h2>
-              <p className="mb-3 text-xs text-ink-4">여기 쌓인 원인·가설이 예측 정확도를 높입니다.</p>
-              <Notes promotionId={id} notes={notes} suggested={suggested} />
-            </section>
+          <div className="max-w-3xl">
+            <h2 className="mb-1 text-sm font-semibold text-ink-2">성과 원인 기록하기</h2>
+            <p className="mb-3 text-xs text-ink-4">왜 이런 성과가 났는지 적어두면 다음 캠페인 예측이 정확해집니다.</p>
+            <Notes promotionId={id} notes={notes} suggested={suggested} />
           </div>
         )}
       </div>
@@ -650,11 +626,11 @@ function buildQuestions(rows: MeasurementRow[], summary: PromotionSummary | null
   const worst = [...rows].sort((a, b) => a.uplift_revenue - b.uplift_revenue)[0];
 
   if (topMain && topMain.uplift_revenue > 0)
-    qs.push(`메인 '${topMain.base_name}'의 증분이 컸어요. 광고·노출을 늘렸나요?`);
+    qs.push(`메인 '${topMain.base_name}'의 초과 달성이 컸어요. 광고·노출을 늘렸나요?`);
   if (topHalo && topHalo.uplift_revenue > 0)
     qs.push(`'${topHalo.base_name}'가 함께 잘 팔렸어요. 동반구매를 유도한 요인은?`);
   if (worst && worst.uplift_revenue < 0)
-    qs.push(`'${worst.base_name}'는 증분이 마이너스였어요. 원인이 있나요?`);
+    qs.push(`'${worst.base_name}'는 초과 달성이 마이너스였어요. 원인이 있나요?`);
   if (summary && summary.halo_share != null && summary.halo_share > 0.4)
     qs.push("후광효과 비중이 높습니다. 어떤 상품군이 같이 담겼나요?");
   qs.push("이 기간에 외부 이벤트(시즌·경쟁사·트렌드)가 있었나요?");


### PR DESCRIPTION
## 3가지 UX 개선

1. **'증분' → '초과 달성'** 전 화면 표기 변경(성과 개요·매출 흐름·대시보드·회고 질문). 양수 초과 달성은 **메인 그린**으로 강조(표 값·Top10·차트 메인 막대 `#16a34a`). → 예측보다 더 판 만큼이 한눈에.
2. **'데이터·회고' 탭 → '회고'**. 비어 있던 **데이터 출처 섹션 제거**, 회고 전폭 표시. **'성과의 원인 — 집요하게 묻기' → '성과 원인 기록하기'**. Notes **작성 편의 개선**: 제안 클릭 시 답변창 포커스, 주제 라벨(Q.), 큰 입력창, **⌘/Ctrl+Enter 저장**.
3. **캠페인 리스트(플랜 목록)에 행별 '삭제'** 추가(promotion DELETE + 새로고침).

### 검증
`tsc`·테스트·`build` 통과.

> 참고: '초과 달성'은 baseline(미행사 시 예상) 대비 추가분이며, '달성률'(계획 대비)과는 다른 개념입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgVazVxKcLQnxP8oW79BE9)_