### PR TITLE
성과 재업로드 실패 수정(max(uuid) 버그) + 교체 확인 흐름 + 업로드 이력 스크롤

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/PerformanceUpload.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/PerformanceUpload.tsx
@@ -5,6 +5,17 @@ import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { parseSegmentSheet } from "@/lib/parse";
 import { ensureProducts } from "@/lib/products";
+import { useReplaceConfirm } from "../../upload/useReplaceConfirm";
+
+// Supabase 에러(PostgrestError)는 Error 인스턴스가 아니라 일반 객체 → message/details/hint를 직접 추출.
+function errText(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  if (e && typeof e === "object") {
+    const o = e as { message?: string; details?: string; hint?: string };
+    return o.message || o.details || o.hint || "업로드 실패";
+  }
+  return "업로드 실패";
+}
 
 // 캠페인에 직접 성과 추가 (통합 포맷) — 회원/등급/카테고리·일반/정기까지 분해된 매출 export를
 // '이 캠페인'에 promotion_id로 고정 적재. replace_promotion_performance RPC가 한 번에
@@ -26,6 +37,7 @@ export default function PerformanceUpload({
   const inputRef = useRef<HTMLInputElement>(null);
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState<{ kind: "ok" | "err"; text: string } | null>(null);
+  const { confirm, element: replaceDialog } = useReplaceConfirm();
 
   // 전체 실공헌이익액·실광고비 직접 입력 — 옵션 분해의 기준값(groundTruth)·광고 배분에 반영
   const [contrib, setContrib] = useState(contributionAmount != null ? String(contributionAmount) : "");
@@ -89,6 +101,37 @@ export default function PerformanceUpload({
         cost: r.cost,
       }));
 
+      // 교체 검토 (DB 변경 전) — 일별 매출과 동일한 흐름. 기존 성과가 있으면 old/new 비교 후 확인.
+      const { data: existing } = await supabase
+        .from("promotion_sales")
+        .select("revenue")
+        .eq("promotion_id", promotionId);
+      const oldCount = existing?.length ?? 0;
+      if (oldCount > 0) {
+        const oldRevenue = (existing ?? []).reduce((s, x) => s + (Number(x.revenue) || 0), 0);
+        const newRevenue = records.reduce((s, x) => s + (x.revenue || 0), 0);
+        const newGrain = new Set(
+          parsed.rows.map((r) => `${r.base_name}|${r.option_info ?? ""}`),
+        ).size;
+        const uniqNames = new Set(parsed.rows.map((r) => r.base_name)).size;
+        const ok = await confirm({
+          title: "성과 교체 — 이 캠페인의 기존 성과를 새 파일로",
+          oldCount,
+          oldRevenue,
+          newCount: newGrain,
+          newRevenue,
+          matchedSkus: productMap.size,
+          totalSkus: uniqNames,
+          note: "이 캠페인의 옵션/SKU별 집계와 세그먼트(회원·등급·AOV·ARPPU)가 새 파일로 원자적으로 교체됩니다(누적 아님).",
+        });
+        if (!ok) {
+          setMsg(null);
+          setBusy(false);
+          if (inputRef.current) inputRef.current.value = "";
+          return;
+        }
+      }
+
       // 통합 적재: 세그먼트 풀그레인 + promotion_sales 집계(달성률) 원자적 교체
       const { error } = await supabase.rpc("replace_promotion_performance", {
         p_promotion_id: promotionId,
@@ -127,7 +170,7 @@ export default function PerformanceUpload({
       });
       router.refresh();
     } catch (e) {
-      setMsg({ kind: "err", text: e instanceof Error ? e.message : "업로드 실패" });
+      setMsg({ kind: "err", text: errText(e) });
     } finally {
       setBusy(false);
       if (inputRef.current) inputRef.current.value = "";
@@ -136,6 +179,7 @@ export default function PerformanceUpload({
 
   return (
     <div className="rounded-2xl card-soft p-5">
+      {replaceDialog}
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="min-w-0">
           <h2 className="text-sm font-semibold text-ink-2">

--- a/promo-analytics/app/(dash)/upload/CardHistory.tsx
+++ b/promo-analytics/app/(dash)/upload/CardHistory.tsx
@@ -13,8 +13,8 @@ type LogRow = {
 };
 
 // 카드별 미니 업로드 이력 — upload_log 를 kind 로 필터해 최근 N건. (기존 전역 '연동 이력' 섹션 대체)
-// upload-done window 이벤트로 자동 갱신.
-export default function CardHistory({ kinds, limit = 4 }: { kinds: string[]; limit?: number }) {
+// upload-done window 이벤트로 자동 갱신. 항목이 많으면 영역 내부 스크롤로 전부 볼 수 있다.
+export default function CardHistory({ kinds, limit = 50 }: { kinds: string[]; limit?: number }) {
   const [rows, setRows] = useState<LogRow[]>([]);
   const [loaded, setLoaded] = useState(false);
 
@@ -42,8 +42,10 @@ export default function CardHistory({ kinds, limit = 4 }: { kinds: string[]; lim
 
   return (
     <div className="mt-3 border-t border-neutral-100 pt-2.5">
-      <div className="text-[11px] font-medium text-neutral-400">최근 업로드</div>
-      <ul className="mt-1 space-y-0.5">
+      <div className="text-[11px] font-medium text-neutral-400">
+        최근 업로드{rows.length >= 6 ? ` · ${rows.length}건` : ""}
+      </div>
+      <ul className="mt-1 max-h-44 space-y-0.5 overflow-y-auto pr-1">
         {rows.map((r) => (
           <li key={r.id} className="flex items-center gap-2 text-[11px] text-neutral-500">
             <span className="whitespace-nowrap text-neutral-400">

--- a/promo-analytics/app/(dash)/upload/PlanGuideList.tsx
+++ b/promo-analytics/app/(dash)/upload/PlanGuideList.tsx
@@ -20,26 +20,32 @@ export default function PlanGuideList() {
   const load = useCallback(async () => {
     const supabase = createClient();
     setRows(null);
-    // 현재 버전 플랜 + 캠페인명
+    // 현재 버전 플랜. campaign_plans→promotions는 FK가 2개(promotion_id·actual_promotion_id)라
+    // PostgREST 임베드가 모호해 실패하므로, 캠페인명은 별도 조회로 합친다.
     const { data: plans } = await supabase
       .from("campaign_plans")
-      .select("promotion_id, status, promotions(name)")
+      .select("promotion_id, status")
       .eq("is_current", true)
       .not("promotion_id", "is", null);
 
     const seen = new Map<string, { name: string; status: string }>();
-    for (const p of (plans ?? []) as unknown as {
-      promotion_id: string;
-      status: string;
-      promotions: { name: string | null } | null;
-    }[]) {
+    for (const p of (plans ?? []) as { promotion_id: string; status: string }[]) {
       if (!seen.has(p.promotion_id))
-        seen.set(p.promotion_id, {
-          name: p.promotions?.name ?? "(이름 없음)",
-          status: p.status,
-        });
+        seen.set(p.promotion_id, { name: "(이름 없음)", status: p.status });
     }
     const ids = [...seen.keys()];
+
+    // 캠페인명 채우기
+    if (ids.length > 0) {
+      const { data: proms } = await supabase
+        .from("promotions")
+        .select("id, name")
+        .in("id", ids);
+      for (const pr of (proms ?? []) as { id: string; name: string | null }[]) {
+        const e = seen.get(pr.id);
+        if (e) e.name = pr.name ?? "(이름 없음)";
+      }
+    }
 
     // 성과(실판매) 업로드 유무 — promotion_sales 존재 여부
     const perfSet = new Set<string>();

--- a/promo-analytics/supabase/migrations/0067_fix_performance_max_uuid.sql
+++ b/promo-analytics/supabase/migrations/0067_fix_performance_max_uuid.sql
@@ -1,0 +1,89 @@
+-- 0067 · 성과 업로드 RPC 버그 수정: max(uuid) → array_agg 픽
+--
+-- replace_promotion_performance 의 promotion_sales 집계에서 product_id(uuid)를 max()로
+-- 골랐는데, PostgreSQL에는 uuid용 max/min 집계가 없어 "function max(uuid) does not exist"로
+-- 성과 업로드가 항상 실패했다. 그룹(base_name·option) 내 product_id는 동일하므로
+-- 비-NULL 중 하나를 array_agg로 고른다.
+
+create or replace function promo.replace_promotion_performance(
+  p_promotion_id uuid,
+  p_rows jsonb
+)
+returns integer
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  n integer;
+begin
+  -- (1) 세그먼트 풀그레인 교체 ---------------------------------------------
+  delete from promo.promotion_segment_sales where promotion_id = p_promotion_id;
+
+  insert into promo.promotion_segment_sales
+    (promotion_id, product_id, base_name, option_info, category, member_type, member_grade,
+     order_type, revenue, order_count, aov, arppu, paying_users, quantity, fee, cost, raw)
+  select p_promotion_id,
+         nullif(r->>'product_id', '')::uuid,
+         r->>'base_name',
+         nullif(r->>'option_info', ''),
+         nullif(r->>'category', ''),
+         nullif(r->>'member_type', ''),
+         nullif(r->>'member_grade', ''),
+         nullif(r->>'order_type', ''),
+         coalesce((r->>'revenue')::numeric, 0),
+         coalesce((r->>'order_count')::numeric, 0),
+         nullif(r->>'aov', '')::numeric,
+         nullif(r->>'arppu', '')::numeric,
+         nullif(r->>'paying_users', '')::numeric,
+         coalesce((r->>'quantity')::numeric, 0),
+         coalesce((r->>'fee')::numeric, 0),
+         coalesce((r->>'cost')::numeric, 0),
+         r->'raw'
+  from jsonb_array_elements(coalesce(p_rows, '[]'::jsonb)) r;
+
+  get diagnostics n = row_count;
+
+  -- 카테고리 백필(빈 products.category만, 정규화 SKU명 매칭) -----------------
+  with seg as (
+    select promo.normalize_sku_name(base_name) as skey, category, count(*) as c
+    from promo.promotion_segment_sales
+    where promotion_id = p_promotion_id and nullif(category, '') is not null
+    group by 1, 2
+  ),
+  pick as (
+    select distinct on (skey) skey, category from seg order by skey, c desc
+  )
+  update promo.products p
+     set category = pick.category
+    from pick
+   where promo.normalize_sku_name(p.base_name) = pick.skey
+     and (p.category is null or p.category = '');
+
+  -- (2) promotion_sales 집계 교체 (달성률·롤업 호환) -----------------------
+  -- product_id(uuid)는 max() 불가 → 그룹 내 비-NULL 하나를 array_agg로 픽.
+  delete from promo.promotion_sales where promotion_id = p_promotion_id;
+
+  insert into promo.promotion_sales
+    (promotion_id, product_id, base_name, option_info, revenue, order_count, aov, fee, cost, quantity)
+  select p_promotion_id,
+         (array_agg(product_id) filter (where product_id is not null))[1] as product_id,
+         base_name,
+         coalesce(option_info, '')                                as option_info,
+         sum(revenue)                                             as revenue,
+         sum(order_count)                                         as order_count,
+         case when sum(order_count) > 0
+              then sum(revenue) / sum(order_count) else null end  as aov,
+         sum(fee)                                                 as fee,
+         sum(cost)                                                as cost,
+         sum(quantity)                                            as quantity
+  from promo.promotion_segment_sales
+  where promotion_id = p_promotion_id
+  group by base_name, coalesce(option_info, '');
+
+  return n;
+end;
+$$;
+
+grant execute on function promo.replace_promotion_performance(uuid, jsonb) to authenticated;
+notify pgrst, 'reload schema';

--- a/promo-analytics/supabase/migrations/0068_fix_plan_vs_actual_is_sub_null.sql
+++ b/promo-analytics/supabase/migrations/0068_fix_plan_vs_actual_is_sub_null.sql
@@ -1,0 +1,104 @@
+-- 0068 · 성과 달성 0원 버그 수정: is_sub 3치 논리(NULL) → null-safe
+--
+-- 통합 성과 RPC(replace_promotion_performance)가 만드는 promotion_sales 행은 order_type이
+-- NULL이다(집계 행이라 일반/정기 혼재 → 단일 order_type 없음). 그런데 plan_vs_actual_summary의
+-- is_sub 판정이 `ps.order_type = 'subscription' or ...` 라서, order_type가 NULL이면
+-- 'NULL = ...' → NULL 이 되고 `filter (where not is_sub)`가 모든 행을 제외해
+-- campaign_revenue_total / main_revenue / halo_revenue 가 전부 0이 됐다.
+-- → hasActuals=false 로 워크플로/달성 KPI가 채워지지 않던 원인.
+-- 각 항을 coalesce(...,false)로 감싸 NULL을 false로 만든다(구독 신호는 product.is_subscription·
+-- 옵션명 패턴으로 유지).
+
+create or replace function promo.plan_vs_actual_summary(p_id uuid)
+returns table(has_confirmed_plan boolean, expected_revenue_total numeric, actual_revenue_total numeric, ach_revenue numeric, expected_qty_total numeric, actual_qty_total numeric, ach_qty numeric, expected_contribution_total numeric, actual_contribution_total numeric, ach_contribution numeric, unplanned_revenue numeric, unplanned_qty numeric, unplanned_contribution numeric, matched_sku_count integer, unsold_sku_count integer, unplanned_sku_count integer, quantity_reliable boolean, snapshot_mult numeric, subscription_revenue numeric, main_revenue numeric, halo_revenue numeric, campaign_revenue_total numeric, revenue_ach_total numeric, contribution_total numeric, contribution_ach_total numeric, main_nonsub_qty numeric, main_subscription_qty numeric)
+language plpgsql
+stable
+set search_path to ''
+as $function$
+declare
+  v_has boolean; v_mult numeric; v_plan_id uuid; v_actual_pid uuid; v_main uuid[];
+begin
+  select true, (rate_card_snapshot->>'mult')::numeric, id,
+         coalesce(actual_promotion_id, promotion_id), main_product_ids
+    into v_has, v_mult, v_plan_id, v_actual_pid, v_main
+  from promo.campaign_plans
+  where promotion_id = p_id and is_current and status = 'confirmed' limit 1;
+
+  if not coalesce(v_has, false) then
+    return query select false,
+      null::numeric, null::numeric, null::numeric, null::numeric, null::numeric, null::numeric,
+      null::numeric, null::numeric, null::numeric, null::numeric, null::numeric, null::numeric,
+      null::int, null::int, null::int, null::boolean, null::numeric,
+      null::numeric, null::numeric, null::numeric, null::numeric, null::numeric, null::numeric, null::numeric,
+      null::numeric, null::numeric;
+    return;
+  end if;
+
+  return query
+  with rows as (select * from promo.plan_vs_actual(p_id)),
+  exp_rows as (select * from rows where status in ('matched','unsold')),
+  unp_rows as (select * from rows where status = 'unplanned'),
+  main_keys as (
+    select distinct promo.normalize_sku_name(pr.base_name) as k
+    from promo.campaign_plan_option_items i
+    join promo.campaign_plan_options o on o.id = i.campaign_plan_option_id
+    join promo.products pr on pr.id = i.product_id
+    where o.campaign_plan_id = v_plan_id and (v_main is null or i.product_id = any(v_main))
+  ),
+  plan_keys as (
+    select distinct promo.normalize_sku_name(pr.base_name) as k
+    from promo.campaign_plan_option_items i
+    join promo.campaign_plan_options o on o.id = i.campaign_plan_option_id
+    join promo.products pr on pr.id = i.product_id
+    where o.campaign_plan_id = v_plan_id
+  ),
+  sales as (
+    select ps.revenue, coalesce(ps.cost,0) as cost, coalesce(ps.quantity,0) as qty,
+      (coalesce(ps.order_type = 'subscription', false)
+        or coalesce(pr.is_subscription, false)
+        or coalesce(promo.is_subscription_positive(ps.option_info), false)) as is_sub,
+      (promo.normalize_sku_name(pr.base_name) in (select k from main_keys)) as is_main,
+      (promo.normalize_sku_name(pr.base_name) in (select k from plan_keys)) as in_plan
+    from promo.promotion_sales ps
+    left join promo.products pr on pr.id = ps.product_id
+    where ps.promotion_id = v_actual_pid
+  ),
+  agg as (
+    select
+      coalesce(sum(revenue) filter (where is_sub), 0) as sub_rev,
+      coalesce(sum(revenue) filter (where is_main and not is_sub), 0) as main_rev,
+      coalesce(sum(revenue) filter (where not is_main and not is_sub), 0) as halo_rev,
+      coalesce(sum(revenue) filter (where not is_sub), 0) as total_rev,
+      coalesce(sum(cost) filter (where not is_sub), 0) as total_cost,
+      coalesce(sum(qty) filter (where not is_sub and in_plan), 0) as main_nonsub_qty,
+      coalesce(sum(qty) filter (where is_sub and in_plan), 0) as main_subscription_qty
+    from sales
+  ),
+  e as (
+    select coalesce(sum(expected_revenue),0) exp_rev, coalesce(sum(actual_revenue),0) act_rev,
+      coalesce(sum(expected_qty),0) exp_qty, coalesce(sum(actual_qty),0) act_qty,
+      coalesce(sum(expected_contribution),0) exp_contrib, coalesce(sum(actual_contribution),0) act_contrib
+    from exp_rows
+  )
+  select true,
+    e.exp_rev, e.act_rev,
+    case when e.exp_rev > 0 then e.act_rev/e.exp_rev else null end,
+    e.exp_qty, e.act_qty,
+    case when e.exp_qty > 0 then e.act_qty/e.exp_qty else null end,
+    e.exp_contrib, e.act_contrib,
+    case when e.exp_contrib > 0 then e.act_contrib/e.exp_contrib else null end,
+    (select coalesce(sum(actual_revenue),0) from unp_rows),
+    (select coalesce(sum(actual_qty),0) from unp_rows),
+    (select coalesce(sum(actual_contribution),0) from unp_rows),
+    (select count(*)::int from rows where status = 'matched'),
+    (select count(*)::int from rows where status = 'unsold'),
+    (select count(*)::int from unp_rows),
+    (e.act_qty > 0), v_mult,
+    a.sub_rev, a.main_rev, a.halo_rev, a.total_rev,
+    case when e.exp_rev > 0 then a.total_rev/e.exp_rev else null end,
+    (a.total_rev * v_mult - a.total_cost),
+    case when e.exp_contrib > 0 then (a.total_rev * v_mult - a.total_cost)/e.exp_contrib else null end,
+    a.main_nonsub_qty, a.main_subscription_qty
+  from e, agg a;
+end;
+$function$;


### PR DESCRIPTION
성과 업로드 관련 후속 수정 4건.

### 1. 성과 재업로드 실패 수정 (근본 원인)
서버 로그에서 `ERROR: function max(uuid) does not exist` 확인. `replace_promotion_performance` RPC가 `promotion_sales` 집계 시 `max(product_id)`(uuid)를 썼는데 PostgreSQL엔 uuid용 max/min 집계가 없어 **성과 업로드가 매번 실패**했습니다.
- `max(product_id)` → `(array_agg(product_id) filter (where product_id is not null))[1]` 로 교체 (마이그레이션 **0067**, 라이브 DB 적용·검증 완료).
- 에러 표면화 개선: Supabase `PostgrestError`는 `Error` 인스턴스가 아니라 그냥 "업로드 실패"로만 보였음 → `message/details/hint` 추출.
- **교체 흐름 추가**: 기존 성과가 있으면 일별 매출과 동일한 확인 다이얼로그(`useReplaceConfirm`)로 old/new 매출·건수·SKU 매칭을 보여주고 확인 후 원자적 교체.

### 2. 업로드 후 워크플로·달성 KPI가 0으로 멈추던 버그 (마이그레이션 0068)
통합 성과 RPC가 만드는 `promotion_sales` 행은 `order_type`이 NULL(집계 행이라 일반/정기 혼재)인데, `plan_vs_actual_summary`의 구독 판정이 `order_type = 'subscription' OR …` 라 NULL이 끼면 **3치 논리로 is_sub 전체가 NULL** → `filter(where not is_sub)`가 모든 행을 제외 → `campaign_revenue_total`/main/halo가 전부 0 → `hasActuals=false`로 워크플로·KPI가 안 채워짐.
- 각 항을 `coalesce(…, false)`로 null-safe 처리. 롤업 force 재계산. (검증: 모래 벌크UP 캠페인 매출 ₩86.7M·달성률 43%)

### 3. ⑤ 캠페인 플랜 가이드가 "플랜 없음"으로 표시되던 버그
`campaign_plans→promotions` FK가 2개(`promotion_id`·`actual_promotion_id`)라 PostgREST 임베드(`promotions(name)`)가 모호해 빈 결과 → 임베드 제거하고 캠페인명은 별도 조회로 합침. 현재 확정 플랜 2개가 정상 표시.

### 4. 최근 업로드 리스트 스크롤
`CardHistory`가 최근 4건만 보였음 → limit 50 + 내부 스크롤(`max-h-44 overflow-y-auto`)로 전체 열람.

빌드/타입체크 통과. 0067·0068은 라이브 DB 적용 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)