### PR TITLE
중복 product 병합·재발 방지 (같은 dr_code 가 이름만 달라 2행으로 적재)

### DIFF
--- a/promo-analytics/lib/priceMasterSync.ts
+++ b/promo-analytics/lib/priceMasterSync.ts
@@ -149,6 +149,15 @@ export async function applyPriceMasterCsv(
     if (error) throw new Error(error.message);
   }
 
+  // 6) 중복 product 자동 치유 — 같은 dr_code 가 이름만 달라 2행으로 들어온 경우 1행으로 병합(0071).
+  //    매칭은 product 이름 정규화로 이뤄져, 카탈로그명/적재명이 다르면 '플랜만·성과만' 고아가 생기므로
+  //    코드 기준으로 재발을 막는다. best-effort: 함수 미적용 환경에서도 동기화는 성공.
+  try {
+    await supabase.rpc("merge_dup_products_by_code");
+  } catch {
+    /* 0071 미적용 등 무시 */
+  }
+
   return { items: itemPayload.length, configs: records.length, unmatched };
 }
 

--- a/promo-analytics/supabase/migrations/0071_merge_dup_products_by_code.sql
+++ b/promo-analytics/supabase/migrations/0071_merge_dup_products_by_code.sql
@@ -1,0 +1,104 @@
+-- 0071: 같은 dr_code 를 가진 중복 product 병합 (이름만 다르고 같은 상품)
+--
+-- 원인: products 는 base_name 기준으로 생성/업서트되는데(applyPriceMasterCsv·ensureProducts),
+-- 같은 SKU 가 마스터 카탈로그명("(제품) …")과 플랜/성과 적재명("…")으로 서로 다르게 들어오면
+-- 같은 dr_code 를 가진 두 행이 생긴다. 매칭 진단(sku_match_diagnostic)은 product 의 base_name 을
+-- 정규화해 비교하므로, 한쪽 이름이 달라 '플랜만/성과만' 고아로 남는다.
+--
+-- 해결: dr_code 가 같은 행을 1개로 병합. survivor = 매출 보유 우선 → '(제품)' 접두 → 오래된 순.
+-- 모든 참조를 survivor 로 repoint 후 loser 삭제. 매출(promotion_sales/segment_sales/daily_sales)은
+-- 코드별로 한쪽 id 에만 존재하므로(점검 완료) 합산/중복 없이 안전. 가격구성·메인·매핑은 충돌행 정리 후 이전.
+-- 이 함수는 가격 마스터 동기화(applyPriceMasterCsv) 끝에서 best-effort 로 호출돼 재발을 자동 치유한다.
+
+create or replace function promo.merge_dup_products_by_code()
+returns table(out_code text, out_survivor uuid, out_merged int)
+language plpgsql
+set search_path = ''
+as $$
+declare
+  r record;
+  v_survivor uuid;
+  v_loser uuid;
+  v_count int;
+begin
+  for r in
+    select p.dr_code as code, array_agg(p.id) as ids
+    from promo.products p
+    where p.dr_code is not null and p.dr_code <> ''
+    group by p.dr_code
+    having count(*) > 1
+  loop
+    select p.id into v_survivor
+    from promo.products p
+    where p.id = any(r.ids)
+    order by
+      (exists(select 1 from promo.promotion_sales s where s.product_id=p.id)
+        or exists(select 1 from promo.promotion_segment_sales s where s.product_id=p.id)
+        or exists(select 1 from promo.daily_sales s where s.product_id=p.id)) desc,
+      (p.base_name like '(제품)%') desc,
+      p.created_at asc
+    limit 1;
+
+    v_count := 0;
+    foreach v_loser in array r.ids loop
+      if v_loser = v_survivor then continue; end if;
+
+      -- 충돌 가능 테이블: 충돌행 먼저 삭제 후 repoint
+      delete from promo.product_price_configs l
+      where l.product_id = v_loser
+        and exists (select 1 from promo.product_price_configs s
+                    where s.product_id=v_survivor and s.config_type=l.config_type);
+      update promo.product_price_configs set product_id=v_survivor where product_id=v_loser;
+
+      delete from promo.promotion_excluded_skus l
+      where l.product_id=v_loser
+        and exists (select 1 from promo.promotion_excluded_skus s
+                    where s.product_id=v_survivor and s.promotion_id=l.promotion_id);
+      update promo.promotion_excluded_skus set product_id=v_survivor where product_id=v_loser;
+
+      delete from promo.promotion_main_products l
+      where l.product_id=v_loser
+        and exists (select 1 from promo.promotion_main_products s
+                    where s.product_id=v_survivor and s.promotion_id=l.promotion_id);
+      update promo.promotion_main_products set product_id=v_survivor where product_id=v_loser;
+
+      -- sku_mappings: plan/actual 두 컬럼 (PK promotion_id,plan,actual)
+      delete from promo.promotion_sku_mappings l
+      where l.plan_product_id=v_loser
+        and exists (select 1 from promo.promotion_sku_mappings s
+                    where s.promotion_id=l.promotion_id and s.plan_product_id=v_survivor and s.actual_product_id=l.actual_product_id);
+      update promo.promotion_sku_mappings set plan_product_id=v_survivor where plan_product_id=v_loser;
+      delete from promo.promotion_sku_mappings l
+      where l.actual_product_id=v_loser
+        and exists (select 1 from promo.promotion_sku_mappings s
+                    where s.promotion_id=l.promotion_id and s.actual_product_id=v_survivor and s.plan_product_id=l.plan_product_id);
+      update promo.promotion_sku_mappings set actual_product_id=v_survivor where actual_product_id=v_loser;
+      delete from promo.promotion_sku_mappings where plan_product_id = actual_product_id;
+
+      -- 충돌 없는 테이블: 단순 repoint (loser 측엔 매출이 없음)
+      update promo.campaign_plan_option_items set product_id=v_survivor where product_id=v_loser;
+      update promo.daily_sales set product_id=v_survivor where product_id=v_loser;
+      update promo.promotion_sales set product_id=v_survivor where product_id=v_loser;
+      update promo.promotion_segment_sales set product_id=v_survivor where product_id=v_loser;
+
+      -- 메인상품 배열(uuid[]) 내 치환 + 중복 제거
+      update promo.campaign_plans
+      set main_product_ids = (select array(select distinct e from unnest(array_replace(main_product_ids, v_loser, v_survivor)) e))
+      where main_product_ids @> array[v_loser];
+
+      delete from promo.products where id = v_loser;
+      v_count := v_count + 1;
+    end loop;
+
+    out_code := r.code; out_survivor := v_survivor; out_merged := v_count;
+    return next;
+  end loop;
+end;
+$$;
+
+grant execute on function promo.merge_dup_products_by_code() to authenticated, service_role, anon;
+
+-- 기존 중복 일괄 정리 (idempotent — 중복 없으면 no-op)
+select promo.merge_dup_products_by_code();
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## 문제
SKU 매칭 보정에서, 플랜에 있는 SKU(예: `퍼펙트 케어 스틱 연어 150g`)를 성과와 연동하려는데 **드롭다운에 맞는 성과 SKU가 없어** 고를 수 없는 현상.

원인: 매칭 진단(`sku_match_diagnostic`)은 **product 의 `base_name` 을 정규화**해 플랜↔성과를 비교합니다. 그런데 같은 물리 SKU(같은 `dr_code`)가
- 카탈로그명 `(제품) 데일리 솔루션 퍼펙트 연어 150g` (가격 마스터)
- 적재명 `퍼펙트 케어 스틱 연어 150g` (플랜/성과 import)

처럼 **이름만 다른 별도 product 2행**으로 들어오면, 이름 정규화 키가 달라 한쪽이 `플랜만`(또는 `성과만`) 고아로 남습니다. 전수 조사 결과 **카탈로그 전반 47개 dr_code 가 중복**이었습니다.

## 해결
- **`0071` 마이그레이션 — `promo.merge_dup_products_by_code()`**: `dr_code` 가 같은 행을 1개로 병합.
  - survivor = **매출 보유 우선 → `(제품)` 접두 → 오래된 순**
  - 모든 참조를 survivor 로 repoint 후 loser 삭제: `campaign_plan_option_items`·`promotion_sales`·`promotion_segment_sales`·`daily_sales`·`product_price_configs`·`promotion_main_products`·`promotion_excluded_skus`·`promotion_sku_mappings`(plan/actual)·`campaign_plans.main_product_ids[]`
  - **안전성**: 매출(promotion_sales/segment_sales/daily_sales)은 코드별로 **한쪽 id 에만 존재**함을 사전 점검(`codes_with_conflicting_sales = 0`) → 합산·중복·오귀속 없음. 가격구성/메인/매핑 등 충돌 가능 테이블은 충돌행 정리 후 이전.
- **재발 방지**: `priceMasterSync` 가 동기화 끝에서 `merge_dup_products_by_code` 를 best-effort 호출 → 코드가 같은 새 중복이 생겨도 자동 치유.

## 적용 현황
- 운영 DB(`ryuhowoo-CXdashboard`)에 **이미 병합 적용 완료** — 47개 코드 → 47개 중복행 제거, 남은 중복 0.
- 검증: `[BETTER HABITS]` 캠페인의 `DR10064` 가 `플랜만`(고아) → **`both`(자동 매칭, 계획 541 / 성과 663)** 으로 전환, 플랜 미매칭 1 → 0. 롤업 재계산 완료.
- `npx tsc --noEmit` 통과, `npm run test` 78 passed.

> 이 PR 은 동일 정리/방지 로직을 **레포 마이그레이션 + 동기화 코드**에 남겨, 새 환경·재빌드에서도 자동 적용되게 합니다(운영 DB 데이터는 이미 정리됨).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zkqVzCBpDUh7ntB3EdnLG

---
_Generated by [Claude Code](https://claude.ai/code/session_015zkqVzCBpDUh7ntB3EdnLG)_