### PR TITLE
feat(analytics): 카테고리 기반 서브상품 어태치율 플래닝 + 세그먼트(회원·등급·AOV) 성과

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/DetailTabsNav.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/DetailTabsNav.tsx
@@ -2,12 +2,13 @@ import Link from "next/link";
 import { cn } from "@/lib/cn";
 
 // 상세 심층분석 탭 — URL(?view=)로 보존, 선택 탭만 서버 렌더(lazy). 네비게이션 기반(공유·뒤로가기 정상).
-export type DetailView = "overview" | "skus" | "trend" | "purpose" | "sources";
+export type DetailView = "overview" | "skus" | "trend" | "segment" | "purpose" | "sources";
 
 export const DETAIL_VIEWS: { id: DetailView; label: string }[] = [
   { id: "overview", label: "성과 개요" },
   { id: "skus", label: "SKU·옵션" },
   { id: "trend", label: "매출 흐름" },
+  { id: "segment", label: "세그먼트" },
   { id: "purpose", label: "목적 분석" },
   { id: "sources", label: "회고" },
 ];

--- a/promo-analytics/app/(dash)/promotions/[id]/SegmentBlock.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/SegmentBlock.tsx
@@ -1,0 +1,175 @@
+import { won, wonShort, num, pct } from "@/lib/format";
+import type { SegmentSummary, SegmentRow } from "@/lib/types";
+
+// Feature C — 세그먼트 성과(회원/비회원·회원등급·객단가/AOV). 세그먼트 실적(⑥) 업로드 시 채워짐.
+// AOV=매출/결제건수, ARPPU(객단가)=매출/결제유저수 — 집계 합계에서 파생(행 단위 값은 합산 불가).
+const aov = (r: { revenue: number; orders: number }) => (r.orders > 0 ? r.revenue / r.orders : null);
+const arppu = (r: { revenue: number; users: number }) => (r.users > 0 ? r.revenue / r.users : null);
+
+// 등급 라벨은 자유 텍스트라 하드코딩하지 않음 — 등장 순서대로 표시(매출 desc는 RPC가 정렬).
+export default function SegmentBlock({ summary }: { summary: SegmentSummary | null }) {
+  if (!summary || !summary.has_data) {
+    return (
+      <div className="rounded-2xl card-soft p-6 text-center">
+        <p className="text-sm font-medium text-ink">세그먼트 실적이 아직 없습니다.</p>
+        <p className="mx-auto mt-1 max-w-md text-sm text-ink-4">
+          <strong>데이터 업로드 → ⑥ 세그먼트 실적(회원·등급·카테고리)</strong>에서 카페24 채널별
+          매출 export를 올리면 회원/비회원·등급·객단가(ARPPU)·AOV 분석이 여기 표시됩니다.
+        </p>
+      </div>
+    );
+  }
+
+  const total = summary.total;
+  const totalRev = total?.revenue ?? 0;
+  const member = summary.member_split.find((m) => m.seg === "회원") ?? null;
+  const guest = summary.member_split.find((m) => m.seg === "비회원") ?? null;
+  const excludedRev = summary.excluded.reduce((s, e) => s + e.revenue, 0);
+
+  return (
+    <div className="space-y-6">
+      {/* 회원 vs 비회원 */}
+      <section>
+        <h2 className="mb-2 text-sm font-semibold text-ink-2">회원 / 비회원</h2>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <SegCard title="회원" row={member} totalRev={totalRev} primary />
+          <SegCard title="비회원" row={guest} totalRev={totalRev} />
+        </div>
+        <p className="mt-2 text-[11px] text-ink-4">
+          AOV = 매출 / 결제건수 · ARPPU(객단가) = 매출 / 결제 유저수. Staff·동물병원(도매)은 고객 성과에서 제외됨.
+        </p>
+      </section>
+
+      {/* 회원등급 코호트 */}
+      {summary.grades.length > 0 && (
+        <section>
+          <h2 className="mb-2 text-sm font-semibold text-ink-2">회원등급 코호트</h2>
+          <div className="overflow-x-auto rounded-2xl card-soft">
+            <table className="w-full min-w-[640px] text-sm">
+              <thead className="bg-soft/60 text-left text-xs text-ink-3">
+                <tr>
+                  <th className="px-3 py-2.5 font-medium">등급</th>
+                  <th className="px-3 py-2.5 text-right font-medium">매출</th>
+                  <th className="px-3 py-2.5 text-right font-medium">비중</th>
+                  <th className="px-3 py-2.5 text-right font-medium">결제건수</th>
+                  <th className="px-3 py-2.5 text-right font-medium">유저수</th>
+                  <th className="px-3 py-2.5 text-right font-medium">AOV</th>
+                  <th className="px-3 py-2.5 text-right font-medium">ARPPU(객단가)</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-line/70">
+                {summary.grades.map((g) => (
+                  <tr key={g.grade} className="hover:bg-soft/50">
+                    <td className="px-3 py-2.5 text-ink">{g.grade}</td>
+                    <td className="px-3 py-2.5 text-right text-ink-2">{wonShort(g.revenue)}</td>
+                    <td className="px-3 py-2.5 text-right text-ink-4">
+                      {totalRev > 0 ? pct(g.revenue / totalRev) : "—"}
+                    </td>
+                    <td className="px-3 py-2.5 text-right text-ink-3">{num(g.orders)}</td>
+                    <td className="px-3 py-2.5 text-right text-ink-3">{num(g.users)}</td>
+                    <td className="px-3 py-2.5 text-right text-ink-2">{wonOrDash(aov(g))}</td>
+                    <td className="px-3 py-2.5 text-right font-semibold text-ink">{wonOrDash(arppu(g))}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <p className="mt-2 text-[11px] text-ink-4">
+            표본이 적은 등급(유저수 적음)은 AOV·ARPPU 신뢰도가 낮습니다 — 유저수와 함께 해석하세요.
+          </p>
+        </section>
+      )}
+
+      {/* 일반/정기 · 카테고리 분해 */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        {summary.order_types.length > 0 && (
+          <section>
+            <h2 className="mb-2 text-sm font-semibold text-ink-2">일반 / 정기</h2>
+            <div className="rounded-2xl card-soft p-4">
+              <ul className="space-y-2 text-sm">
+                {summary.order_types.map((o) => (
+                  <li key={o.order_type} className="flex items-center justify-between">
+                    <span className="text-ink-2">{o.order_type === "subscription" ? "정기(구독)" : "일반"}</span>
+                    <span className="text-ink-3">
+                      <b className="text-ink-2">{wonShort(o.revenue)}</b>
+                      {totalRev > 0 && <span className="ml-1.5 text-[11px] text-ink-4">{pct(o.revenue / totalRev)}</span>}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </section>
+        )}
+        {summary.categories.length > 0 && (
+          <section>
+            <h2 className="mb-2 text-sm font-semibold text-ink-2">카테고리별 매출</h2>
+            <div className="rounded-2xl card-soft p-4">
+              <ul className="space-y-2 text-sm">
+                {summary.categories.map((c) => (
+                  <li key={c.category} className="flex items-center justify-between">
+                    <span className="truncate text-ink-2">{c.category}</span>
+                    <span className="ml-2 shrink-0 text-ink-3">
+                      <b className="text-ink-2">{wonShort(c.revenue)}</b>
+                      {totalRev > 0 && <span className="ml-1.5 text-[11px] text-ink-4">{pct(c.revenue / totalRev)}</span>}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </section>
+        )}
+      </div>
+
+      {excludedRev > 0 && (
+        <p className="text-[11px] text-ink-4">
+          제외(고객 성과에서 빠짐): {summary.excluded.map((e) => `${e.grade} ${wonShort(e.revenue)}`).join(" · ")} —
+          Staff·동물병원(도매)은 객단가 왜곡 방지를 위해 합계에서 제외했습니다.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function SegCard({
+  title,
+  row,
+  totalRev,
+  primary,
+}: {
+  title: string;
+  row: (SegmentRow & { seg: string }) | null;
+  totalRev: number;
+  primary?: boolean;
+}) {
+  const rev = row?.revenue ?? 0;
+  return (
+    <div className={`rounded-2xl border p-4 ${primary ? "border-transparent bg-brand-500 text-white" : "border-line bg-card"}`}>
+      <div className="flex items-baseline justify-between">
+        <span className={`text-sm font-semibold ${primary ? "text-white" : "text-ink"}`}>{title}</span>
+        <span className={`text-xs ${primary ? "text-white/70" : "text-ink-4"}`}>
+          {totalRev > 0 ? pct(rev / totalRev) : "—"}
+        </span>
+      </div>
+      <div className="mt-1 text-lg font-semibold">{won(rev)}</div>
+      <dl className={`mt-2 grid grid-cols-2 gap-x-3 gap-y-1 text-xs ${primary ? "text-white/80" : "text-ink-3"}`}>
+        <Mini label="AOV" value={wonOrDash(aov(row ?? { revenue: 0, orders: 0 }))} />
+        <Mini label="ARPPU" value={wonOrDash(arppu(row ?? { revenue: 0, users: 0 }))} />
+        <Mini label="결제건수" value={num(row?.orders ?? 0)} />
+        <Mini label="유저수" value={num(row?.users ?? 0)} />
+      </dl>
+    </div>
+  );
+}
+
+function Mini({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between">
+      <dt className="opacity-80">{label}</dt>
+      <dd className="font-medium tabular-nums">{value}</dd>
+    </div>
+  );
+}
+
+function wonOrDash(v: number | null): string {
+  return v == null ? "—" : wonShort(v);
+}

--- a/promo-analytics/app/(dash)/promotions/[id]/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/page.tsx
@@ -27,6 +27,8 @@ import { CampaignWorkflowBar } from "./CampaignWorkflowBar";
 import { ActionPanel } from "./ActionPanel";
 import { DetailTabsNav, type DetailView } from "./DetailTabsNav";
 import { DeleteCampaignButton } from "./DeleteCampaignButton";
+import SegmentBlock from "./SegmentBlock";
+import type { SegmentSummary } from "@/lib/types";
 
 export const dynamic = "force-dynamic";
 
@@ -69,7 +71,7 @@ type UploadSource = {
   created_at: string;
 };
 
-const VALID_VIEWS: DetailView[] = ["overview", "skus", "trend", "purpose", "sources"];
+const VALID_VIEWS: DetailView[] = ["overview", "skus", "trend", "segment", "purpose", "sources"];
 
 export default async function PromotionDetail({
   params,
@@ -110,6 +112,11 @@ export default async function PromotionDetail({
   // N13 P2: 옵션 단위 실측 공헌 분해 (마이그레이션 미적용 시 함수 부재 → 조용히 빈 배열)
   const { data: contribData } = await supabase.rpc("sale_option_contribution", { p_id: id });
   const optionContribs = (contribData as OptionContribRow[] | null) ?? [];
+  // Feature C: 세그먼트 요약 (선택 탭에서만 조회 — 마이그레이션 미적용 시 함수 부재 → null)
+  const segSummary =
+    view === "segment"
+      ? (((await supabase.rpc("promotion_segment_summary", { p_id: id })).data) as SegmentSummary | null)
+      : null;
   const optionInfos = [
     ...new Set(
       (bundle?.option_infos ?? []).map((s) => s.trim()).filter((s) => s.length > 0),
@@ -537,6 +544,8 @@ export default async function PromotionDetail({
             }
           />
         )}
+
+        {view === "segment" && <SegmentBlock summary={segSummary} />}
 
         {view === "purpose" && <PurposeBlock rows={purposeRows} />}
 

--- a/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/lib/plan";
 import { won, pct, num } from "@/lib/format";
 import { validatePlan } from "@/lib/plan-validation";
-import { InlineAlert, Dialog, DialogContent, DialogHeader, DialogFooter, Button } from "@/components/ui";
+import { InlineAlert, Dialog, DialogContent, DialogHeader, DialogFooter, Button, SegmentedControl } from "@/components/ui";
 import PlanLoadPanel from "./PlanLoadPanel";
 import SubProductSuggest, { type Bench } from "./SubProductSuggest";
 import { downloadPlanXlsx, type ExportOption } from "@/lib/plan-export";
@@ -115,12 +115,31 @@ export default function PlanEditor({
     coupon_min_order?: number | null;
     coupon_rate?: number | null;
     coupon_max?: number | null;
+    main_category?: string | null;
   }) | null;
   const [coupon, setCoupon] = useState(() => ({
     min: Number(planC?.coupon_min_order ?? 0) || 0,
     ratePct: (Number(planC?.coupon_rate ?? 0) || 0) * 100,
     max: Number(planC?.coupon_max ?? 0) || 0,
   }));
+  // Feature A/B — 메인 카테고리(서브 어태치율 추천 기준). '전체'=전사 할인(n주년 등) 분석.
+  const [mainCategory, setMainCategory] = useState<string>(() => planC?.main_category || "전체");
+  const [categories, setCategories] = useState<string[]>([]);
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      const { data } = await createClient()
+        .from("products")
+        .select("category")
+        .not("category", "is", null);
+      if (!alive) return;
+      const uniq = [...new Set((data ?? []).map((r) => (r.category as string)?.trim()).filter(Boolean))].sort();
+      setCategories(uniq);
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState<{ kind: "err" | "ok"; text: string } | null>(null);
   const [dirty, setDirty] = useState(false);
@@ -157,10 +176,11 @@ export default function PlanEditor({
     try {
       const raw = localStorage.getItem(draftKey);
       if (raw) {
-        const d = JSON.parse(raw) as { options?: OptState[]; coupon?: typeof coupon };
+        const d = JSON.parse(raw) as { options?: OptState[]; coupon?: typeof coupon; mainCategory?: string };
         if (Array.isArray(d.options) && d.options.length > 0) {
           setOptions(d.options);
           if (d.coupon) setCoupon(d.coupon);
+          if (d.mainCategory) setMainCategory(d.mainCategory);
           setRestored(true);
           setDirty(true);
         }
@@ -175,13 +195,13 @@ export default function PlanEditor({
     if (!draftKey || confirmed || !hydrated.current) return;
     const t = setTimeout(() => {
       try {
-        localStorage.setItem(draftKey, JSON.stringify({ options, coupon, ts: Date.now() }));
+        localStorage.setItem(draftKey, JSON.stringify({ options, coupon, mainCategory, ts: Date.now() }));
       } catch {
         /* 용량 초과 등 무시 */
       }
     }, 600);
     return () => clearTimeout(t);
-  }, [options, coupon, draftKey, confirmed]);
+  }, [options, coupon, mainCategory, draftKey, confirmed]);
   const clearDraft = () => {
     if (draftKey) {
       try {
@@ -314,10 +334,16 @@ export default function PlanEditor({
   // 옵션 단가는 '상시 판매가'로 들어간다(할인 안 하는 서브를 평균 할인가로 채우면 수정이 번거로움).
   function buildSubOption(b: Bench): OptState {
     const unit = b.regular_price ?? b.consumer_price ?? Math.round(b.avg_unit_price) ?? 0;
+    // Feature A — 어태치율이 있으면 (계획 메인 수량 × 어태치율)로 환산, 없으면 과거 평균 수량
+    const mq = options.filter((o) => o.is_main).reduce((s, o) => s + (o.expected_option_qty || 0), 0);
+    const qty =
+      b.avg_attach_ratio != null && mq > 0
+        ? Math.round(b.avg_attach_ratio * mq) || 0
+        : Math.round(b.avg_qty) || 0;
     return {
       key: uid(),
       option_label: b.base_name,
-      expected_option_qty: Math.round(b.avg_qty) || 0,
+      expected_option_qty: qty,
       is_main: false,
       match_patterns: [],
       items: [
@@ -407,6 +433,17 @@ export default function PlanEditor({
     if (!res.ok) {
       setMsg({ kind: "err", text: (await res.json()).error ?? "저장 실패" });
       return false;
+    }
+    // Feature B — 선택한 메인 카테고리 저장(다음 플래닝 시 기준 기억). best-effort: 컬럼 미적용 시 무시.
+    if (plan) {
+      try {
+        await createClient()
+          .from("campaign_plans")
+          .update({ main_category: mainCategory === "전체" ? null : mainCategory })
+          .eq("id", plan.id);
+      } catch {
+        /* 0059 미적용 등 무시 */
+      }
     }
     return true;
   }
@@ -745,8 +782,28 @@ export default function PlanEditor({
           >
             + 메인 옵션 추가
           </button>
+          <div className="mt-4 flex flex-wrap items-center gap-2 rounded-2xl card-soft px-5 py-3">
+            <span className="text-sm font-semibold text-ink-2">메인 카테고리</span>
+            <SegmentedControl
+              ariaLabel="메인 카테고리 선택"
+              value={mainCategory}
+              onValueChange={(v) => {
+                setMainCategory(v);
+                setDirty(true);
+              }}
+              options={[
+                { value: "전체", label: "전체" },
+                ...categories.map((c) => ({ value: c, label: c })),
+              ]}
+            />
+            <span className="text-[11px] text-ink-4">
+              선택한 카테고리가 메인이던 과거 캠페인의 어태치율로 서브 수량을 제안합니다. ‘전체’=전사 할인(n주년 등).
+            </span>
+          </div>
           <SubProductSuggest
             existingProductIds={options.flatMap((o) => o.items.map((it) => it.product_id))}
+            mainCategory={mainCategory}
+            mainQty={options.filter((o) => o.is_main).reduce((s, o) => s + (o.expected_option_qty || 0), 0)}
             onAdd={addSubOption}
             onAddAll={addSubOptions}
           />

--- a/promo-analytics/app/(dash)/promotions/[id]/plan/SubProductSuggest.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/SubProductSuggest.tsx
@@ -2,10 +2,11 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { createClient } from "@/lib/supabase/client";
-import { won, pct } from "@/lib/format";
+import { won, pct, num } from "@/lib/format";
 
-// Phase 4 — 서브상품 자동 예측. 과거 캠페인 벤치마크(자주/최근 판매)로 옵션단가·예상수량·
-// 원가를 prefilled한 서브 옵션을 한 번에 추가 → 노가다 제거.
+// Phase 4 + Feature A — 서브상품 자동 예측. 메인 카테고리가 선택되면 '같은 카테고리가 메인이던 과거
+// 캠페인'의 어태치율(메인 1개당 서브 평균수량)을 끌어와, 계획한 메인 수량에 맞춰 서브 수량을 제안.
+// 카테고리 매칭 결과가 없으면 전역 빈도 벤치마크(0048)로 폴백해 패널이 비지 않게 한다.
 export type Bench = {
   product_id: string;
   base_name: string;
@@ -17,46 +18,78 @@ export type Bench = {
   regular_price: number | null;
   cost: number | null;
   avg_discount: number | null;
+  avg_attach_ratio?: number | null; // 메인 1개당 서브 평균수량 (category_sub_benchmarks)
 };
 
 export default function SubProductSuggest({
   existingProductIds,
+  mainCategory,
+  mainQty,
   onAdd,
   onAddAll,
 }: {
   existingProductIds: string[];
+  mainCategory?: string | null;
+  mainQty?: number;
   onAdd: (b: Bench) => void;
   onAddAll?: (bs: Bench[]) => void;
 }) {
   const [rows, setRows] = useState<Bench[] | null>(null);
   const [recent, setRecent] = useState(false);
   const [open, setOpen] = useState(false);
+  const [fellBack, setFellBack] = useState(false);
   const existing = useMemo(() => new Set(existingProductIds), [existingProductIds]);
+  const planMainQty = mainQty ?? 0;
 
   useEffect(() => {
     let alive = true;
     (async () => {
       const supabase = createClient();
-      const { data } = await supabase.rpc("sub_product_benchmarks", {
-        p_months: recent ? 3 : null,
-        p_category: null,
+      setRows(null);
+      // 1차: 카테고리 어태치율 벤치마크 (메인 카테고리가 메인이던 과거 캠페인 기준)
+      const { data: catData } = await supabase.rpc("category_sub_benchmarks", {
+        p_main_category: mainCategory ?? null,
+        p_months: recent ? 3 : 12,
         p_exclude_skeys: null,
       });
-      if (alive) setRows((data as Bench[]) ?? []);
+      let list = (catData as Bench[]) ?? [];
+      let usedFallback = false;
+      // 폴백: 매칭되는 과거 캠페인이 없으면 전역 빈도 벤치마크로 대체(어태치율 없음)
+      if (list.length === 0) {
+        const { data } = await supabase.rpc("sub_product_benchmarks", {
+          p_months: recent ? 3 : null,
+          p_category: null,
+          p_exclude_skeys: null,
+        });
+        list = (data as Bench[]) ?? [];
+        usedFallback = list.length > 0;
+      }
+      if (alive) {
+        setRows(list);
+        setFellBack(usedFallback);
+      }
     })();
     return () => {
       alive = false;
     };
-  }, [recent]);
+  }, [recent, mainCategory]);
 
-  // 메인/기존에 없는 모든 추천 상품 (전체 표시 — 리스트는 스크롤)
+  // 메인/기존에 없는 모든 추천 상품
   const list = (rows ?? []).filter((r) => !existing.has(r.product_id));
+  const catLabel = !mainCategory || mainCategory === "전체" ? "전체" : mainCategory;
+
+  // 어태치율 → 계획 메인 수량 기준 권장 서브 수량
+  const planned = (b: Bench): number | null =>
+    b.avg_attach_ratio != null && planMainQty > 0 ? Math.round(b.avg_attach_ratio * planMainQty) : null;
 
   return (
     <div className="mt-4 rounded-2xl card-soft p-5">
       <button type="button" onClick={() => setOpen((o) => !o)} className="flex w-full items-center justify-between">
         <span className="text-sm font-semibold text-ink-2">
-          서브 상품 추천 <span className="font-normal text-ink-4">· 과거 캠페인 자주 판매</span>
+          서브 상품 추천{" "}
+          <span className="font-normal text-ink-4">
+            · {fellBack ? "과거 캠페인 자주 판매(전역)" : `‘${catLabel}’ 메인 캠페인 어태치율`}
+          </span>
         </span>
         <span className="text-ink-4">{open ? "▲" : "▼"}</span>
       </button>
@@ -64,7 +97,11 @@ export default function SubProductSuggest({
         <>
           <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
             <p className="text-xs text-ink-4">
-              누르면 상시 판매가·예상수량·원가가 채워진 서브 옵션이 추가됩니다(할인은 직접 조정).
+              {fellBack
+                ? "해당 메인 카테고리의 과거 캠페인이 없어 전역 평균으로 대체했습니다. 누르면 상시가·예상수량이 채워집니다."
+                : planMainQty > 0
+                  ? `누르면 계획 메인 수량(${num(planMainQty)}개) × 어태치율로 환산된 서브 수량이 채워집니다(할인은 직접 조정).`
+                  : "메인 옵션 수량을 입력하면 어태치율로 서브 수량이 자동 환산됩니다. 누르면 추천 서브가 추가됩니다."}
             </p>
             <div className="flex items-center gap-3">
               <label className="flex shrink-0 items-center gap-1.5 text-[11px] text-ink-3">
@@ -88,24 +125,31 @@ export default function SubProductSuggest({
             <p className="mt-3 text-xs text-ink-4">추천할 서브 상품이 없습니다(이미 모두 추가됨).</p>
           ) : (
             <ul className="mt-3 grid max-h-96 gap-2 overflow-y-auto pr-1 sm:grid-cols-2">
-              {list.map((r) => (
-                <li key={r.product_id}>
-                  <button
-                    type="button"
-                    onClick={() => onAdd(r)}
-                    className="flex w-full items-start justify-between gap-2 rounded-xl border border-line bg-card p-3 text-left transition hover:border-brand-300 hover:bg-brand-50/50"
-                  >
-                    <span className="min-w-0">
-                      <span className="block truncate text-sm font-medium text-ink">{r.base_name}</span>
-                      <span className="mt-0.5 block text-[11px] text-ink-4">
-                        {r.campaigns}회 등장 · 평균 {Math.round(r.avg_qty)}개 · 단가 {won(r.avg_unit_price)}
-                        {r.avg_discount != null ? ` · 할인 ${pct(r.avg_discount)}` : ""}
+              {list.map((r) => {
+                const rec = planned(r);
+                return (
+                  <li key={r.product_id}>
+                    <button
+                      type="button"
+                      onClick={() => onAdd(r)}
+                      className="flex w-full items-start justify-between gap-2 rounded-xl border border-line bg-card p-3 text-left transition hover:border-brand-300 hover:bg-brand-50/50"
+                    >
+                      <span className="min-w-0">
+                        <span className="block truncate text-sm font-medium text-ink">{r.base_name}</span>
+                        <span className="mt-0.5 block text-[11px] text-ink-4">
+                          {r.avg_attach_ratio != null
+                            ? `메인 100개당 ${Math.round(r.avg_attach_ratio * 100)}개${rec != null ? ` · 계획 ≈ ${num(rec)}개` : ""}`
+                            : `평균 ${Math.round(r.avg_qty)}개`}
+                          {" · "}
+                          {r.campaigns}회 등장 · 단가 {won(r.avg_unit_price)}
+                          {r.avg_discount != null ? ` · 할인 ${pct(r.avg_discount)}` : ""}
+                        </span>
                       </span>
-                    </span>
-                    <span className="shrink-0 text-[11px] font-semibold text-brand-600">+ 추가</span>
-                  </button>
-                </li>
-              ))}
+                      <span className="shrink-0 text-[11px] font-semibold text-brand-600">+ 추가</span>
+                    </button>
+                  </li>
+                );
+              })}
             </ul>
           )}
         </>

--- a/promo-analytics/app/(dash)/promotions/[id]/plan/SubProductSuggest.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/SubProductSuggest.tsx
@@ -18,6 +18,7 @@ export type Bench = {
   regular_price: number | null;
   cost: number | null;
   avg_discount: number | null;
+  total_revenue?: number | null; // 풀 내 누적 매출(서브 기여 규모)
   avg_attach_ratio?: number | null; // 메인 1개당 서브 평균수량 (category_sub_benchmarks)
 };
 
@@ -136,11 +137,15 @@ export default function SubProductSuggest({
                     >
                       <span className="min-w-0">
                         <span className="block truncate text-sm font-medium text-ink">{r.base_name}</span>
-                        <span className="mt-0.5 block text-[11px] text-ink-4">
+                        {/* 평균수량 · 매출 · 부착률 — 사용자 선택 지표 */}
+                        <span className="mt-0.5 block text-[11px] text-ink-3">
+                          평균 {Math.round(r.avg_qty)}개
+                          {r.total_revenue != null ? ` · 매출 ${won(r.total_revenue)}` : ""}
                           {r.avg_attach_ratio != null
-                            ? `메인 100개당 ${Math.round(r.avg_attach_ratio * 100)}개${rec != null ? ` · 계획 ≈ ${num(rec)}개` : ""}`
-                            : `평균 ${Math.round(r.avg_qty)}개`}
-                          {" · "}
+                            ? ` · 부착률 메인 100개당 ${Math.round(r.avg_attach_ratio * 100)}개${rec != null ? ` (계획 ≈ ${num(rec)}개)` : ""}`
+                            : ""}
+                        </span>
+                        <span className="mt-0.5 block text-[11px] text-ink-4">
                           {r.campaigns}회 등장 · 단가 {won(r.avg_unit_price)}
                           {r.avg_discount != null ? ` · 할인 ${pct(r.avg_discount)}` : ""}
                         </span>

--- a/promo-analytics/app/(dash)/upload/page.tsx
+++ b/promo-analytics/app/(dash)/upload/page.tsx
@@ -12,7 +12,7 @@ import { useReplaceConfirm } from "./useReplaceConfirm";
 async function logUpload(
   supabase: ReturnType<typeof createClient>,
   entry: {
-    kind: "daily" | "promotion" | "price_master" | "plan_guide";
+    kind: "daily" | "promotion" | "price_master" | "plan_guide" | "segment";
     source_file: string;
     detail?: string;
     row_count?: number;
@@ -79,6 +79,7 @@ export default function UploadPage() {
           <UploadCard key={c.key} def={c} />
         ))}
         <PriceMasterCard />
+        <SegmentImportCard />
         <PlanGuideImportCard />
       </div>
       <UploadHistory />
@@ -103,6 +104,7 @@ const KIND_LABEL: Record<string, string> = {
   promotion: "캠페인",
   price_master: "가격 마스터",
   plan_guide: "플랜 가이드",
+  segment: "세그먼트 실적",
 };
 
 function UploadHistory() {
@@ -1113,6 +1115,192 @@ function PriceMasterCard() {
                 className="h-full bg-brand-500 transition-all"
                 style={{ width: `${pctVal}%` }}
               />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────
+// ⑥ 세그먼트 실적 — 카페24 채널별(회원/비회원·회원등급·카테고리·일반/정기 분해) 매출 export.
+//    캠페인 코드(파일명)·이름으로 캠페인을 식별(없으면 생성), 세그먼트 fact 적재 + 카테고리 백필.
+//    회원/등급/객단가/AOV 분석(상세 '세그먼트' 탭)의 데이터원. 기존 ③ 흐름과 독립.
+// ─────────────────────────────────────────────
+function SegmentImportCard() {
+  const router = useRouter();
+  const [p, setP] = useState<Progress>({ phase: "idle", message: "" });
+  const { confirm, element: replaceDialog } = useReplaceConfirm();
+
+  async function handleFile(file: File) {
+    try {
+      setP({ phase: "reading", message: `${file.name} 읽는 중…` });
+      const buf = await file.arrayBuffer();
+      setP({ phase: "parsing", message: "세그먼트 시트 파싱 중…" });
+      const parse = await import("@/lib/parse");
+      const products = await import("@/lib/products");
+      const supabase = createClient();
+
+      const parsed = parse.parseSegmentSheet(buf);
+      if (parsed.rows.length === 0) throw new Error("유효한 행이 없습니다.");
+
+      const rawName = file.name.replace(/\.(xlsx|xls|csv)$/i, "");
+      const code = parse.extractPromoCode(rawName);
+      const name = code ? rawName.slice(rawName.indexOf(code)) : rawName;
+      const newRevenue = parsed.rows.reduce((s, r) => s + r.revenue, 0);
+      const cats = [...new Set(parsed.rows.map((r) => r.category).filter(Boolean))];
+      const grades = [...new Set(parsed.rows.map((r) => r.member_grade).filter(Boolean))];
+
+      // 캠페인 식별 (코드 우선, 없으면 이름) — 없으면 신규 생성
+      setP({ phase: "uploading", message: "캠페인 확인 중…" });
+      let existing: { id: string } | null = null;
+      if (code) {
+        const { data } = await supabase
+          .from("promotions").select("id").eq("code", code).limit(1).maybeSingle();
+        existing = (data as { id: string } | null) ?? null;
+      }
+      if (!existing) {
+        const { data } = await supabase
+          .from("promotions").select("id").eq("name", name).limit(1).maybeSingle();
+        existing = (data as { id: string } | null) ?? null;
+      }
+
+      // 상품 매칭(이름 → product_id) — base_name 매칭 실패 행도 적재하되 product_id=null
+      setP({ phase: "uploading", message: "상품 매칭 중…" });
+      const productMap = await products.ensureProducts(
+        supabase,
+        parsed.rows.map((r) => r.base_name),
+      );
+      const matched = parsed.rows.filter((r) => productMap.get(r.base_name)).length;
+
+      let promotionId: string;
+      if (existing) {
+        promotionId = existing.id;
+        const { count: oldCount } = await supabase
+          .from("promotion_segment_sales")
+          .select("*", { count: "exact", head: true })
+          .eq("promotion_id", promotionId);
+        if (oldCount && oldCount > 0) {
+          const ok = await confirm({
+            title: `세그먼트 실적 교체 — ${name}`,
+            oldCount,
+            oldRevenue: 0,
+            newCount: parsed.rows.length,
+            newRevenue,
+            matchedSkus: matched,
+            totalSkus: new Set(parsed.rows.map((r) => r.base_name)).size,
+            note: "이 캠페인의 기존 세그먼트 실적을 최신 파일로 교체합니다(삭제+삽입 원자적). 카테고리는 빈 품목만 백필됩니다.",
+          });
+          if (!ok) {
+            setP({ phase: "idle", message: "취소됨" });
+            return;
+          }
+        }
+      } else {
+        setP({ phase: "uploading", message: "캠페인 생성 중…" });
+        const { inferSeasonality } = await import("@/lib/season");
+        const { data: seasonRows } = await supabase.from("seasonalities").select("name").order("sort");
+        const seasonNames = (seasonRows ?? []).map((r) => r.name as string);
+        const season_tag = inferSeasonality(name, parsed.start_date, seasonNames);
+        const { data: created, error: cErr } = await supabase
+          .from("promotions")
+          .insert({ name, code, start_date: parsed.start_date, end_date: parsed.end_date, season_tag })
+          .select("id").single();
+        if (cErr) throw cErr;
+        promotionId = created.id as string;
+      }
+
+      const records = parsed.rows.map((r) => ({
+        product_id: productMap.get(r.base_name) ?? null,
+        base_name: r.base_name,
+        option_info: r.option_info,
+        category: r.category,
+        member_type: r.member_type,
+        member_grade: r.member_grade,
+        order_type: r.order_type,
+        revenue: r.revenue,
+        order_count: r.order_count,
+        aov: r.aov,
+        arppu: r.arppu,
+        paying_users: r.paying_users,
+        quantity: r.quantity,
+        fee: r.fee,
+        cost: r.cost,
+      }));
+
+      setP({ phase: "uploading", message: `세그먼트 ${records.length}행 적재 중…`, done: 0, total: records.length });
+      const { data: insertedN, error: rpcErr } = await supabase.rpc("replace_promotion_segment_sales", {
+        p_promotion_id: promotionId,
+        p_rows: records,
+      });
+      if (rpcErr) throw rpcErr;
+      const done = Number(insertedN) || records.length;
+
+      await logUpload(supabase, {
+        kind: "segment",
+        source_file: file.name,
+        detail: `${name} · 카테고리 ${cats.length}종 · 등급 ${grades.length}종`,
+        row_count: done,
+        total_revenue: newRevenue,
+        action: existing ? "replace" : "insert",
+        codes: code ? [code] : undefined,
+      });
+      setP({ phase: "ok", message: `${name} 세그먼트 ${done}행 적재 완료. 상세로 이동합니다…` });
+      router.push(`/promotions/${promotionId}?view=segment`);
+    } catch (e) {
+      setP({ phase: "error", message: errMsg(e) });
+    }
+  }
+
+  const busy = p.phase === "reading" || p.phase === "parsing" || p.phase === "uploading";
+  const pctVal = p.total && p.total > 0 && p.done != null ? Math.round((p.done / p.total) * 100) : null;
+
+  return (
+    <div className="rounded-2xl card-soft p-5">
+      {replaceDialog}
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="font-medium">⑥ 세그먼트 실적 (회원·등급·카테고리)</h2>
+          <p className="mt-1 text-sm text-neutral-500">
+            카페24 채널별 매출 export(회원/비회원 × 회원등급 × 카테고리 × 일반/정기 분해)를 올리면
+            <b> 회원/비회원·등급·객단가(ARPPU)·AOV</b> 분석이 캠페인 상세 ‘세그먼트’ 탭에 표시됩니다.
+            파일명의 캠페인 코드로 캠페인을 식별(없으면 생성)하고, 빈 품목의 카테고리도 자동 백필합니다.
+            재업로드 시 같은 캠페인의 세그먼트 실적을 교체합니다.
+          </p>
+        </div>
+        <label
+          className={`shrink-0 cursor-pointer rounded-xl border border-neutral-200 px-4 py-2 text-sm font-medium hover:bg-neutral-50 ${
+            busy ? "pointer-events-none opacity-50" : ""
+          }`}
+        >
+          파일 선택
+          <input
+            type="file"
+            accept=".xlsx,.xls,.csv"
+            className="hidden"
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) handleFile(f);
+              e.target.value = "";
+            }}
+          />
+        </label>
+      </div>
+      {p.phase !== "idle" && p.message && (
+        <div
+          className={`mt-3 rounded-lg px-3 py-2 text-sm ${
+            p.phase === "error"
+              ? "bg-red-50 text-red-700"
+              : p.phase === "ok"
+                ? "bg-green-50 text-green-700"
+                : "bg-neutral-100 text-neutral-600"
+          }`}
+        >
+          <div>{p.message}</div>
+          {pctVal != null && p.phase === "uploading" && (
+            <div className="mt-1.5 h-1.5 overflow-hidden rounded-full bg-white/60">
+              <div className="h-full bg-brand-500 transition-all" style={{ width: `${pctVal}%` }} />
             </div>
           )}
         </div>

--- a/promo-analytics/lib/__tests__/parse.test.ts
+++ b/promo-analytics/lib/__tests__/parse.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import * as XLSX from "xlsx";
-import { parsePromotionSheet } from "../parse";
+import { parsePromotionSheet, parseSegmentSheet } from "../parse";
 
 /** AOA → xlsx ArrayBuffer (parsePromotionSheet 입력 형태) */
 function sheetBuf(aoa: unknown[][]): ArrayBuffer {
@@ -70,5 +70,80 @@ describe("parsePromotionSheet — 리치 채널별 매출 export", () => {
   it("금액·원가를 읽는다", () => {
     expect(parsed.rows[0].revenue).toBe(88029979);
     expect(parsed.rows[1].cost).toBe(27485600);
+  });
+});
+
+// 세그먼트(회원/비회원 × 회원등급 × 카테고리 × 일반/정기) 분해 export — 실제 카페24 헤더
+const SEG_HEADER = [
+  "일자 (누적)",
+  "판매 채널",
+  "기초 상품명",
+  "상품명",
+  "옵션정보",
+  "회원/비회원 주문",
+  "일반/정기 배송",
+  "기초 상품 카테고리",
+  "주문 회원등급",
+  "결제금액 (환불/취소 제외)",
+  "결제금액 (환불/취소 제외) %",
+  "결제 건수 (클레임 제외)",
+  "평균 주문 가치 (AOV) (환불/취소 제외)",
+  "수수료 (발생 환불/취소 제외)",
+  "원가 (환불/취소 제외)",
+  "기초 상품 판매 수량 (환불/취소 제외)",
+  "상품 판매가 할인 (환불/취소 제외)",
+  "객단가(ARPPU) (환불/취소 제외)",
+  "결제 유저수 (환불/취소 제외)",
+];
+
+describe("parseSegmentSheet — 세그먼트 분해 export", () => {
+  const buf = sheetBuf([
+    SEG_HEADER,
+    [
+      "2026-06-08 ~ 2026-06-14 ", "카페24", "퓨저나이트 슈퍼볼 8.3kg (대용량)", "퓨저나이트 슈퍼볼 8.3kg",
+      "상품선택=슈퍼볼 8.3kg 4개", "회원", "일반", "배변용품", "고영희",
+      "61490", "1", "1", "61490", "2367", "34400", "4", "0", "61490", "1",
+    ],
+    [
+      "2026-06-08 ~ 2026-06-14 ", "카페24", "어떤 간식", "어떤 간식",
+      "옵션X", "비회원", "정기", "간식", "-",
+      "12000", "1", "2", "6000", "400", "5000", "3", "0", "6000", "2",
+    ],
+    [
+      "2026-06-08 ~ 2026-06-14 ", "카페24", "직원 구매품", "직원 구매품",
+      "옵션Y", "회원", "일반", "용품", "Staff",
+      "9000", "1", "1", "9000", "0", "8000", "1", "0", "9000", "1",
+    ],
+  ]);
+  const parsed = parseSegmentSheet(buf);
+
+  it("회원/비회원·회원등급·카테고리를 분리해 읽는다", () => {
+    expect(parsed.rows[0].member_type).toBe("회원");
+    expect(parsed.rows[0].member_grade).toBe("고영희");
+    expect(parsed.rows[0].category).toBe("배변용품");
+  });
+
+  it("'-' 등급·비회원을 null/비회원으로 정규화한다", () => {
+    expect(parsed.rows[1].member_type).toBe("비회원");
+    expect(parsed.rows[1].member_grade).toBeNull();
+  });
+
+  it("일반/정기를 order_type으로, ARPPU·결제유저수를 읽는다", () => {
+    expect(parsed.rows[0].order_type).toBe("onetime");
+    expect(parsed.rows[1].order_type).toBe("subscription");
+    expect(parsed.rows[0].arppu).toBe(61490);
+    expect(parsed.rows[1].paying_users).toBe(2);
+  });
+
+  it("AOV·수량·매출을 읽고 Staff 행도 보존한다(집계 단계에서 제외)", () => {
+    expect(parsed.rows[0].aov).toBe(61490);
+    expect(parsed.rows[0].quantity).toBe(4);
+    expect(parsed.rows[2].member_grade).toBe("Staff");
+    expect(parsed.rows).toHaveLength(3);
+  });
+
+  it("누적 기간을 파싱한다", () => {
+    expect(parsed.start_date).toBe("2026-06-08");
+    expect(parsed.end_date).toBe("2026-06-14");
   });
 });

--- a/promo-analytics/lib/parse.ts
+++ b/promo-analytics/lib/parse.ts
@@ -277,6 +277,104 @@ export function parsePromotionSheet(buf: ArrayBuffer): ParsedPromotion {
 }
 
 // ─────────────────────────────────────────────
+// ⑥ 세그먼트 실적 (회원/비회원 × 회원등급 × 카테고리 × 일반/정기)
+//    카페24 채널별 매출 export — 한 라인을 세그먼트로 분해. promotion_segment_sales 적재용.
+// ─────────────────────────────────────────────
+export type SegmentSalesRow = {
+  base_name: string;
+  option_info: string;
+  category: string | null;
+  member_type: string | null; // 회원 | 비회원
+  member_grade: string | null; // 고영희/꼬물이/아깽이/캣초딩/묘르신 · Staff · 동물병원 · null
+  order_type: "subscription" | "onetime" | null;
+  revenue: number;
+  order_count: number;
+  aov: number;
+  arppu: number;
+  paying_users: number;
+  quantity: number;
+  fee: number;
+  cost: number;
+};
+
+export type ParsedSegment = {
+  start_date: string | null;
+  end_date: string | null;
+  rows: SegmentSalesRow[];
+};
+
+export function parseSegmentSheet(buf: ArrayBuffer): ParsedSegment {
+  const rows = firstSheetRows(buf);
+  // 세그먼트 export는 회원/비회원·회원등급 컬럼이 핵심 — 일반 캠페인 시트와 구분되는 지표
+  const h = findHeaderRow(rows, ["기초상품명", "결제금액", "회원", "회원등급", "카테고리"]);
+  if (h < 0)
+    throw new Error(
+      "세그먼트 실적 시트 헤더를 찾을 수 없습니다 (회원/비회원·회원등급·카테고리·결제금액 컬럼 필요). " +
+        "카페24 채널별(세그먼트 분해) 매출 export인지 확인하세요.",
+    );
+  const header = rows[h];
+  const cPeriod = findCol(header, ["일자"]);
+  const cName = preferBaseName(header);
+  const cOpt = findCol(header, ["옵션정보", "옵션"]);
+  const cCat = findCol(header, ["기초상품카테고리", "카테고리", "분류"]);
+  // '회원/비회원 주문'(→회원비회원주문)과 '주문 회원등급'(→주문회원등급)을 정확히 분리
+  const cMember = findCol(header, ["회원/비회원", "회원비회원"]);
+  const cGrade = findCol(header, ["주문회원등급", "회원등급"]);
+  const cOrderType = findCol(header, ["일반/정기 배송", "일반/정기", "주문유형", "정기여부"]);
+  const cRev = findCol(header, ["결제금액"]);
+  const cCnt = findCol(header, ["결제건수", "건수"]);
+  const cAov = findCol(header, ["평균주문가치", "aov"]);
+  const cArppu = findCol(header, ["객단가", "arppu"]);
+  const cUsers = findCol(header, ["결제유저수", "유저수"]);
+  const cFee = findCol(header, ["수수료"]);
+  const cCost = findCol(header, ["원가"]);
+  const cQty = findCol(header, ["판매수량", "수량"]);
+
+  let start: string | null = null;
+  let end: string | null = null;
+  const out: SegmentSalesRow[] = [];
+
+  for (let i = h + 1; i < rows.length; i++) {
+    const r = rows[i];
+    const name = String(r[cName] ?? "").trim();
+    if (!name || name === "-") continue;
+
+    if (!start && cPeriod >= 0) {
+      const p = String(r[cPeriod] ?? "");
+      const parts = p.split("~");
+      if (parts.length >= 2) {
+        start = toDateStr(parts[0]);
+        end = toDateStr(parts[1]);
+      } else {
+        start = toDateStr(p);
+      }
+    }
+
+    const at = (c: number) => (c >= 0 ? String(r[c] ?? "").trim() : "");
+    const cat = at(cCat);
+    const member = at(cMember);
+    const grade = at(cGrade);
+    out.push({
+      base_name: name,
+      option_info: at(cOpt),
+      category: cat && cat !== "-" ? cat : null,
+      member_type: member && member !== "-" ? member : null,
+      member_grade: grade && grade !== "-" ? grade : null,
+      order_type: cOrderType >= 0 ? normOrderType(r[cOrderType]) : null,
+      revenue: toNum(r[cRev]),
+      order_count: toNum(r[cCnt]),
+      aov: toNum(r[cAov]),
+      arppu: toNum(r[cArppu]),
+      paying_users: toNum(r[cUsers]),
+      quantity: toNum(r[cQty]),
+      fee: toNum(r[cFee]),
+      cost: toNum(r[cCost]),
+    });
+  }
+  return { start_date: start, end_date: end, rows: out };
+}
+
+// ─────────────────────────────────────────────
 // ③ 마스터 (품목코드)
 // ─────────────────────────────────────────────
 export type MasterRow = {

--- a/promo-analytics/lib/types.ts
+++ b/promo-analytics/lib/types.ts
@@ -301,3 +301,22 @@ export type CampaignAchievement = {
   actual_contribution_total: number | null;
   quantity_reliable: boolean | null;
 };
+
+// 0058: 세그먼트 성과 요약 (promotion_segment_summary RPC 반환)
+//   회원/비회원·회원등급 코호트·일반정기·카테고리. Staff·동물병원은 excluded로 분리.
+//   AOV·ARPPU는 합계에서 파생: AOV=revenue/orders, ARPPU=revenue/users.
+export type SegmentRow = {
+  revenue: number;
+  orders: number;
+  qty: number;
+  users: number;
+};
+export type SegmentSummary = {
+  has_data: boolean;
+  total: SegmentRow | null;
+  member_split: (SegmentRow & { seg: string })[];
+  grades: (SegmentRow & { grade: string })[];
+  order_types: { order_type: string; revenue: number; orders: number; qty: number }[];
+  categories: { category: string; revenue: number; orders: number; qty: number }[];
+  excluded: { grade: string; revenue: number; orders: number }[];
+};

--- a/promo-analytics/supabase/migrations/0057_segment_sales.sql
+++ b/promo-analytics/supabase/migrations/0057_segment_sales.sql
@@ -32,6 +32,13 @@ create table if not exists promo.promotion_segment_sales (
 create index if not exists promotion_segment_sales_promo_idx
   on promo.promotion_segment_sales(promotion_id);
 
+-- RLS: 기존 promo 테이블 규약과 동일(인증 사용자 허용). 앱이 교체 확인용으로 이 테이블을
+-- authenticated 클라이언트로 직접 count 조회하므로 정책이 없으면 조용히 0건이 된다.
+alter table promo.promotion_segment_sales enable row level security;
+drop policy if exists promotion_segment_sales_auth on promo.promotion_segment_sales;
+create policy promotion_segment_sales_auth on promo.promotion_segment_sales
+  for all to authenticated using (true) with check (true);
+
 -- 원자 교체(삭제+삽입) + 카테고리 백필 — 업로드 직후 일관 적용
 create or replace function promo.replace_promotion_segment_sales(
   p_promotion_id uuid,

--- a/promo-analytics/supabase/migrations/0057_segment_sales.sql
+++ b/promo-analytics/supabase/migrations/0057_segment_sales.sql
@@ -1,0 +1,94 @@
+-- 0057: 세그먼트 실적 수집 (회원/비회원 × 회원등급 × 카테고리 × 일반/정기) + 카테고리 백필
+--
+-- 카페24 채널별 매출 export는 한 라인을 회원유형·회원등급·기초상품 카테고리·주문유형(일반/정기)으로
+-- 분해해 제공한다. 기존 promotion_sales(SKU/옵션 합계)는 이 차원을 담지 못하므로 세그먼트 단위
+-- fact 테이블을 신설한다. 동시에 export의 '기초 상품 카테고리'로 products.category를 백필(현재
+-- 16% → 대폭 상승)해 카테고리 기반 서브상품 어태치율 추천(0059)·카테고리 선택기를 의미있게 만든다.
+--
+-- 모두 추가형(기존 업로드/RPC 불변). product_id는 업로드 시 ensureProducts로 해석해 채운다.
+
+create table if not exists promo.promotion_segment_sales (
+  id            bigint generated always as identity primary key,
+  promotion_id  uuid references promo.promotions(id) on delete cascade,
+  product_id    uuid references promo.products(id),
+  base_name     text not null,
+  option_info   text,
+  category      text,              -- 기초 상품 카테고리 (영양케어/간식/배변용품/용품/굿즈…)
+  member_type   text,              -- '회원' | '비회원'
+  member_grade  text,              -- 주문 회원등급 (고영희/꼬물이/아깽이/캣초딩/묘르신 · Staff · 동물병원)
+  order_type    text,              -- 'subscription' | 'onetime' | null (일반/정기 배송)
+  revenue       numeric default 0,
+  order_count   numeric default 0, -- 결제 건수(클레임 제외)
+  aov           numeric,           -- 평균 주문 가치 (export 원본값, 행 단위)
+  arppu         numeric,           -- 객단가 (export 원본값, 행 단위)
+  paying_users  numeric,           -- 결제 유저수
+  quantity      numeric default 0, -- 기초 상품 판매 수량
+  fee           numeric default 0,
+  cost          numeric default 0,
+  raw           jsonb,
+  created_at    timestamptz not null default now()
+);
+
+create index if not exists promotion_segment_sales_promo_idx
+  on promo.promotion_segment_sales(promotion_id);
+
+-- 원자 교체(삭제+삽입) + 카테고리 백필 — 업로드 직후 일관 적용
+create or replace function promo.replace_promotion_segment_sales(
+  p_promotion_id uuid,
+  p_rows jsonb
+)
+returns integer
+language plpgsql security definer set search_path = ''
+as $$
+declare
+  n integer;
+begin
+  delete from promo.promotion_segment_sales where promotion_id = p_promotion_id;
+
+  insert into promo.promotion_segment_sales
+    (promotion_id, product_id, base_name, option_info, category, member_type, member_grade,
+     order_type, revenue, order_count, aov, arppu, paying_users, quantity, fee, cost, raw)
+  select p_promotion_id,
+         nullif(r->>'product_id', '')::uuid,
+         r->>'base_name',
+         nullif(r->>'option_info', ''),
+         nullif(r->>'category', ''),
+         nullif(r->>'member_type', ''),
+         nullif(r->>'member_grade', ''),
+         nullif(r->>'order_type', ''),
+         coalesce((r->>'revenue')::numeric, 0),
+         coalesce((r->>'order_count')::numeric, 0),
+         nullif(r->>'aov', '')::numeric,
+         nullif(r->>'arppu', '')::numeric,
+         nullif(r->>'paying_users', '')::numeric,
+         coalesce((r->>'quantity')::numeric, 0),
+         coalesce((r->>'fee')::numeric, 0),
+         coalesce((r->>'cost')::numeric, 0),
+         r->'raw'
+  from jsonb_array_elements(coalesce(p_rows, '[]'::jsonb)) r;
+
+  get diagnostics n = row_count;
+
+  -- 카테고리 백필: export가 들고 온 카테고리로 비어있는 products.category만 채운다(정규화 SKU명 매칭,
+  -- 동일 정규화명 중 가장 흔한 카테고리 선택). 기존 값은 덮어쓰지 않음.
+  with seg as (
+    select promo.normalize_sku_name(base_name) as skey, category, count(*) as c
+    from promo.promotion_segment_sales
+    where promotion_id = p_promotion_id and nullif(category, '') is not null
+    group by 1, 2
+  ),
+  pick as (
+    select distinct on (skey) skey, category from seg order by skey, c desc
+  )
+  update promo.products p
+     set category = pick.category
+    from pick
+   where promo.normalize_sku_name(p.base_name) = pick.skey
+     and (p.category is null or p.category = '');
+
+  return n;
+end;
+$$;
+
+grant execute on function promo.replace_promotion_segment_sales(uuid, jsonb) to authenticated;
+notify pgrst, 'reload schema';

--- a/promo-analytics/supabase/migrations/0058_segment_summary.sql
+++ b/promo-analytics/supabase/migrations/0058_segment_summary.sql
@@ -1,0 +1,70 @@
+-- 0058: 세그먼트 성과 요약 (회원/비회원, 회원등급 코호트, AOV/ARPPU, 일반/정기)
+--
+-- promotion_segment_sales(0057)를 회원유형·회원등급으로 집계해 단일 JSON으로 반환.
+-- 정책(사용자 확정): Staff·동물병원(도매)은 고객 성과 합계에서 제외하고 별도 'excluded' 블록으로 노출.
+--   · 회원 vs 비회원 분리. 회원은 등급 코호트(아깽이/꼬물이/캣초딩/고영희/묘르신 등) 유지.
+--   · AOV·ARPPU는 합산이 불가능한 행 단위 값이라 집계 매출에서 파생: AOV=매출/결제건수,
+--     ARPPU=매출/결제유저수. (프런트에서 파생 — RPC는 합계만 신뢰성 있게 제공)
+-- detail bundle과 동일하게 단일 RPC. 미적재 캠페인은 has_data=false.
+
+create or replace function promo.promotion_segment_summary(p_id uuid)
+returns jsonb
+language sql stable security definer set search_path = ''
+as $$
+  with base as (
+    select *,
+      (coalesce(member_grade, '') in ('Staff', '동물병원')) as is_excluded
+    from promo.promotion_segment_sales
+    where promotion_id = p_id
+  ),
+  member_split as (
+    select
+      case when member_type = '비회원' then '비회원' else '회원' end as seg,
+      sum(revenue) as revenue, sum(order_count) as orders,
+      sum(quantity) as qty, sum(coalesce(paying_users, 0)) as users
+    from base where not is_excluded
+    group by 1
+  ),
+  grade as (
+    select member_grade as grade,
+      sum(revenue) as revenue, sum(order_count) as orders,
+      sum(quantity) as qty, sum(coalesce(paying_users, 0)) as users
+    from base
+    where not is_excluded and member_type <> '비회원' and nullif(member_grade, '') is not null
+    group by 1
+  ),
+  ordtype as (
+    select coalesce(order_type, 'onetime') as order_type,
+      sum(revenue) as revenue, sum(order_count) as orders, sum(quantity) as qty
+    from base where not is_excluded
+    group by 1
+  ),
+  cat as (
+    select coalesce(nullif(category, ''), '미분류') as category,
+      sum(revenue) as revenue, sum(order_count) as orders, sum(quantity) as qty
+    from base where not is_excluded
+    group by 1
+  ),
+  excluded as (
+    select member_grade as grade, sum(revenue) as revenue, sum(order_count) as orders
+    from base where is_excluded
+    group by 1
+  ),
+  totals as (
+    select sum(revenue) as revenue, sum(order_count) as orders,
+           sum(coalesce(paying_users, 0)) as users, sum(quantity) as qty
+    from base where not is_excluded
+  )
+  select jsonb_build_object(
+    'has_data', (select count(*) from base) > 0,
+    'total', (select to_jsonb(t) from totals t),
+    'member_split', coalesce((select jsonb_agg(to_jsonb(m) order by m.revenue desc) from member_split m), '[]'::jsonb),
+    'grades', coalesce((select jsonb_agg(to_jsonb(g) order by g.revenue desc) from grade g), '[]'::jsonb),
+    'order_types', coalesce((select jsonb_agg(to_jsonb(o) order by o.revenue desc) from ordtype o), '[]'::jsonb),
+    'categories', coalesce((select jsonb_agg(to_jsonb(c) order by c.revenue desc) from cat c), '[]'::jsonb),
+    'excluded', coalesce((select jsonb_agg(to_jsonb(e) order by e.revenue desc) from excluded e), '[]'::jsonb)
+  );
+$$;
+
+grant execute on function promo.promotion_segment_summary(uuid) to authenticated;
+notify pgrst, 'reload schema';

--- a/promo-analytics/supabase/migrations/0059_category_sub_benchmarks.sql
+++ b/promo-analytics/supabase/migrations/0059_category_sub_benchmarks.sql
@@ -31,7 +31,8 @@ returns table(
   consumer_price numeric,
   regular_price numeric,
   cost numeric,
-  avg_discount numeric        -- 소비자가 대비 평균 할인율(0~1)
+  avg_discount numeric,       -- 소비자가 대비 평균 할인율(0~1)
+  total_revenue numeric       -- 풀 내 누적 매출(서브상품 기여 규모)
 )
 language sql stable security definer set search_path = ''
 as $$
@@ -114,7 +115,8 @@ as $$
     pr.consumer_price, pr.regular_price, pr.cost,
     case when pr.consumer_price > 0
          then round(1 - (a.total_revenue / nullif(a.total_qty, 0)) / pr.consumer_price, 3)
-         else null end as avg_discount
+         else null end as avg_discount,
+    a.total_revenue
   from agg a
   join prod pr on pr.skey = a.skey
   where (p_exclude_skeys is null or a.skey <> all(p_exclude_skeys))

--- a/promo-analytics/supabase/migrations/0059_category_sub_benchmarks.sql
+++ b/promo-analytics/supabase/migrations/0059_category_sub_benchmarks.sql
@@ -1,0 +1,125 @@
+-- 0059: 카테고리 기반 서브상품 어태치율 벤치마크 + 플랜 메인 카테고리
+--
+-- 목적: "메인 카테고리 = X 인 과거 캠페인"에서 다른 상품들이 '메인 대비 얼마나 팔렸는지(어태치율)'를
+-- 집계 → 새 플랜에서 (계획한 메인 수량 × 어태치율)로 서브 수량을 적정하게 자동 제안.
+-- 0048(sub_product_benchmarks, 전역 빈도)과 별개로, 카테고리·비율 전용 RPC를 신설한다.
+--
+-- 메인 판별: 확정·현행 플랜의 main_product_ids(0034) → products.category 를 1차 신호로 사용하고,
+-- 메인 수량은 그 메인 SKU(정규화명)와 일치하는 promotion_sale_options 수량 합으로 본다.
+-- p_main_category = '전체'/null → 전 캠페인(전사 할인·n주년 분석용).
+
+alter table promo.campaign_plans
+  add column if not exists main_category text;
+comment on column promo.campaign_plans.main_category is
+  '플래닝 시 선택한 메인 카테고리(서브 어태치율 추천 기준). 전체=null 또는 ''전체''.';
+
+drop function if exists promo.category_sub_benchmarks(text, int, text[]);
+
+create function promo.category_sub_benchmarks(
+  p_main_category text default null,
+  p_months int default 12,
+  p_exclude_skeys text[] default null
+)
+returns table(
+  product_id uuid,
+  base_name text,
+  category text,
+  campaigns int,
+  avg_attach_ratio numeric,   -- 메인 1개당 서브 평균 수량 (캠페인별 비율의 평균)
+  avg_qty numeric,            -- 등장 캠페인당 평균 절대 수량
+  avg_unit_price numeric,     -- 평균 단가(매출/수량)
+  consumer_price numeric,
+  regular_price numeric,
+  cost numeric,
+  avg_discount numeric        -- 소비자가 대비 평균 할인율(0~1)
+)
+language sql stable security definer set search_path = ''
+as $$
+  with plan_main as (
+    -- 확정·현행 플랜의 메인 product_id → 연결 캠페인(actual 우선)
+    select coalesce(cp.actual_promotion_id, cp.promotion_id) as promotion_id,
+           unnest(cp.main_product_ids) as product_id
+    from promo.campaign_plans cp
+    where cp.is_current and cp.status = 'confirmed'
+      and cp.main_product_ids is not null and array_length(cp.main_product_ids, 1) > 0
+  ),
+  main_cat as (
+    -- 캠페인별 메인 카테고리(최빈) + 메인 SKU 정규화 키 집합
+    select pm.promotion_id,
+      mode() within group (order by pr.category) filter (where pr.category is not null) as main_category,
+      array_agg(distinct promo.normalize_sku_name(pr.base_name)) as main_skeys
+    from plan_main pm
+    join promo.products pr on pr.id = pm.product_id
+    group by pm.promotion_id
+  ),
+  main_qty as (
+    -- 메인 SKU와 일치하는 실적옵션 수량 합 = 캠페인 메인 총수량(구독 제외)
+    select o.promotion_id, sum(o.quantity) as main_qty
+    from promo.promotion_sale_options o
+    join main_cat mc on mc.promotion_id = o.promotion_id
+    join promo.promotions p on p.id = o.promotion_id
+    where not o.is_subscription and o.quantity > 0
+      and promo.normalize_sku_name(o.label) = any(mc.main_skeys)
+      and (p_months is null or p.start_date >= (current_date - make_interval(months => p_months)))
+    group by o.promotion_id
+  ),
+  camp as (
+    select mc.promotion_id, mc.main_category, mc.main_skeys, q.main_qty
+    from main_cat mc
+    join main_qty q on q.promotion_id = mc.promotion_id
+    where q.main_qty > 0
+      and (p_main_category is null or p_main_category = '전체' or mc.main_category = p_main_category)
+  ),
+  sub_opt as (
+    -- 풀 안 캠페인의 '서브'(메인 SKU 제외) 옵션
+    select o.promotion_id, o.label, o.revenue, o.quantity, c.main_qty
+    from promo.promotion_sale_options o
+    join camp c on c.promotion_id = o.promotion_id
+    where not o.is_subscription and o.quantity > 0
+      and promo.normalize_sku_name(o.label) <> all(c.main_skeys)
+  ),
+  per_camp as (
+    select promo.normalize_sku_name(label) as skey, promotion_id,
+      sum(quantity) as qty, sum(revenue) as revenue,
+      sum(quantity) / nullif(max(main_qty), 0) as attach_ratio
+    from sub_opt
+    group by 1, 2
+  ),
+  agg as (
+    select skey,
+      count(distinct promotion_id) as campaigns,
+      avg(attach_ratio) as avg_attach_ratio,
+      avg(qty) as avg_qty,
+      sum(qty) as total_qty,
+      sum(revenue) as total_revenue
+    from per_camp
+    group by skey
+  ),
+  prod as (
+    select promo.normalize_sku_name(base_name) as skey,
+      (array_agg(id order by coalesce(consumer_price, 0) desc))[1] as product_id,
+      (array_agg(base_name order by coalesce(consumer_price, 0) desc))[1] as base_name,
+      (array_agg(category order by coalesce(consumer_price, 0) desc nulls last))[1] as category,
+      max(consumer_price) as consumer_price,
+      max(regular_price) as regular_price,
+      max(cost) as cost
+    from promo.products
+    group by 1
+  )
+  select pr.product_id, pr.base_name, pr.category,
+    a.campaigns::int,
+    round(a.avg_attach_ratio, 3) as avg_attach_ratio,
+    round(a.avg_qty, 1) as avg_qty,
+    round(a.total_revenue / nullif(a.total_qty, 0)) as avg_unit_price,
+    pr.consumer_price, pr.regular_price, pr.cost,
+    case when pr.consumer_price > 0
+         then round(1 - (a.total_revenue / nullif(a.total_qty, 0)) / pr.consumer_price, 3)
+         else null end as avg_discount
+  from agg a
+  join prod pr on pr.skey = a.skey
+  where (p_exclude_skeys is null or a.skey <> all(p_exclude_skeys))
+  order by a.campaigns desc, a.avg_attach_ratio desc;
+$$;
+
+grant execute on all functions in schema promo to authenticated;
+notify pgrst, 'reload schema';

--- a/promo-analytics/supabase/migrations/0059_category_sub_benchmarks.sql
+++ b/promo-analytics/supabase/migrations/0059_category_sub_benchmarks.sql
@@ -64,12 +64,23 @@ as $$
       and (p_months is null or p.start_date >= (current_date - make_interval(months => p_months)))
     group by o.promotion_id
   ),
-  camp as (
+  camp_all as (
     select mc.promotion_id, mc.main_category, mc.main_skeys, q.main_qty
     from main_cat mc
     join main_qty q on q.promotion_id = mc.promotion_id
     where q.main_qty > 0
-      and (p_main_category is null or p_main_category = '전체' or mc.main_category = p_main_category)
+  ),
+  sel as (
+    -- 선택한 메인 카테고리가 메인이던 캠페인(또는 전체)
+    select * from camp_all
+    where (p_main_category is null or p_main_category = '전체' or main_category = p_main_category)
+  ),
+  sel_count as (select count(*) as n from sel),
+  camp as (
+    -- 동일 메인카테고리 표본이 충분(>=2)하면 그것만, 부족하면 전체 캠페인으로 자동 보완
+    select promotion_id, main_skeys, main_qty from sel where (select n from sel_count) >= 2
+    union all
+    select promotion_id, main_skeys, main_qty from camp_all where (select n from sel_count) < 2
   ),
   sub_opt as (
     -- 풀 안 캠페인의 '서브'(메인 SKU 제외) 옵션


### PR DESCRIPTION
## 배경

업로드된 카페24 export(696행)가 현재 파이프라인보다 훨씬 잘게 분해돼 있다는 점에서 출발했습니다. 현재 `promotion_sales`는 SKU 합계만 저장해 **회원/비회원·회원등급·카테고리·ARPPU·결제유저수**를 담지 못합니다. 이 PR은 그 데이터를 수집·분석하고, 동시에 카테고리 기반 서브상품 추천을 어태치율로 자동화합니다.

사용자 확정 사항(질문→답변): 어태치율 단위 / 신규 세그먼트 업로드+테이블 / Staff·동물병원 제외·회원·비회원 분리 / 기존 화면 통합.

## 변경 요약

### A·B — 카테고리 기반 서브상품 어태치율 추천
- **`category_sub_benchmarks()` RPC(0059)**: 메인 카테고리가 X였던 과거 확정 캠페인에서 서브상품의 **어태치율(메인 1개당 서브 수량)** 집계. `'전체'`/null → 전 캠페인(n주년 등).
- 플랜 에디터에 **메인 카테고리 선택기(SegmentedControl, '전체' 포함)** 추가. 계획한 메인 수량 × 어태치율로 서브 수량 자동 환산.
- 카테고리 매칭되는 과거 캠페인이 없으면 기존 전역 빈도 벤치마크(`sub_product_benchmarks`)로 **graceful fallback** → 패널이 비지 않음.
- `campaign_plans.main_category` 컬럼으로 선택 기억(best-effort 저장).

### C — 회원/등급/객단가/AOV 세그먼트 분석
- **`promotion_segment_sales` fact 테이블(0057)**: 회원유형 × 등급 × 카테고리 × 일반/정기 grain. `replace_promotion_segment_sales()` 원자 교체 + **`products.category` 백필**(현재 ~16% → 대폭 상승).
- 업로드 페이지에 **⑥ 세그먼트 실적 카드** 추가(코드로 캠페인 식별·없으면 생성).
- **`promotion_segment_summary()` RPC(0058)**: 회원/비회원 분리, 등급 코호트, AOV=매출/건수·ARPPU=매출/유저수 파생. **Staff·동물병원(도매)은 고객 합계에서 제외**하고 별도 표기.
- 캠페인 상세에 **세그먼트 탭**(`SegmentBlock`) 신설.

## 마이그레이션 (⚠️ 적용 필요)
`0057`·`0058`·`0059` 모두 **추가형**(drop/rename 없음). 프로덕션 DB(원격)에는 **아직 적용하지 않았습니다** — 적용 전까지 앱은 graceful degrade(세그먼트 탭 빈 상태, 추천은 전역 폴백)합니다. 적용을 원하시면 Supabase MCP `apply_migration`으로 0057→0058→0059 순서로 진행하겠습니다.

## 검증
- `npm run build` ✅ (tsc 통과) · `npm test` ✅ (67 → 72 통과, `parseSegmentSheet` 테스트 5개 추가)
- lint: 기존 13개 pre-existing 에러만 존재(본 변경이 추가한 신규 에러 없음)

## 적용 후 E2E 체크
1. 업로드 → ⑥ 세그먼트 실적에 첨부 export 적재 → `promotion_segment_sales` 696행, 카테고리 백필 증가 확인
2. 캠페인 상세 `?view=segment` — 회원/비회원·등급 AOV/ARPPU, Staff·동물병원 제외 확인
3. 플랜 에디터에서 '배변용품' 선택 → 어태치율 추천·메인 수량 변경 시 스케일, '전체' 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vrSc7PUyxGFhDwhVDjisF

---
_Generated by [Claude Code](https://claude.ai/code/session_011vrSc7PUyxGFhDwhVDjisF)_