### PR TITLE
feat(upload): 데이터 업로드 4카드 재설계 — 채널 일별매출·시트연동·통합 캠페인 성과

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/PerformanceUpload.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/PerformanceUpload.tsx
@@ -3,12 +3,14 @@
 import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
-import { parsePromotionSheet } from "@/lib/parse";
+import { parseSegmentSheet } from "@/lib/parse";
 import { ensureProducts } from "@/lib/products";
 
-// 캠페인에 직접 성과 추가 (6단계) — 라플라스 동기간 매출 export를 '이 캠페인'에 고정 적재.
-// 이름/코드 매칭에 의존하지 않고 promotion_id로 바로 넣어 플랜↔성과가 확실히 같은 캠페인에 붙는다.
-// replace_promotion_sales RPC가 원자적 교체 + 성과옵션 재구성(구독/시그니처)을 수행한다.
+// 캠페인에 직접 성과 추가 (통합 포맷) — 회원/등급/카테고리·일반/정기까지 분해된 매출 export를
+// '이 캠페인'에 promotion_id로 고정 적재. replace_promotion_performance RPC가 한 번에
+//   (1) promotion_segment_sales 풀그레인(세그먼트 탭·어태치율) + 카테고리 백필
+//   (2) promotion_sales 집계(달성률·롤업)
+// 를 원자적으로 채운다. 이어서 sale_options 재구성 + 롤업 갱신.
 export default function PerformanceUpload({
   promotionId,
   hasActuals,
@@ -60,9 +62,9 @@ export default function PerformanceUpload({
     setMsg(null);
     try {
       const buf = await file.arrayBuffer();
-      const parsed = parsePromotionSheet(buf);
+      const parsed = parseSegmentSheet(buf);
       if (parsed.rows.length === 0)
-        throw new Error("성과 행이 없습니다 — 라플라스 캠페인 매출 export인지 확인하세요.");
+        throw new Error("성과 행이 없습니다 — 회원/등급/카테고리까지 분해된 캠페인 매출 export인지 확인하세요.");
 
       const supabase = createClient();
       const productMap = await ensureProducts(
@@ -70,34 +72,58 @@ export default function PerformanceUpload({
         parsed.rows.map((r) => r.base_name),
       );
       const records = parsed.rows.map((r) => ({
-        promotion_id: promotionId,
         product_id: productMap.get(r.base_name) ?? null,
         base_name: r.base_name,
         option_info: r.option_info,
+        category: r.category,
+        member_type: r.member_type,
+        member_grade: r.member_grade,
+        order_type: r.order_type, // 정기/일반 — 구독 자동 분류
         revenue: r.revenue,
         order_count: r.order_count,
         aov: r.aov,
+        arppu: r.arppu,
+        paying_users: r.paying_users,
+        quantity: r.quantity,
         fee: r.fee,
         cost: r.cost,
-        quantity: r.quantity,
-        order_type: r.order_type, // 정기/일반 — 구독 자동 분류
-        sale_option_code: r.sale_option_code,
-        raw: r.composition ? { composition: r.composition } : null,
       }));
 
-      // 원자적 교체 + 성과옵션 재구성(구독/시그니처 자동 분류)
-      const { error } = await supabase.rpc("replace_promotion_sales", {
+      // 통합 적재: 세그먼트 풀그레인 + promotion_sales 집계(달성률) 원자적 교체
+      const { error } = await supabase.rpc("replace_promotion_performance", {
         p_promotion_id: promotionId,
         p_rows: records,
       });
       if (error) throw error;
-      // 롤업 갱신(달성률·구독분리) — 실패해도 적재는 유효
+      // 성과옵션(구독/시그니처) 재구성 + 롤업 갱신 — 실패해도 적재는 유효
+      try {
+        await supabase.rpc("rebuild_sale_options", { p_promotion_id: promotionId });
+      } catch {
+        /* 옵션 재구성 실패는 무시 — 다음 조회 시 ensure */
+      }
       await supabase.rpc("refresh_rollups", { p_force: true });
+
+      // 업로드 이력(④ 캠페인 성과 카드) — best-effort
+      try {
+        const cats = new Set(records.map((x) => x.category).filter(Boolean)).size;
+        const { data: au } = await supabase.auth.getUser();
+        await supabase.from("upload_log").insert({
+          kind: "segment",
+          source_file: file.name,
+          detail: `${parsed.rows.length}행 · 카테고리 ${cats}종`,
+          row_count: parsed.rows.length,
+          total_revenue: records.reduce((s, x) => s + (x.revenue || 0), 0),
+          action: hasActuals ? "replace" : "insert",
+          uploaded_by: au.user?.email ?? null,
+        });
+      } catch {
+        /* 이력 기록 실패는 무시 */
+      }
 
       const subN = records.filter((x) => x.order_type === "subscription").length;
       setMsg({
         kind: "ok",
-        text: `성과 ${records.length}행 적재·자동 분류 완료${subN > 0 ? ` (정기구독 ${subN}행 분리)` : ""}. 달성률을 갱신합니다…`,
+        text: `성과 ${records.length}행 적재·자동 분류 완료${subN > 0 ? ` (정기구독 ${subN}행 분리)` : ""}. 세그먼트·달성률을 갱신합니다…`,
       });
       router.refresh();
     } catch (e) {
@@ -116,8 +142,8 @@ export default function PerformanceUpload({
             성과 {hasActuals ? "교체" : "추가"}
           </h2>
           <p className="mt-0.5 text-xs text-ink-4">
-            캠페인 종료 후 <strong className="text-ink-3">동기간 매출 export</strong>(상품명·일반/정기·옵션정보·기초상품명)를 올리면
-            이 캠페인에 바로 적재 → 옵션/SKU별 달성률과 구독 제외 값이 자동 분류됩니다.
+            캠페인 종료 후 <strong className="text-ink-3">통합 매출 export</strong>(기초상품명·옵션정보·회원/비회원·회원등급·카테고리·일반/정기)를 올리면
+            이 캠페인에 바로 적재 → 옵션/SKU별 <strong className="text-ink-3">달성률</strong>과 <strong className="text-ink-3">세그먼트</strong>(회원·등급·AOV·ARPPU)가 한 번에 채워집니다.
           </p>
         </div>
         <label className={`shrink-0 cursor-pointer rounded-full px-5 py-2.5 text-sm font-semibold text-white shadow-soft transition duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] ${busy ? "bg-ink-4" : "bg-brand-500 hover:-translate-y-0.5 hover:bg-brand-600 hover:shadow-float"}`}>

--- a/promo-analytics/app/(dash)/upload/CampaignPerformanceList.tsx
+++ b/promo-analytics/app/(dash)/upload/CampaignPerformanceList.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/client";
+import { won } from "@/lib/format";
+import { downloadPlanXlsx, downloadPerformanceXlsx } from "@/lib/exportXlsx";
+import CardHistory from "./CardHistory";
+
+type Row = {
+  promotion_id: string;
+  name: string;
+  code: string | null;
+  channel: string | null;
+  start_date: string | null;
+  end_date: string | null;
+  seg_rows: number;
+  revenue: number;
+  categories: number;
+  subscription_revenue: number;
+  last_at: string | null;
+};
+
+// ④ 캠페인 성과 — 적재 완료된 캠페인의 플랜·성과를 리스트업하고 엑셀로 내려받기.
+// 업로드 자체는 각 캠페인 상세의 '성과 업로드'에서 통합 포맷으로 수행한다.
+export default function CampaignPerformanceList() {
+  const [rows, setRows] = useState<Row[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    const supabase = createClient();
+    const { data, error } = await supabase.rpc("campaign_performance_list");
+    if (error) setErr(error.message);
+    setRows((data as Row[]) ?? []);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    load();
+    const h = () => load();
+    window.addEventListener("upload-done", h);
+    return () => window.removeEventListener("upload-done", h);
+  }, [load]);
+
+  async function dl(kind: "plan" | "perf", r: Row) {
+    setErr(null);
+    setBusy(`${kind}:${r.promotion_id}`);
+    try {
+      if (kind === "plan") await downloadPlanXlsx(r.promotion_id, r.name);
+      else await downloadPerformanceXlsx(r.promotion_id, r.name);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  function period(r: Row) {
+    if (!r.start_date) return "—";
+    return `${r.start_date}${r.end_date ? ` ~ ${r.end_date}` : ""}`;
+  }
+
+  return (
+    <div className="rounded-2xl card-soft p-5">
+      <div className="flex items-baseline justify-between">
+        <h2 className="font-medium">④ 캠페인 성과 (회원·등급·카테고리)</h2>
+        <span className="text-[11px] text-neutral-400">{rows.length}개 캠페인</span>
+      </div>
+      <p className="mt-1 text-sm text-neutral-500">
+        성과 업로드는 각 캠페인 상세의 <b>성과 업로드</b>에서 통합 포맷(달성률+세그먼트)으로 진행합니다.
+        여기서는 적재된 캠페인의 플랜·성과를 확인하고 엑셀로 내려받습니다.
+      </p>
+
+      {err && <p className="mt-3 text-xs text-rose-600">{err}</p>}
+
+      {loading ? (
+        <p className="mt-4 text-sm text-neutral-400">불러오는 중…</p>
+      ) : rows.length === 0 ? (
+        <p className="mt-4 text-sm text-neutral-400">아직 성과가 적재된 캠페인이 없습니다.</p>
+      ) : (
+        <div className="mt-3 overflow-x-auto">
+          <table className="w-full min-w-[760px] text-left text-sm">
+            <thead className="text-xs text-neutral-400">
+              <tr>
+                <th className="py-1.5 pr-3">최종 적재</th>
+                <th className="py-1.5 pr-3">채널</th>
+                <th className="py-1.5 pr-3">캠페인</th>
+                <th className="py-1.5 pr-3">기간</th>
+                <th className="py-1.5 pr-3">요약</th>
+                <th className="py-1.5 text-right">다운로드</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr key={r.promotion_id} className="border-t border-neutral-100 align-top">
+                  <td className="py-2 pr-3 whitespace-nowrap text-neutral-500">
+                    {r.last_at
+                      ? new Date(r.last_at).toLocaleString("ko-KR", { month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit" })
+                      : "—"}
+                  </td>
+                  <td className="py-2 pr-3 whitespace-nowrap">
+                    <span className="rounded-full bg-neutral-100 px-2 py-0.5 text-xs text-neutral-600">{r.channel ?? "—"}</span>
+                  </td>
+                  <td className="py-2 pr-3 font-medium text-neutral-800">
+                    <Link href={`/promotions/${r.promotion_id}?view=segment`} className="hover:underline">
+                      {r.name}
+                    </Link>
+                  </td>
+                  <td className="py-2 pr-3 whitespace-nowrap text-neutral-500">{period(r)}</td>
+                  <td className="py-2 pr-3 text-neutral-500">
+                    {won(r.revenue)} · {r.seg_rows.toLocaleString()}행 · 카테고리 {r.categories}종
+                    {r.revenue > 0 && r.subscription_revenue > 0 && (
+                      <> · 정기 {Math.round((r.subscription_revenue / r.revenue) * 100)}%</>
+                    )}
+                  </td>
+                  <td className="py-2 text-right whitespace-nowrap">
+                    <button
+                      onClick={() => dl("plan", r)}
+                      disabled={busy != null}
+                      className="rounded-lg border border-neutral-200 px-2 py-1 text-xs text-neutral-600 hover:bg-neutral-50 disabled:opacity-50"
+                    >
+                      {busy === `plan:${r.promotion_id}` ? "…" : "플랜"}
+                    </button>
+                    <button
+                      onClick={() => dl("perf", r)}
+                      disabled={busy != null}
+                      className="ml-1.5 rounded-lg border border-neutral-200 px-2 py-1 text-xs text-neutral-600 hover:bg-neutral-50 disabled:opacity-50"
+                    >
+                      {busy === `perf:${r.promotion_id}` ? "…" : "성과"}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <CardHistory kinds={["segment", "performance"]} />
+    </div>
+  );
+}

--- a/promo-analytics/app/(dash)/upload/CardHistory.tsx
+++ b/promo-analytics/app/(dash)/upload/CardHistory.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+
+type LogRow = {
+  id: string;
+  source_file: string;
+  detail: string | null;
+  row_count: number | null;
+  action: string | null;
+  created_at: string;
+};
+
+// 카드별 미니 업로드 이력 — upload_log 를 kind 로 필터해 최근 N건. (기존 전역 '연동 이력' 섹션 대체)
+// upload-done window 이벤트로 자동 갱신.
+export default function CardHistory({ kinds, limit = 4 }: { kinds: string[]; limit?: number }) {
+  const [rows, setRows] = useState<LogRow[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  const load = useCallback(async () => {
+    const supabase = createClient();
+    const { data } = await supabase
+      .from("upload_log")
+      .select("id, source_file, detail, row_count, action, created_at, kind")
+      .in("kind", kinds)
+      .order("created_at", { ascending: false })
+      .limit(limit);
+    setRows((data as LogRow[]) ?? []);
+    setLoaded(true);
+  }, [kinds, limit]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    load();
+    const h = () => load();
+    window.addEventListener("upload-done", h);
+    return () => window.removeEventListener("upload-done", h);
+  }, [load]);
+
+  if (!loaded || rows.length === 0) return null;
+
+  return (
+    <div className="mt-3 border-t border-neutral-100 pt-2.5">
+      <div className="text-[11px] font-medium text-neutral-400">최근 업로드</div>
+      <ul className="mt-1 space-y-0.5">
+        {rows.map((r) => (
+          <li key={r.id} className="flex items-center gap-2 text-[11px] text-neutral-500">
+            <span className="whitespace-nowrap text-neutral-400">
+              {new Date(r.created_at).toLocaleString("ko-KR", { month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit" })}
+            </span>
+            <span className="truncate font-medium text-neutral-600">{r.source_file}</span>
+            {r.detail && <span className="truncate text-neutral-400">· {r.detail}</span>}
+            {r.row_count != null && (
+              <span className="ml-auto whitespace-nowrap tabular-nums text-neutral-400">{r.row_count.toLocaleString()}행</span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/promo-analytics/app/(dash)/upload/PriceMasterSync.tsx
+++ b/promo-analytics/app/(dash)/upload/PriceMasterSync.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+
+type SyncRow = {
+  csv_url: string | null;
+  enabled: boolean;
+  last_synced_at: string | null;
+  last_status: string | null;
+  last_row_count: number | null;
+};
+
+// 품목/가격 마스터 — Google Sheets '웹에 게시(CSV)' 연동. URL 저장 + 수동 동기화 + 상태 표시.
+// 자동(일 1회)은 Vercel Cron(/api/cron/sync-price-master)이 수행.
+export default function PriceMasterSync() {
+  const [row, setRow] = useState<SyncRow | null>(null);
+  const [url, setUrl] = useState("");
+  const [busy, setBusy] = useState<"idle" | "saving" | "syncing">("idle");
+  const [msg, setMsg] = useState<{ kind: "ok" | "err"; text: string } | null>(null);
+
+  const load = useCallback(async () => {
+    const supabase = createClient();
+    const { data } = await supabase
+      .from("sheet_sync")
+      .select("csv_url, enabled, last_synced_at, last_status, last_row_count")
+      .eq("id", 1)
+      .maybeSingle();
+    const r = (data as SyncRow) ?? null;
+    setRow(r);
+    setUrl(r?.csv_url ?? "");
+  }, []);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    load();
+  }, [load]);
+
+  async function save() {
+    setBusy("saving");
+    setMsg(null);
+    try {
+      const supabase = createClient();
+      const { error } = await supabase
+        .from("sheet_sync")
+        .update({ csv_url: url.trim() || null, updated_at: new Date().toISOString() })
+        .eq("id", 1);
+      if (error) throw new Error(error.message);
+      setMsg({ kind: "ok", text: "CSV URL 저장됨" });
+      await load();
+    } catch (e) {
+      setMsg({ kind: "err", text: e instanceof Error ? e.message : String(e) });
+    } finally {
+      setBusy("idle");
+    }
+  }
+
+  async function syncNow() {
+    setBusy("syncing");
+    setMsg(null);
+    try {
+      const res = await fetch("/api/cron/sync-price-master", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ csv_url: url.trim() || undefined }),
+      });
+      const json = (await res.json()) as {
+        ok?: boolean;
+        items?: number;
+        configs?: number;
+        unmatched?: number;
+        error?: string;
+      };
+      if (!res.ok || !json.ok) throw new Error(json.error ?? `동기화 실패 (HTTP ${res.status})`);
+      setMsg({
+        kind: "ok",
+        text: `동기화 완료 · 품목 ${json.items ?? 0}건 · 구성 ${json.configs ?? 0}건${
+          json.unmatched ? ` · 매칭실패 ${json.unmatched}` : ""
+        }`,
+      });
+      if (typeof window !== "undefined") window.dispatchEvent(new Event("upload-done"));
+      await load();
+    } catch (e) {
+      setMsg({ kind: "err", text: e instanceof Error ? e.message : String(e) });
+    } finally {
+      setBusy("idle");
+    }
+  }
+
+  return (
+    <div className="mt-4 rounded-xl border border-neutral-150 bg-neutral-50/60 p-3.5">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-neutral-700">스프레드시트 연동 (Google Sheets · 매일 자동)</span>
+        {row?.last_synced_at && (
+          <span className="text-[11px] text-neutral-400">
+            마지막 동기화 {new Date(row.last_synced_at).toLocaleString("ko-KR", { month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit" })}
+          </span>
+        )}
+      </div>
+      <p className="mt-1 text-xs text-neutral-500">
+        시트 → 파일 → 공유 → ‘웹에 게시’ → 해당 시트 · CSV → 게시. 생성된 CSV 링크를 등록하면 매일 1회 자동 동기화됩니다.
+      </p>
+      <div className="mt-2 flex flex-col gap-2 sm:flex-row">
+        <input
+          type="url"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://docs.google.com/spreadsheets/d/e/…/pub?gid=0&single=true&output=csv"
+          className="min-w-0 flex-1 rounded-lg border border-neutral-200 px-3 py-1.5 text-sm"
+        />
+        <div className="flex gap-2">
+          <button
+            onClick={save}
+            disabled={busy !== "idle"}
+            className="rounded-lg border border-neutral-200 px-3 py-1.5 text-sm text-neutral-600 hover:bg-neutral-50 disabled:opacity-50"
+          >
+            {busy === "saving" ? "저장 중…" : "URL 저장"}
+          </button>
+          <button
+            onClick={syncNow}
+            disabled={busy !== "idle" || !url.trim()}
+            className="rounded-lg bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+          >
+            {busy === "syncing" ? "동기화 중…" : "지금 동기화"}
+          </button>
+        </div>
+      </div>
+      {msg && (
+        <p className={`mt-2 text-xs ${msg.kind === "ok" ? "text-emerald-600" : "text-rose-600"}`}>{msg.text}</p>
+      )}
+      {!msg && row?.last_status && row.last_status !== "ok" && (
+        <p className="mt-2 text-xs text-rose-600">최근 상태: {row.last_status}</p>
+      )}
+    </div>
+  );
+}

--- a/promo-analytics/app/(dash)/upload/page.tsx
+++ b/promo-analytics/app/(dash)/upload/page.tsx
@@ -285,16 +285,17 @@ function UploadCard({ def }: { def: CardDef }) {
         );
         const dedup = new Map<
           string,
-          { sale_date: string; product_id: string | null; base_name: string; option_info: string; revenue: number; quantity: number; source_file: string }
+          { sale_date: string; product_id: string | null; base_name: string; option_info: string; channel: string; revenue: number; quantity: number; source_file: string }
         >();
         for (const r of rows) {
-          const key = JSON.stringify([r.sale_date, r.base_name, r.option_info]);
+          const key = JSON.stringify([r.sale_date, r.base_name, r.option_info, r.channel]);
           const prev = dedup.get(key);
           dedup.set(key, {
             sale_date: r.sale_date,
             product_id: productMap.get(r.base_name) ?? null,
             base_name: r.base_name,
             option_info: r.option_info,
+            channel: r.channel,
             revenue: (prev?.revenue ?? 0) + r.revenue,
             quantity: (prev?.quantity ?? 0) + r.quantity,
             source_file: file.name,

--- a/promo-analytics/app/(dash)/upload/page.tsx
+++ b/promo-analytics/app/(dash)/upload/page.tsx
@@ -1,11 +1,14 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { won, pct } from "@/lib/format";
 import type { ParsedPriceConfig } from "@/lib/parse";
 import { useReplaceConfirm } from "./useReplaceConfirm";
+import PriceMasterSync from "./PriceMasterSync";
+import CampaignPerformanceList from "./CampaignPerformanceList";
+import CardHistory from "./CardHistory";
 
 // 업로드 이력 기록 — 연동 파일명·시간·종류·행수를 남긴다(업데이트 참고용).
 // 실패해도 업로드 자체를 막지 않는다(best-effort).
@@ -50,19 +53,9 @@ type CardDef = {
 
 const CARDS: CardDef[] = [
   {
-    key: "master",
-    title: "① 마스터 (품목코드)",
-    desc: "기초상품 원가·소비자가·상시가. 가장 먼저 올리면 상품 정보가 채워집니다.",
-  },
-  {
     key: "daily",
-    title: "② 일별 매출 추이",
-    desc: "일자 × 기초상품 × 옵션 × 결제금액 × 수량. baseline(평소 매출)의 연료입니다. 재업로드 시 같은 기간·상품을 교체합니다(누적 아님) — 수량·옵션정보 백필용.",
-  },
-  {
-    key: "promotion",
-    title: "③ 캠페인 시트",
-    desc: "캠페인 기간 성과(전 제품). 파일명의 캠페인 코드(CF_P_…)로 캠페인을 식별 — 같은 코드의 가이드(⑤)·성과(②)은 자동으로 한 캠페인에 결속됩니다(비교연결·병합 불필요). 같은 코드가 있으면 성과를 교체(백필)하고 확정 플랜은 보존, 없으면 새로 생성합니다.",
+    title: "① 일별 전체 매출",
+    desc: "모든 B2C 채널 합본을 한 번에 올리면 채널별로 분해해 적재합니다(일자 × 기초상품 × 옵션 × 채널 × 결제금액 × 수량). baseline(평소 매출)과 캠페인 시점 비교의 연료입니다. 재업로드 시 같은 기간·상품을 교체합니다(누적 아님).",
   },
 ];
 
@@ -79,124 +72,13 @@ export default function UploadPage() {
           <UploadCard key={c.key} def={c} />
         ))}
         <PriceMasterCard />
-        <SegmentImportCard />
         <PlanGuideImportCard />
+        <CampaignPerformanceList />
       </div>
-      <UploadHistory />
     </div>
   );
 }
 
-type LogRow = {
-  id: string;
-  kind: string;
-  source_file: string;
-  detail: string | null;
-  row_count: number | null;
-  total_revenue: number | null;
-  action: string | null;
-  uploaded_by: string | null;
-  created_at: string;
-};
-
-const KIND_LABEL: Record<string, string> = {
-  daily: "일별 매출",
-  promotion: "캠페인",
-  price_master: "가격 마스터",
-  plan_guide: "플랜 가이드",
-  segment: "세그먼트 실적",
-};
-
-function UploadHistory() {
-  const [rows, setRows] = useState<LogRow[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  const load = useCallback(async () => {
-    const supabase = createClient();
-    const { data } = await supabase
-      .from("upload_log")
-      .select("*")
-      .order("created_at", { ascending: false })
-      .limit(30);
-    setRows((data as LogRow[]) ?? []);
-    setLoading(false);
-  }, []);
-
-  useEffect(() => {
-    load();
-    const h = () => load();
-    window.addEventListener("upload-done", h);
-    return () => window.removeEventListener("upload-done", h);
-  }, [load]);
-
-  return (
-    <div className="mt-6 rounded-2xl card-soft p-5">
-      <div className="flex items-center justify-between">
-        <h2 className="font-medium">연동 이력</h2>
-        <button
-          onClick={load}
-          className="rounded-lg border border-neutral-200 px-3 py-1 text-xs text-neutral-600 hover:bg-neutral-50"
-        >
-          새로고침
-        </button>
-      </div>
-      <p className="mt-1 text-sm text-neutral-500">
-        최근 업로드한 파일·시간·행수입니다. 다음 업데이트 때 어떤 소스가 반영됐는지 참고하세요.
-      </p>
-      {loading ? (
-        <p className="mt-4 text-sm text-neutral-400">불러오는 중…</p>
-      ) : rows.length === 0 ? (
-        <p className="mt-4 text-sm text-neutral-400">아직 업로드 이력이 없습니다.</p>
-      ) : (
-        <div className="mt-3 overflow-x-auto">
-          <table className="w-full min-w-[640px] text-left text-sm">
-            <thead className="text-xs text-neutral-400">
-              <tr>
-                <th className="py-1.5 pr-3">시간</th>
-                <th className="py-1.5 pr-3">종류</th>
-                <th className="py-1.5 pr-3">파일명</th>
-                <th className="py-1.5 pr-3">요약</th>
-                <th className="py-1.5 pr-3 text-right">행수</th>
-                <th className="py-1.5">방식</th>
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((r) => (
-                <tr key={r.id} className="border-t border-neutral-100 align-top">
-                  <td className="py-1.5 pr-3 whitespace-nowrap text-neutral-500">
-                    {new Date(r.created_at).toLocaleString("ko-KR", {
-                      month: "2-digit",
-                      day: "2-digit",
-                      hour: "2-digit",
-                      minute: "2-digit",
-                    })}
-                  </td>
-                  <td className="py-1.5 pr-3 whitespace-nowrap">
-                    <span className="rounded-full bg-neutral-100 px-2 py-0.5 text-xs text-neutral-600">
-                      {KIND_LABEL[r.kind] ?? r.kind}
-                    </span>
-                  </td>
-                  <td className="py-1.5 pr-3 font-medium text-neutral-800">{r.source_file}</td>
-                  <td className="py-1.5 pr-3 text-neutral-500">{r.detail ?? "—"}</td>
-                  <td className="py-1.5 pr-3 text-right tabular-nums text-neutral-700">
-                    {r.row_count != null ? r.row_count.toLocaleString() : "—"}
-                  </td>
-                  <td className="py-1.5">
-                    {r.action === "replace" ? (
-                      <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[11px] text-amber-700">교체(백필)</span>
-                    ) : (
-                      <span className="rounded bg-neutral-100 px-1.5 py-0.5 text-[11px] text-neutral-500">신규</span>
-                    )}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </div>
-  );
-}
 
 type Progress = {
   phase: "idle" | "reading" | "parsing" | "uploading" | "ok" | "error";
@@ -594,6 +476,7 @@ function UploadCard({ def }: { def: CardDef }) {
           )}
         </div>
       )}
+      <CardHistory kinds={[def.key]} />
     </div>
   );
 }
@@ -931,7 +814,7 @@ function PriceMasterCard() {
     <div className="rounded-2xl card-soft p-5">
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h2 className="font-medium">④ 가격 마스터 (가격가이드 워크북)</h2>
+          <h2 className="font-medium">② 품목/가격 마스터</h2>
           <p className="mt-1 text-sm text-neutral-500">
             품목 시트 + 가격가이드 시트를 한 번에 적재합니다. SKU × 구성(단품/2·3·4·5묶음)별
             할인율·공헌이익은 rate card로 자동 계산합니다. 재업로드 시 중복 없이 갱신됩니다.
@@ -1120,195 +1003,12 @@ function PriceMasterCard() {
           )}
         </div>
       )}
+      <PriceMasterSync />
+      <CardHistory kinds={["price_master"]} />
     </div>
   );
 }
 
-// ─────────────────────────────────────────────
-// ⑥ 세그먼트 실적 — 카페24 채널별(회원/비회원·회원등급·카테고리·일반/정기 분해) 매출 export.
-//    캠페인 코드(파일명)·이름으로 캠페인을 식별(없으면 생성), 세그먼트 fact 적재 + 카테고리 백필.
-//    회원/등급/객단가/AOV 분석(상세 '세그먼트' 탭)의 데이터원. 기존 ③ 흐름과 독립.
-// ─────────────────────────────────────────────
-function SegmentImportCard() {
-  const router = useRouter();
-  const [p, setP] = useState<Progress>({ phase: "idle", message: "" });
-  const { confirm, element: replaceDialog } = useReplaceConfirm();
-
-  async function handleFile(file: File) {
-    try {
-      setP({ phase: "reading", message: `${file.name} 읽는 중…` });
-      const buf = await file.arrayBuffer();
-      setP({ phase: "parsing", message: "세그먼트 시트 파싱 중…" });
-      const parse = await import("@/lib/parse");
-      const products = await import("@/lib/products");
-      const supabase = createClient();
-
-      const parsed = parse.parseSegmentSheet(buf);
-      if (parsed.rows.length === 0) throw new Error("유효한 행이 없습니다.");
-
-      const rawName = file.name.replace(/\.(xlsx|xls|csv)$/i, "");
-      const code = parse.extractPromoCode(rawName);
-      const name = code ? rawName.slice(rawName.indexOf(code)) : rawName;
-      const newRevenue = parsed.rows.reduce((s, r) => s + r.revenue, 0);
-      const cats = [...new Set(parsed.rows.map((r) => r.category).filter(Boolean))];
-      const grades = [...new Set(parsed.rows.map((r) => r.member_grade).filter(Boolean))];
-
-      // 캠페인 식별 (코드 우선, 없으면 이름) — 없으면 신규 생성
-      setP({ phase: "uploading", message: "캠페인 확인 중…" });
-      let existing: { id: string } | null = null;
-      if (code) {
-        const { data } = await supabase
-          .from("promotions").select("id").eq("code", code).limit(1).maybeSingle();
-        existing = (data as { id: string } | null) ?? null;
-      }
-      if (!existing) {
-        const { data } = await supabase
-          .from("promotions").select("id").eq("name", name).limit(1).maybeSingle();
-        existing = (data as { id: string } | null) ?? null;
-      }
-
-      // 상품 매칭(이름 → product_id) — base_name 매칭 실패 행도 적재하되 product_id=null
-      setP({ phase: "uploading", message: "상품 매칭 중…" });
-      const productMap = await products.ensureProducts(
-        supabase,
-        parsed.rows.map((r) => r.base_name),
-      );
-      const matched = parsed.rows.filter((r) => productMap.get(r.base_name)).length;
-
-      let promotionId: string;
-      if (existing) {
-        promotionId = existing.id;
-        const { count: oldCount } = await supabase
-          .from("promotion_segment_sales")
-          .select("*", { count: "exact", head: true })
-          .eq("promotion_id", promotionId);
-        if (oldCount && oldCount > 0) {
-          const ok = await confirm({
-            title: `세그먼트 실적 교체 — ${name}`,
-            oldCount,
-            oldRevenue: 0,
-            newCount: parsed.rows.length,
-            newRevenue,
-            matchedSkus: matched,
-            totalSkus: new Set(parsed.rows.map((r) => r.base_name)).size,
-            note: "이 캠페인의 기존 세그먼트 실적을 최신 파일로 교체합니다(삭제+삽입 원자적). 카테고리는 빈 품목만 백필됩니다.",
-          });
-          if (!ok) {
-            setP({ phase: "idle", message: "취소됨" });
-            return;
-          }
-        }
-      } else {
-        setP({ phase: "uploading", message: "캠페인 생성 중…" });
-        const { inferSeasonality } = await import("@/lib/season");
-        const { data: seasonRows } = await supabase.from("seasonalities").select("name").order("sort");
-        const seasonNames = (seasonRows ?? []).map((r) => r.name as string);
-        const season_tag = inferSeasonality(name, parsed.start_date, seasonNames);
-        const { data: created, error: cErr } = await supabase
-          .from("promotions")
-          .insert({ name, code, start_date: parsed.start_date, end_date: parsed.end_date, season_tag })
-          .select("id").single();
-        if (cErr) throw cErr;
-        promotionId = created.id as string;
-      }
-
-      const records = parsed.rows.map((r) => ({
-        product_id: productMap.get(r.base_name) ?? null,
-        base_name: r.base_name,
-        option_info: r.option_info,
-        category: r.category,
-        member_type: r.member_type,
-        member_grade: r.member_grade,
-        order_type: r.order_type,
-        revenue: r.revenue,
-        order_count: r.order_count,
-        aov: r.aov,
-        arppu: r.arppu,
-        paying_users: r.paying_users,
-        quantity: r.quantity,
-        fee: r.fee,
-        cost: r.cost,
-      }));
-
-      setP({ phase: "uploading", message: `세그먼트 ${records.length}행 적재 중…`, done: 0, total: records.length });
-      const { data: insertedN, error: rpcErr } = await supabase.rpc("replace_promotion_segment_sales", {
-        p_promotion_id: promotionId,
-        p_rows: records,
-      });
-      if (rpcErr) throw rpcErr;
-      const done = Number(insertedN) || records.length;
-
-      await logUpload(supabase, {
-        kind: "segment",
-        source_file: file.name,
-        detail: `${name} · 카테고리 ${cats.length}종 · 등급 ${grades.length}종`,
-        row_count: done,
-        total_revenue: newRevenue,
-        action: existing ? "replace" : "insert",
-        codes: code ? [code] : undefined,
-      });
-      setP({ phase: "ok", message: `${name} 세그먼트 ${done}행 적재 완료. 상세로 이동합니다…` });
-      router.push(`/promotions/${promotionId}?view=segment`);
-    } catch (e) {
-      setP({ phase: "error", message: errMsg(e) });
-    }
-  }
-
-  const busy = p.phase === "reading" || p.phase === "parsing" || p.phase === "uploading";
-  const pctVal = p.total && p.total > 0 && p.done != null ? Math.round((p.done / p.total) * 100) : null;
-
-  return (
-    <div className="rounded-2xl card-soft p-5">
-      {replaceDialog}
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h2 className="font-medium">⑥ 세그먼트 실적 (회원·등급·카테고리)</h2>
-          <p className="mt-1 text-sm text-neutral-500">
-            카페24 채널별 매출 export(회원/비회원 × 회원등급 × 카테고리 × 일반/정기 분해)를 올리면
-            <b> 회원/비회원·등급·객단가(ARPPU)·AOV</b> 분석이 캠페인 상세 ‘세그먼트’ 탭에 표시됩니다.
-            파일명의 캠페인 코드로 캠페인을 식별(없으면 생성)하고, 빈 품목의 카테고리도 자동 백필합니다.
-            재업로드 시 같은 캠페인의 세그먼트 실적을 교체합니다.
-          </p>
-        </div>
-        <label
-          className={`shrink-0 cursor-pointer rounded-xl border border-neutral-200 px-4 py-2 text-sm font-medium hover:bg-neutral-50 ${
-            busy ? "pointer-events-none opacity-50" : ""
-          }`}
-        >
-          파일 선택
-          <input
-            type="file"
-            accept=".xlsx,.xls,.csv"
-            className="hidden"
-            onChange={(e) => {
-              const f = e.target.files?.[0];
-              if (f) handleFile(f);
-              e.target.value = "";
-            }}
-          />
-        </label>
-      </div>
-      {p.phase !== "idle" && p.message && (
-        <div
-          className={`mt-3 rounded-lg px-3 py-2 text-sm ${
-            p.phase === "error"
-              ? "bg-red-50 text-red-700"
-              : p.phase === "ok"
-                ? "bg-green-50 text-green-700"
-                : "bg-neutral-100 text-neutral-600"
-          }`}
-        >
-          <div>{p.message}</div>
-          {pctVal != null && p.phase === "uploading" && (
-            <div className="mt-1.5 h-1.5 overflow-hidden rounded-full bg-white/60">
-              <div className="h-full bg-brand-500 transition-all" style={{ width: `${pctVal}%` }} />
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
 
 // ─────────────────────────────────────────────
 // ⑤ 캠페인 플랜 가이드 — 표준 양식(평평한 표) → 캠페인 플랜(예상) 적재.
@@ -1542,7 +1242,7 @@ function PlanGuideImportCard() {
     <div className="rounded-2xl card-soft p-5">
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h2 className="font-medium">⑤ 캠페인 플랜 가이드 (예상 적재)</h2>
+          <h2 className="font-medium">③ 캠페인 플랜 가이드</h2>
           <p className="mt-1 text-sm text-neutral-500">
             표준 양식(1행=옵션)으로 캠페인별 <b>예상(가설)</b> — 옵션·가격·예상수량·목표매출·공헌이익을
             플랜으로 적재합니다. 캠페인(성과) row는 만들지 않아요 — 성과는 ③ 매출 export로 별도
@@ -1636,6 +1336,7 @@ function PlanGuideImportCard() {
           </div>
         </div>
       )}
+      <CardHistory kinds={["plan_guide"]} />
     </div>
   );
 }

--- a/promo-analytics/app/api/cron/sync-price-master/route.ts
+++ b/promo-analytics/app/api/cron/sync-price-master/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { runPriceMasterSync } from "@/lib/priceMasterSync";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// 품목/가격 마스터 — Google Sheets '웹에 게시(CSV)' 동기화 엔드포인트.
+//   GET  : Vercel Cron(일 1회). Authorization: Bearer <CRON_SECRET> 검증 → 서비스 역할로 동기화.
+//   POST : UI '지금 동기화'. 로그인 세션으로 동기화. body.csv_url 주면 그 URL 사용(저장값 무시).
+
+export async function GET(req: Request) {
+  const secret = process.env.CRON_SECRET;
+  const auth = req.headers.get("authorization");
+  if (!secret || auth !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+  try {
+    const supabase = createAdminClient();
+    const out = await runPriceMasterSync(supabase);
+    return NextResponse.json({ ok: true, ...out });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return NextResponse.json({ ok: false, error: msg }, { status: 500 });
+  }
+}
+
+export async function POST(req: Request) {
+  const supabase = await createClient();
+  const { data: auth } = await supabase.auth.getUser();
+  if (!auth.user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  let csvUrl: string | undefined;
+  try {
+    const body = (await req.json()) as { csv_url?: string };
+    csvUrl = body.csv_url?.trim() || undefined;
+  } catch {
+    /* body 없음 — 저장된 URL 사용 */
+  }
+  try {
+    const out = await runPriceMasterSync(supabase, csvUrl ? { csvUrl } : undefined);
+    return NextResponse.json({ ok: true, ...out });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return NextResponse.json({ ok: false, error: msg }, { status: 500 });
+  }
+}

--- a/promo-analytics/lib/exportXlsx.ts
+++ b/promo-analytics/lib/exportXlsx.ts
@@ -1,0 +1,123 @@
+import * as XLSX from "xlsx";
+import { createClient } from "@/lib/supabase/client";
+
+// 캠페인 플랜 / 성과 데이터를 엑셀로 내려받기 (업로드 페이지 ④ '캠페인 성과' 카드).
+// 클라이언트에서 Supabase 조회 → 워크북 생성 → Blob 다운로드.
+
+function safe(name: string): string {
+  return (name || "campaign").replace(/[\\/:*?"<>|]+/g, "_").slice(0, 80);
+}
+
+function downloadWorkbook(wb: XLSX.WorkBook, filename: string) {
+  const out = XLSX.write(wb, { bookType: "xlsx", type: "array" });
+  const blob = new Blob([out], {
+    type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+/** 캠페인 확정/현재 플랜을 엑셀로 — 옵션 시트 + 구성(SKU) 시트. */
+export async function downloadPlanXlsx(promotionId: string, campaignName: string) {
+  const supabase = createClient();
+  const { data: plan } = await supabase
+    .from("campaign_plans")
+    .select("id, status, version")
+    .eq("promotion_id", promotionId)
+    .eq("is_current", true)
+    .maybeSingle();
+  if (!plan) throw new Error("이 캠페인에 플랜이 없습니다.");
+
+  const { data: options } = await supabase
+    .from("campaign_plan_options")
+    .select(
+      "id, option_label, is_main, expected_option_qty, set_price, consumer_total, regular_total, discount_rate_consumer, discount_rate_regular, expected_revenue, expected_contribution, sort",
+    )
+    .eq("campaign_plan_id", plan.id)
+    .order("sort");
+  const opts = options ?? [];
+  const optIds = opts.map((o) => o.id as string);
+
+  const itemsByOpt = new Map<string, Record<string, unknown>[]>();
+  if (optIds.length) {
+    const { data: items } = await supabase
+      .from("campaign_plan_option_items")
+      .select("campaign_plan_option_id, base_name, sku_qty_per_option, unit_sale_price, sort")
+      .in("campaign_plan_option_id", optIds)
+      .order("sort");
+    for (const it of items ?? []) {
+      const k = it.campaign_plan_option_id as string;
+      if (!itemsByOpt.has(k)) itemsByOpt.set(k, []);
+      itemsByOpt.get(k)!.push(it);
+    }
+  }
+
+  const optSheet = opts.map((o) => ({
+    옵션명: o.option_label,
+    메인: o.is_main ? "Y" : "",
+    예상수량: o.expected_option_qty,
+    판매가: o.set_price,
+    소비자정가: o.consumer_total,
+    상시정가: o.regular_total,
+    "할인율(소비자)": o.discount_rate_consumer,
+    "할인율(상시)": o.discount_rate_regular,
+    예상매출: o.expected_revenue,
+    예상공헌이익: o.expected_contribution,
+  }));
+  const skuSheet: Record<string, unknown>[] = [];
+  for (const o of opts) {
+    for (const it of itemsByOpt.get(o.id as string) ?? []) {
+      skuSheet.push({
+        옵션명: o.option_label,
+        기초상품명: it.base_name,
+        "구성수량/옵션": it.sku_qty_per_option,
+        단가: it.unit_sale_price,
+      });
+    }
+  }
+
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(optSheet), "옵션");
+  if (skuSheet.length) XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(skuSheet), "구성");
+  downloadWorkbook(wb, `${safe(campaignName)}_플랜.xlsx`);
+}
+
+/** 캠페인 성과(세그먼트 풀그레인)를 엑셀로. */
+export async function downloadPerformanceXlsx(promotionId: string, campaignName: string) {
+  const supabase = createClient();
+  const { data: rows } = await supabase
+    .from("promotion_segment_sales")
+    .select(
+      "base_name, option_info, category, member_type, member_grade, order_type, revenue, order_count, aov, arppu, paying_users, quantity, fee, cost",
+    )
+    .eq("promotion_id", promotionId)
+    .limit(20000);
+  const list = rows ?? [];
+  if (!list.length) throw new Error("이 캠페인에 성과 데이터가 없습니다.");
+
+  const sheet = list.map((r) => ({
+    기초상품명: r.base_name,
+    옵션정보: r.option_info,
+    카테고리: r.category,
+    "회원/비회원": r.member_type,
+    회원등급: r.member_grade,
+    "일반/정기": r.order_type,
+    결제금액: r.revenue,
+    결제건수: r.order_count,
+    AOV: r.aov,
+    ARPPU: r.arppu,
+    결제유저수: r.paying_users,
+    판매수량: r.quantity,
+    수수료: r.fee,
+    원가: r.cost,
+  }));
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(sheet), "성과");
+  downloadWorkbook(wb, `${safe(campaignName)}_성과.xlsx`);
+}

--- a/promo-analytics/lib/parse.ts
+++ b/promo-analytics/lib/parse.ts
@@ -141,6 +141,7 @@ export type DailyRow = {
   sale_date: string;
   base_name: string;
   option_info: string;
+  channel: string;
   revenue: number;
   quantity: number;
 };
@@ -150,13 +151,15 @@ export function parseDailySales(buf: ArrayBuffer): DailyRow[] {
   const h = findHeaderRow(rows, ["일자", "기초상품명", "결제금액", "판매수량"]);
   if (h < 0)
     throw new Error(
-      "일별 매출 추이 헤더를 찾을 수 없습니다 (일자·기초상품명·결제금액·판매수량 컬럼 필요). " +
+      "일별 전체 매출 헤더를 찾을 수 없습니다 (일자·기초상품명·결제금액·판매수량 컬럼 필요). " +
         "‘가이드/기획’ 문서가 아니라 일자별 매출 export인지 확인하세요.",
     );
   const header = rows[h];
   const cDate = findCol(header, ["일자"]);
   const cName = preferBaseName(header);
   const cOpt = findCol(header, ["옵션정보", "옵션"]);
+  // 채널: '판매채널/채널/유입채널/주문채널' 등. 합본 파일이라 행마다 채널이 들어옴. 없으면 '전체'.
+  const cChannel = findCol(header, ["판매채널", "주문채널", "유입채널", "채널몰", "채널"]);
   const cRev = findCol(header, ["결제금액"]);
   const cQty = findCol(header, ["판매수량", "수량"]);
 
@@ -166,10 +169,12 @@ export function parseDailySales(buf: ArrayBuffer): DailyRow[] {
     const date = toDateStr(r[cDate]);
     const name = String(r[cName] ?? "").trim();
     if (!date || !name || name === "-") continue;
+    const channel = cChannel >= 0 ? String(r[cChannel] ?? "").trim() : "";
     out.push({
       sale_date: date,
       base_name: name,
       option_info: String(r[cOpt] ?? "").trim(),
+      channel: channel || "전체",
       revenue: toNum(r[cRev]),
       quantity: toNum(r[cQty]),
     });

--- a/promo-analytics/lib/priceMasterSync.ts
+++ b/promo-analytics/lib/priceMasterSync.ts
@@ -1,0 +1,191 @@
+import * as XLSX from "xlsx";
+import { parseItemMaster, parsePriceGuide } from "@/lib/parse";
+import { chunk } from "@/lib/products";
+
+// 품목/가격 마스터 — Google Sheets '웹에 게시(CSV)' 동기화 공용 로직.
+// 단일 CSV 시트(품목코드·품목명·카테고리·원가(VAT+)·소비자가·상시가·2~5묶음가)를 받아
+// products + product_price_configs 를 upsert 한다. 수동(클라이언트)·자동(크론) 양쪽에서 호출.
+// window.confirm 없이 동작(서버 호환) — 같은 (품목×구성)은 최신값으로 덮어쓴다.
+
+// 최소 인터페이스만 사용 — 클라이언트/서비스 클라이언트 모두 수용.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type Db = any;
+
+export type PriceMasterSyncResult = {
+  items: number;
+  configs: number;
+  unmatched: number;
+};
+
+async function fetchMult(supabase: Db): Promise<number> {
+  const { data } = await supabase
+    .from("rate_card")
+    .select("fee_rate, ad_rate, logistics_rate, reward_rate")
+    .eq("is_current", true)
+    .order("effective_from", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (!data) return 0.715;
+  const sum =
+    Number(data.fee_rate) +
+    Number(data.ad_rate) +
+    Number(data.logistics_rate) +
+    Number(data.reward_rate);
+  return 1 - sum;
+}
+
+function dedupBy<T>(arr: T[], key: (t: T) => string): T[] {
+  const m = new Map<string, T>();
+  for (const it of arr) m.set(key(it), it);
+  return [...m.values()];
+}
+
+/** CSV 텍스트를 파싱해 products + product_price_configs 적재. 반환: 적재 건수 요약. */
+export async function applyPriceMasterCsv(
+  supabase: Db,
+  csvText: string,
+  fileName: string,
+): Promise<PriceMasterSyncResult> {
+  const wb = XLSX.read(csvText, { type: "string" });
+  const sheet = wb.SheetNames[0];
+  if (!sheet) throw new Error("CSV에 시트가 없습니다.");
+
+  const mult = await fetchMult(supabase);
+  const item = parseItemMaster(wb, sheet);
+  const lookup = new Map(
+    item.rows
+      .filter((r) => r.dr_code)
+      .map((r) => [
+        r.dr_code as string,
+        { cost: r.cost, consumer_price: r.consumer_price, regular_price: r.regular_price },
+      ]),
+  );
+  const guide = parsePriceGuide(wb, sheet, { mult, lookup });
+  if (item.rows.length === 0 && guide.configs.length === 0)
+    throw new Error("적재할 품목·구성이 없습니다. 헤더(품목코드·소비자가)를 확인하세요.");
+
+  // 1) 품목 upsert
+  const itemPayload = dedupBy(item.rows, (r) => r.base_name).map((r) => ({
+    base_name: r.base_name,
+    dr_code: r.dr_code,
+    cost: r.cost,
+    cost_vat_excluded: r.cost_vat_excluded,
+    consumer_price: r.consumer_price,
+    regular_price: r.regular_price,
+  }));
+  if (itemPayload.length > 0) {
+    const { error } = await supabase
+      .from("products")
+      .upsert(itemPayload, { onConflict: "base_name" });
+    if (error) throw new Error(error.message);
+  }
+
+  // 2) product_id 해석 맵
+  const { data: allProducts, error: pErr } = await supabase
+    .from("products")
+    .select("id, base_name, dr_code");
+  if (pErr) throw new Error(pErr.message);
+  const byDr = new Map<string, { id: string; base_name: string }>();
+  const byBase = new Map<string, { id: string; base_name: string }>();
+  for (const pr of allProducts ?? []) {
+    const v = { id: pr.id as string, base_name: pr.base_name as string };
+    if (pr.dr_code) byDr.set(pr.dr_code as string, v);
+    byBase.set(pr.base_name as string, v);
+  }
+
+  // 3) 카테고리 갱신 (가이드 → products.category)
+  const catByDr = new Map<string, string>();
+  const catByBase = new Map<string, string>();
+  for (const c of guide.categories) {
+    if (c.dr_code) catByDr.set(c.dr_code, c.category);
+    if (c.base_name) catByBase.set(c.base_name, c.category);
+  }
+  const catPayload: { base_name: string; category: string }[] = [];
+  for (const pr of allProducts ?? []) {
+    const cat =
+      (pr.dr_code && catByDr.get(pr.dr_code as string)) || catByBase.get(pr.base_name as string);
+    if (cat) catPayload.push({ base_name: pr.base_name as string, category: cat });
+  }
+  if (catPayload.length > 0) {
+    const { error } = await supabase
+      .from("products")
+      .upsert(catPayload, { onConflict: "base_name" });
+    if (error) throw new Error(error.message);
+  }
+
+  // 4) configs 해석 + 중복 제거
+  const recMap = new Map<string, Record<string, unknown>>();
+  let unmatched = 0;
+  for (const c of guide.configs) {
+    const match =
+      (c.dr_code && byDr.get(c.dr_code)) || (c.base_name && byBase.get(c.base_name)) || null;
+    if (!match) {
+      unmatched++;
+      continue;
+    }
+    recMap.set(`${match.id}::${c.config_type}`, {
+      product_id: match.id,
+      base_name: match.base_name,
+      config_type: c.config_type,
+      pack_count: c.pack_count,
+      free_shipping: c.free_shipping,
+      list_price: c.list_price,
+      sale_price: c.sale_price,
+      discount_rate_consumer: c.discount_rate_consumer,
+      discount_rate_regular: c.discount_rate_regular,
+      unit_cost_total: c.unit_cost_total,
+      contribution: c.contribution,
+      contribution_rate: c.contribution_rate,
+      source_file: fileName,
+    });
+  }
+  const records = [...recMap.values()];
+
+  // 5) upsert by (product_id, config_type)
+  for (const batch of chunk(records, 500)) {
+    const { error } = await supabase
+      .from("product_price_configs")
+      .upsert(batch, { onConflict: "product_id,config_type" });
+    if (error) throw new Error(error.message);
+  }
+
+  return { items: itemPayload.length, configs: records.length, unmatched };
+}
+
+/** sheet_sync에 등록된 CSV URL을 fetch → applyPriceMasterCsv → 상태 기록. */
+export async function runPriceMasterSync(
+  supabase: Db,
+  opts?: { csvUrl?: string },
+): Promise<PriceMasterSyncResult & { csvUrl: string }> {
+  let csvUrl = opts?.csvUrl ?? "";
+  if (!csvUrl) {
+    const { data } = await supabase.from("sheet_sync").select("csv_url, enabled").eq("id", 1).maybeSingle();
+    if (!data?.csv_url) throw new Error("등록된 CSV URL이 없습니다. 먼저 시트 URL을 저장하세요.");
+    csvUrl = data.csv_url as string;
+  }
+
+  try {
+    const res = await fetch(csvUrl, { redirect: "follow" });
+    if (!res.ok) throw new Error(`CSV fetch 실패 (HTTP ${res.status})`);
+    const text = await res.text();
+    const out = await applyPriceMasterCsv(supabase, text, "google-sheet");
+    await supabase
+      .from("sheet_sync")
+      .update({
+        csv_url: csvUrl,
+        last_synced_at: new Date().toISOString(),
+        last_status: "ok",
+        last_row_count: out.configs,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", 1);
+    return { ...out, csvUrl };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    await supabase
+      .from("sheet_sync")
+      .update({ last_synced_at: new Date().toISOString(), last_status: `error: ${msg}`.slice(0, 300), updated_at: new Date().toISOString() })
+      .eq("id", 1);
+    throw e;
+  }
+}

--- a/promo-analytics/lib/supabase/admin.ts
+++ b/promo-analytics/lib/supabase/admin.ts
@@ -1,0 +1,14 @@
+import { createClient } from "@supabase/supabase-js";
+
+// 서비스 역할 클라이언트 — 사용자 세션이 없는 크론/서버 작업 전용(예: 가격 마스터 일일 동기화).
+// SUPABASE_SERVICE_ROLE_KEY 는 Vercel 환경변수(서버 전용)로 설정해야 한다. 클라이언트에 노출 금지.
+export function createAdminClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key)
+    throw new Error("SUPABASE_SERVICE_ROLE_KEY(또는 URL) 미설정 — 서버 환경변수를 확인하세요.");
+  return createClient(url, key, {
+    db: { schema: "promo" },
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}

--- a/promo-analytics/supabase/migrations/0060_daily_channel.sql
+++ b/promo-analytics/supabase/migrations/0060_daily_channel.sql
@@ -1,0 +1,57 @@
+-- 0060: 일별 전체 매출 — 채널 분해
+--
+-- '일별 매출 추이'를 '일별 전체 매출'로 확장한다. 모든 B2C 채널(공식몰·네이버·선물하기·톡스토어·
+-- 오늘의집·토스쇼핑·29CM 등) 합본을 한 번에 올리고 채널 단위로 분해 저장해, 캠페인 시점 비교를
+-- 채널별로 할 수 있게 한다. 추가형: channel 컬럼 추가 + 유니크 grain에 channel 포함.
+-- 기존 행은 '전체'로 채워 합계·baseline 동일성 유지(다운스트림은 채널 합산이라 불변).
+
+alter table promo.daily_sales
+  add column if not exists channel text not null default '전체';
+
+-- 유니크 grain 재정의: (일자, 기초상품명, 옵션, 채널)
+drop index if exists promo.daily_sales_uq;
+create unique index if not exists daily_sales_uq
+  on promo.daily_sales (sale_date, base_name, option_info, channel);
+
+create index if not exists daily_sales_channel_idx
+  on promo.daily_sales (channel, sale_date);
+
+-- 교체 RPC: 시그니처 유지(앱 변경 최소화), 채널은 행(p_rows)에서 읽는다.
+-- 합본 업로드라 [min,max]×base_names 범위의 모든 채널을 삭제 후 재삽입(원자적).
+create or replace function promo.replace_daily_sales(
+  p_min date,
+  p_max date,
+  p_base_names text[],
+  p_rows jsonb
+)
+returns integer
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  n integer;
+begin
+  delete from promo.daily_sales
+   where sale_date between p_min and p_max
+     and base_name = any(p_base_names);
+
+  insert into promo.daily_sales
+    (sale_date, product_id, base_name, option_info, channel, revenue, quantity, source_file)
+  select (r->>'sale_date')::date,
+         nullif(r->>'product_id', '')::uuid,
+         r->>'base_name',
+         coalesce(r->>'option_info', ''),
+         coalesce(nullif(r->>'channel', ''), '전체'),
+         coalesce((r->>'revenue')::numeric, 0),
+         coalesce((r->>'quantity')::numeric, 0),
+         r->>'source_file'
+  from jsonb_array_elements(coalesce(p_rows, '[]'::jsonb)) r;
+
+  get diagnostics n = row_count;
+  return n;
+end;
+$$;
+
+grant execute on function promo.replace_daily_sales(date, date, text[], jsonb) to authenticated;
+notify pgrst, 'reload schema';

--- a/promo-analytics/supabase/migrations/0061_sheet_sync.sql
+++ b/promo-analytics/supabase/migrations/0061_sheet_sync.sql
@@ -1,0 +1,25 @@
+-- 0061: 품목/가격 마스터 — Google Sheets '웹에 게시(CSV)' 연동 설정
+--
+-- 가격 마스터를 스프레드시트와 연동해 하루 1회 자동 + 수동 동기화한다. 공개 CSV URL과
+-- 마지막 동기화 상태를 보관하는 싱글톤 설정 테이블. 실제 fetch·파싱·upsert는 앱/크론에서 수행.
+
+create table if not exists promo.sheet_sync (
+  id             int primary key default 1,
+  csv_url        text,
+  enabled        boolean not null default true,
+  last_synced_at timestamptz,
+  last_status    text,            -- 'ok' | 'error: ...'
+  last_row_count integer,
+  updated_at     timestamptz not null default now(),
+  constraint sheet_sync_singleton check (id = 1)
+);
+
+insert into promo.sheet_sync (id) values (1)
+on conflict (id) do nothing;
+
+alter table promo.sheet_sync enable row level security;
+drop policy if exists sheet_sync_auth on promo.sheet_sync;
+create policy sheet_sync_auth on promo.sheet_sync
+  for all to authenticated using (true) with check (true);
+
+notify pgrst, 'reload schema';

--- a/promo-analytics/supabase/migrations/0062_promotion_performance.sql
+++ b/promo-analytics/supabase/migrations/0062_promotion_performance.sql
@@ -1,0 +1,90 @@
+-- 0062: 통합 캠페인 성과 적재 — 세그먼트 풀그레인 + promotion_sales 집계를 한 트랜잭션으로
+--
+-- '캠페인 성과' 통합 업로드(각 캠페인 상세의 성과 업로드)를 위한 단일 RPC. 한 파일로
+--   (1) promotion_segment_sales (회원/비회원·등급·카테고리·일반/정기 풀그레인) + 카테고리 백필
+--   (2) promotion_sales (base_name·option 단위 집계) — 기존 plan_vs_actual·달성률·롤업 그대로 유지
+-- 를 동시에 채운다. 함수는 단일 트랜잭션이므로 둘 다 원자적으로 교체된다.
+-- p_rows = 세그먼트 그레인 행(replace_promotion_segment_sales와 동일 스키마).
+
+create or replace function promo.replace_promotion_performance(
+  p_promotion_id uuid,
+  p_rows jsonb
+)
+returns integer
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  n integer;
+begin
+  -- (1) 세그먼트 풀그레인 교체 ---------------------------------------------
+  delete from promo.promotion_segment_sales where promotion_id = p_promotion_id;
+
+  insert into promo.promotion_segment_sales
+    (promotion_id, product_id, base_name, option_info, category, member_type, member_grade,
+     order_type, revenue, order_count, aov, arppu, paying_users, quantity, fee, cost, raw)
+  select p_promotion_id,
+         nullif(r->>'product_id', '')::uuid,
+         r->>'base_name',
+         nullif(r->>'option_info', ''),
+         nullif(r->>'category', ''),
+         nullif(r->>'member_type', ''),
+         nullif(r->>'member_grade', ''),
+         nullif(r->>'order_type', ''),
+         coalesce((r->>'revenue')::numeric, 0),
+         coalesce((r->>'order_count')::numeric, 0),
+         nullif(r->>'aov', '')::numeric,
+         nullif(r->>'arppu', '')::numeric,
+         nullif(r->>'paying_users', '')::numeric,
+         coalesce((r->>'quantity')::numeric, 0),
+         coalesce((r->>'fee')::numeric, 0),
+         coalesce((r->>'cost')::numeric, 0),
+         r->'raw'
+  from jsonb_array_elements(coalesce(p_rows, '[]'::jsonb)) r;
+
+  get diagnostics n = row_count;
+
+  -- 카테고리 백필(빈 products.category만, 정규화 SKU명 매칭) -----------------
+  with seg as (
+    select promo.normalize_sku_name(base_name) as skey, category, count(*) as c
+    from promo.promotion_segment_sales
+    where promotion_id = p_promotion_id and nullif(category, '') is not null
+    group by 1, 2
+  ),
+  pick as (
+    select distinct on (skey) skey, category from seg order by skey, c desc
+  )
+  update promo.products p
+     set category = pick.category
+    from pick
+   where promo.normalize_sku_name(p.base_name) = pick.skey
+     and (p.category is null or p.category = '');
+
+  -- (2) promotion_sales 집계 교체 (달성률·롤업 호환) -----------------------
+  -- 세그먼트(회원/등급/일반·정기)를 base_name·option 단위로 합산. aov는 매출/건수로 재계산.
+  delete from promo.promotion_sales where promotion_id = p_promotion_id;
+
+  insert into promo.promotion_sales
+    (promotion_id, product_id, base_name, option_info, revenue, order_count, aov, fee, cost, quantity)
+  select p_promotion_id,
+         max(product_id)                                          as product_id,
+         base_name,
+         coalesce(option_info, '')                                as option_info,
+         sum(revenue)                                             as revenue,
+         sum(order_count)                                         as order_count,
+         case when sum(order_count) > 0
+              then sum(revenue) / sum(order_count) else null end  as aov,
+         sum(fee)                                                 as fee,
+         sum(cost)                                                as cost,
+         sum(quantity)                                            as quantity
+  from promo.promotion_segment_sales
+  where promotion_id = p_promotion_id
+  group by base_name, coalesce(option_info, '');
+
+  return n;
+end;
+$$;
+
+grant execute on function promo.replace_promotion_performance(uuid, jsonb) to authenticated;
+notify pgrst, 'reload schema';

--- a/promo-analytics/supabase/migrations/0063_campaign_performance_list.sql
+++ b/promo-analytics/supabase/migrations/0063_campaign_performance_list.sql
@@ -1,0 +1,36 @@
+-- 0063: 캠페인 성과 리스트 — 업로드 페이지 ④ '캠페인 성과' 카드용 읽기 RPC
+-- 세그먼트 성과가 적재된 캠페인을 시작일 최신순으로. 채널·기간·요약(매출·행수·카테고리수·정기비중)·최종적재시각.
+
+create or replace function promo.campaign_performance_list()
+returns table (
+  promotion_id   uuid,
+  name           text,
+  code           text,
+  channel        text,
+  start_date     date,
+  end_date       date,
+  seg_rows       bigint,
+  revenue        numeric,
+  categories     bigint,
+  subscription_revenue numeric,
+  last_at        timestamptz
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select p.id, p.name, p.code, p.channel, p.start_date, p.end_date,
+         count(s.id)                                                              as seg_rows,
+         coalesce(sum(s.revenue), 0)                                              as revenue,
+         count(distinct s.category) filter (where s.category is not null)         as categories,
+         coalesce(sum(s.revenue) filter (where s.order_type = 'subscription'), 0) as subscription_revenue,
+         max(s.created_at)                                                        as last_at
+  from promo.promotions p
+  join promo.promotion_segment_sales s on s.promotion_id = p.id
+  group by p.id
+  order by p.start_date desc nulls last, max(s.created_at) desc;
+$$;
+
+grant execute on function promo.campaign_performance_list() to authenticated;
+notify pgrst, 'reload schema';

--- a/promo-analytics/vercel.json
+++ b/promo-analytics/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/sync-price-master",
+      "schedule": "0 18 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## 배경
운영 흐름에 맞춰 `데이터 업로드` 페이지(6카드)를 정리. ① 마스터는 ④ 가격마스터에 흡수, ③ 캠페인 시트는 ⑤ 플랜가이드로 대체돼 제거. 일별매출은 채널 분해, 가격마스터는 스프레드시트 자동 동기화, 세그먼트 실적은 '캠페인 성과'(달성률+세그먼트 통합)로 일원화하고 업로드 페이지에서는 리스트+다운로드만. 연동 이력은 카드별로 이동.

**확정 사항(질문 답변):** ③ 삭제 · 가격마스터 연동 = Google Sheets '웹에 게시' CSV · 범위 = 한 번에 전부.

## 변경 요약 (6 → 4카드)
- **① 일별 전체 매출** (구 ② 일별 매출 추이) — 모든 B2C 채널 합본 1회 업로드 → **채널 분해 저장**. `daily_sales.channel` + `(일자,기초상품,옵션,채널)` 유니크.
- **② 품목/가격 마스터** (구 ④) — **Google Sheets '웹에 게시(CSV)' 자동(일1회)+수동 동기화**. ① 마스터 흡수. `parsePriceGuide` 재사용.
- **③ 캠페인 플랜 가이드** (구 ⑤) — 변경 없음.
- **④ 캠페인 성과** (구 ⑥ 세그먼트 실적) — **리스트(최종적재·채널·캠페인·기간·요약) + 플랜/성과 엑셀 다운로드** 전용. 업로드는 각 캠페인 상세의 '성과 업로드'에서 **통합 포맷**으로.
- **연동 이력 섹션 삭제** → 각 카드 안에 `upload_log` 미니 이력(CardHistory).

## 통합 캠페인 성과 (핵심)
- 캠페인 상세 '성과 업로드'를 `parseSegmentSheet` → **`replace_promotion_performance`**(0062)로 교체. 한 파일·한 트랜잭션으로:
  1. `promotion_segment_sales` 풀그레인(세그먼트 탭·어태치율) + 카테고리 백필
  2. `promotion_sales` 집계(회원/등급/일반·정기 합산) — 기존 **달성률·롤업 그대로 유지**
- 이후 `rebuild_sale_options` + `refresh_rollups` + `upload_log` 기록.

## 마이그레이션 (추가형, ⚠️ 미적용)
- `0060_daily_channel` — daily_sales.channel + 유니크 재정의 + replace_daily_sales 채널 반영
- `0061_sheet_sync` — CSV URL·동기화 상태 싱글톤
- `0062_promotion_performance` — `replace_promotion_performance()` (세그먼트+집계 원자 적재)
- `0063_campaign_performance_list` — ④ 리스트 읽기 RPC

프로덕션 DB 적용 전까지 ④ 리스트·세그먼트 탭·채널 분해는 비활성(앱은 graceful degrade).

## 환경변수 (가격마스터 동기화)
- `SUPABASE_SERVICE_ROLE_KEY` (서버 전용, 크론용) · `CRON_SECRET` (크론 인증). Vercel 환경변수로 설정 필요. `vercel.json`에 일 1회 cron(`/api/cron/sync-price-master`).

## 검증
- `npm run build` ✅ · `npm test` ✅ 72개 · `tsc`/`eslint` ✅
- 표준 품목/가격 마스터 템플릿(.xlsx) 별도 전달.

## 적용 후 E2E (예정)
1. 0060–0063 적용 → 객체/시그니처 확인
2. 일별 전체 매출 채널 합본 업로드 → 채널 분해, baseline 합계 불변
3. 가격마스터 CSV URL 등록 → '지금 동기화' → products/configs upsert
4. 캠페인 상세 통합 성과 업로드 → segment+promotion_sales 동시 적재, **달성률 불변**, 세그먼트 탭 정상, ④ 리스트 노출 + 플랜/성과 다운로드

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vrSc7PUyxGFhDwhVDjisF

---
_Generated by [Claude Code](https://claude.ai/code/session_011vrSc7PUyxGFhDwhVDjisF)_