### PR TITLE
옵션·사은품 SKU 검색에서 원재료·부재료·부자재 제외

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
@@ -1568,8 +1568,8 @@ function FreebieRow({
       .select("id, base_name, dr_code, consumer_price, regular_price, cost")
       .or(`base_name.ilike.%${safe}%,dr_code.ilike.%${safe}%`)
       .limit(30);
-    // 원재료·부재료·부자재(비판매 구성품)는 사은품 후보에서 제외
-    setHits(((data as SearchHit[]) ?? []).filter((h) => !isComponentName(h.base_name)).slice(0, 8));
+    // 사은품은 스티커·약봉투·팜플렛 등 부재료/판촉물도 쓰이므로 구성품도 포함해 모두 노출
+    setHits(((data as SearchHit[]) ?? []).slice(0, 8));
     setOpen(true);
   }
   function pick(h: SearchHit) {

--- a/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
@@ -21,7 +21,7 @@ import PlanLoadPanel from "./PlanLoadPanel";
 import SubProductSuggest, { type Bench } from "./SubProductSuggest";
 import { downloadPlanXlsx, type ExportOption } from "@/lib/plan-export";
 import { parsePlanWorkbook } from "@/lib/plan-import";
-import { ensureProducts } from "@/lib/products";
+import { ensureProducts, isComponentName } from "@/lib/products";
 
 export type EditorItem = {
   product_id: string;
@@ -1567,8 +1567,9 @@ function FreebieRow({
       .from("products")
       .select("id, base_name, dr_code, consumer_price, regular_price, cost")
       .or(`base_name.ilike.%${safe}%,dr_code.ilike.%${safe}%`)
-      .limit(8);
-    setHits(((data as SearchHit[]) ?? []).slice(0, 8));
+      .limit(30);
+    // 원재료·부재료·부자재(비판매 구성품)는 사은품 후보에서 제외
+    setHits(((data as SearchHit[]) ?? []).filter((h) => !isComponentName(h.base_name)).slice(0, 8));
     setOpen(true);
   }
   function pick(h: SearchHit) {
@@ -1720,10 +1721,12 @@ function AddSku({ onAdd }: { onAdd: (it: ItemState) => void }) {
       .from("products")
       .select("id, base_name, dr_code, consumer_price, regular_price, cost")
       .or(`base_name.ilike.%${safe}%,dr_code.ilike.%${safe}%`)
-      .limit(20);
-    // 불분명 품목(상품코드·소비자가·상시가 전부 없는, 성과에서 이름만 자동생성된 것) 숨김
+      .limit(30);
     const clear = ((data as SearchHit[]) ?? []).filter(
-      (h) => h.dr_code || h.consumer_price || h.regular_price,
+      // 불분명 품목(상품코드·소비자가·상시가 전부 없는, 성과에서 이름만 자동생성된 것) 숨김
+      (h) => (h.dr_code || h.consumer_price || h.regular_price) &&
+        // 원재료·부재료·부자재(비판매 구성품)는 옵션에 담지 않으므로 제외
+        !isComponentName(h.base_name),
     );
     setHits(clear.slice(0, 8));
     setOpen(true);


### PR DESCRIPTION
## 문제
새 캠페인 옵션 추가 시 SKU 검색에 **원재료·부재료·부자재**(택배박스·단상자·스티커 등)가 같이 잡힘.

원인: 품목 마스터(SKU 템플릿)는 이름 접두로 종류를 구분하는데, 이 구성품들도 **상품코드(DR)를 가지고 있어** 기존 검색 필터(`코드 || 소비자가 || 상시가` 보유)를 통과해 그대로 노출됐습니다. ("예전 데이터"가 아니라 현재 카탈로그에 포함된 항목)

운영 DB 실측:
| 접두 | 개수 | 판매 |
|---|---|---|
| `(제품)` 79 · `(세트)` 72 · `(상품)` 4 | 155 | ✅ |
| `(원재료)` 65 · `(부재료)` 104 · `(부자재)` 12 | **181** | ❌ 옵션 검색서 제외 |

## 변경
- `lib/products`: `isComponentName()` + `COMPONENT_NAME_PREFIXES`(`(원재료)`/`(부재료)`/`(부자재)`) 추가 — 한 곳에서 관리.
- `PlanEditor` **옵션 SKU 검색(AddSku)**: 비판매 구성품 제외 (limit 20→30).
- `PlanEditor` **사은품 검색(FreebieRow)**: 구성품 **포함 유지** — 스티커·약봉투·팜플렛 등 부재료/판촉물도 동봉 사은품으로 쓰이므로 모두 노출.
- 단위 테스트 추가.

데이터 변경 없음(검색 표시 필터만). `tsc` 통과, `npm run test` 81 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zkqVzCBpDUh7ntB3EdnLG