### PR TITLE
상품 카테고리 관리 — 마스터 목록 + 대량 분류 + 이름변경/병합

### DIFF
--- a/promo-analytics/app/(dash)/products/ProductsTable.tsx
+++ b/promo-analytics/app/(dash)/products/ProductsTable.tsx
@@ -29,6 +29,7 @@ const KIND_TONE: Record<ProductKind, string> = {
 };
 
 type KindFilter = "전체" | "판매" | "구성품" | "기타";
+const UNSET = "(미지정)";
 
 export default function ProductsTable({
   initialRows,
@@ -39,6 +40,7 @@ export default function ProductsTable({
 }) {
   const router = useRouter();
   const [rows, setRows] = useState<ProductRow[]>(initialRows);
+  const [cats, setCats] = useState<string[]>(categories);
   const [q, setQ] = useState("");
   const [kindF, setKindF] = useState<KindFilter>("전체");
   const [catF, setCatF] = useState<string>("전체");
@@ -46,6 +48,8 @@ export default function ProductsTable({
   const [savingId, setSavingId] = useState<string | null>(null);
   const [flashId, setFlashId] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [bulkCat, setBulkCat] = useState<string>("");
 
   const filtered = useMemo(() => {
     const term = q.trim();
@@ -55,24 +59,34 @@ export default function ProductsTable({
       if (kindF === "판매" && !SELLABLE_KINDS.includes(k)) return false;
       if (kindF === "구성품" && !COMPONENT_KINDS.includes(k)) return false;
       if (kindF === "기타" && k !== "기타") return false;
-      if (catF !== "전체" && (r.category ?? "") !== catF) return false;
+      if (catF === UNSET && r.category) return false;
+      if (catF !== "전체" && catF !== UNSET && (r.category ?? "") !== catF) return false;
       if (missingOnly && r.cost != null && r.consumer_price != null && r.regular_price != null) return false;
       return true;
     });
   }, [rows, q, kindF, catF, missingOnly]);
 
-  async function patch(id: string, field: Field, value: string | boolean) {
+  const catCounts = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const r of rows) {
+      const c = r.category?.trim();
+      if (c) m.set(c, (m.get(c) ?? 0) + 1);
+    }
+    return m;
+  }, [rows]);
+  const unsetCount = rows.filter((r) => !r.category).length;
+
+  async function patch(id: string, field: Field, value: string | boolean | null) {
     setErr(null);
     setSavingId(id);
     const prev = rows.find((r) => r.id === id);
-    // 낙관적 반영
     setRows((rs) =>
       rs.map((r) =>
         r.id === id
           ? {
               ...r,
               [field]: NUMERIC_FIELDS.includes(field)
-                ? value === "" ? null : Number(String(value).replace(/[^0-9.-]/g, ""))
+                ? value === "" || value == null ? null : Number(String(value).replace(/[^0-9.-]/g, ""))
                 : field === "is_subscription" ? value : (value === "" ? null : value),
             }
           : r,
@@ -88,10 +102,31 @@ export default function ProductsTable({
       setFlashId(id);
       setTimeout(() => setFlashId((f) => (f === id ? null : f)), 800);
     } catch (e) {
-      if (prev) setRows((rs) => rs.map((r) => (r.id === id ? prev : r))); // 롤백
+      if (prev) setRows((rs) => rs.map((r) => (r.id === id ? prev : r)));
       setErr(e instanceof Error ? e.message : "수정 실패");
     } finally {
       setSavingId(null);
+    }
+  }
+
+  async function bulkAssign() {
+    const ids = [...selected];
+    if (ids.length === 0) return;
+    const cat = bulkCat === UNSET || bulkCat === "" ? null : bulkCat;
+    setErr(null);
+    const snapshot = rows;
+    setRows((rs) => rs.map((r) => (selected.has(r.id) ? { ...r, category: cat } : r)));
+    try {
+      const res = await fetch("/api/products", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ ids, category: cat }),
+      });
+      if (!res.ok) throw new Error((await res.json()).error ?? "일괄 적용 실패");
+      setSelected(new Set());
+    } catch (e) {
+      setRows(snapshot);
+      setErr(e instanceof Error ? e.message : "일괄 적용 실패");
     }
   }
 
@@ -113,15 +148,43 @@ export default function ProductsTable({
 
   function onCreated(row: ProductRow) {
     setRows((rs) => [row, ...rs]);
+    if (row.category && !cats.includes(row.category)) setCats((c) => [...c, row.category!]);
     router.refresh();
   }
 
+  // 카테고리 관리 후 로컬 반영
+  function applyCatChange(kind: "add" | "rename" | "merge" | "delete", a: string, b?: string) {
+    if (kind === "add") setCats((c) => (c.includes(a) ? c : [...c, a]));
+    else if (kind === "rename") {
+      setCats((c) => c.map((x) => (x === a ? b! : x)));
+      setRows((rs) => rs.map((r) => (r.category === a ? { ...r, category: b! } : r)));
+    } else if (kind === "merge") {
+      setCats((c) => c.filter((x) => x !== a));
+      setRows((rs) => rs.map((r) => (r.category === a ? { ...r, category: b! } : r)));
+    } else if (kind === "delete") {
+      setCats((c) => c.filter((x) => x !== a));
+      setRows((rs) => rs.map((r) => (r.category === a ? { ...r, category: null } : r)));
+    }
+    router.refresh();
+  }
+
+  const allSelected = filtered.length > 0 && filtered.every((r) => selected.has(r.id));
+  const toggleAll = () =>
+    setSelected((s) => {
+      const next = new Set(s);
+      if (allSelected) filtered.forEach((r) => next.delete(r.id));
+      else filtered.forEach((r) => next.add(r.id));
+      return next;
+    });
+
   return (
-    <div className="mt-5">
-      <AddProduct categories={categories} onCreated={onCreated} onError={setErr} />
+    <div className="mt-5 space-y-4">
+      <CategoryManager cats={cats} counts={catCounts} unsetCount={unsetCount} onChange={applyCatChange} onError={setErr} />
+
+      <AddProduct categories={cats} onCreated={onCreated} onError={setErr} />
 
       {/* 검색·필터 */}
-      <div className="mt-4 flex flex-wrap items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         <input
           value={q}
           onChange={(e) => setQ(e.target.value)}
@@ -136,8 +199,9 @@ export default function ProductsTable({
         </select>
         <select value={catF} onChange={(e) => setCatF(e.target.value)} className="rounded-xl border border-line bg-card px-2.5 py-2 text-sm">
           <option value="전체">카테고리 전체</option>
-          {categories.map((c) => (
-            <option key={c} value={c}>{c}</option>
+          <option value={UNSET}>미지정 ({unsetCount})</option>
+          {cats.map((c) => (
+            <option key={c} value={c}>{c} ({catCounts.get(c) ?? 0})</option>
           ))}
         </select>
         <label className="flex items-center gap-1.5 text-sm text-ink-3">
@@ -147,12 +211,36 @@ export default function ProductsTable({
         <span className="ml-auto text-xs text-ink-4">{filtered.length} / {rows.length}개</span>
       </div>
 
-      {err && <p className="mt-2 text-sm text-danger">{err}</p>}
+      {/* 선택 일괄 카테고리 적용 */}
+      {selected.size > 0 && (
+        <div className="flex flex-wrap items-center gap-2 rounded-xl bg-brand-50 px-4 py-2.5 text-sm">
+          <span className="font-medium text-brand-700">{selected.size}개 선택</span>
+          <span className="text-ink-3">→ 카테고리</span>
+          <select value={bulkCat} onChange={(e) => setBulkCat(e.target.value)} className="rounded-lg border border-line bg-card px-2.5 py-1.5 text-sm">
+            <option value="">선택…</option>
+            <option value={UNSET}>미지정으로</option>
+            {cats.map((c) => (
+              <option key={c} value={c}>{c}</option>
+            ))}
+          </select>
+          <button
+            onClick={bulkAssign}
+            disabled={!bulkCat}
+            className="rounded-lg bg-brand-500 px-3 py-1.5 text-sm font-semibold text-white hover:bg-brand-600 disabled:opacity-40"
+          >
+            적용
+          </button>
+          <button onClick={() => setSelected(new Set())} className="text-xs text-ink-4 hover:text-ink-2">선택 해제</button>
+        </div>
+      )}
 
-      <div className="mt-3 overflow-x-auto rounded-2xl card-soft">
-        <table className="w-full min-w-[920px] text-sm">
+      {err && <p className="text-sm text-danger">{err}</p>}
+
+      <div className="overflow-x-auto rounded-2xl card-soft">
+        <table className="w-full min-w-[980px] text-sm">
           <thead className="bg-soft/60 text-left text-xs text-ink-3">
             <tr>
+              <th className="px-3 py-2.5"><input type="checkbox" checked={allSelected} onChange={toggleAll} aria-label="전체 선택" /></th>
               <th className="px-3 py-2.5 font-medium">종류</th>
               <th className="px-3 py-2.5 font-medium">SKU 코드</th>
               <th className="px-3 py-2.5 font-medium">상품명</th>
@@ -168,7 +256,21 @@ export default function ProductsTable({
             {filtered.map((r) => {
               const kind = productKind(r.base_name);
               return (
-                <tr key={r.id} className={`hover:bg-soft/40 ${flashId === r.id ? "row-success-flash" : ""}`}>
+                <tr key={r.id} className={`hover:bg-soft/40 ${flashId === r.id ? "row-success-flash" : ""} ${selected.has(r.id) ? "bg-brand-50/40" : ""}`}>
+                  <td className="px-3 py-2">
+                    <input
+                      type="checkbox"
+                      checked={selected.has(r.id)}
+                      onChange={(e) =>
+                        setSelected((s) => {
+                          const next = new Set(s);
+                          if (e.target.checked) next.add(r.id);
+                          else next.delete(r.id);
+                          return next;
+                        })
+                      }
+                    />
+                  </td>
                   <td className="px-3 py-2">
                     <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${KIND_TONE[kind]}`}>{kind}</span>
                   </td>
@@ -179,17 +281,22 @@ export default function ProductsTable({
                     <TextCell value={r.base_name} width="w-72" onSave={(v) => patch(r.id, "base_name", v)} />
                   </td>
                   <td className="px-2 py-1.5">
-                    <TextCell value={r.category} placeholder="—" width="w-28" list="cats" onSave={(v) => patch(r.id, "category", v)} />
+                    <select
+                      value={r.category ?? ""}
+                      disabled={savingId === r.id}
+                      onChange={(e) => patch(r.id, "category", e.target.value === "" ? null : e.target.value)}
+                      className={`w-32 rounded-lg border px-2 py-1 text-sm focus:border-brand-400 focus:outline-none ${r.category ? "border-line bg-card" : "border-amber-300 bg-amber-50 text-amber-700"}`}
+                    >
+                      <option value="">미지정</option>
+                      {r.category && !cats.includes(r.category) && <option value={r.category}>{r.category}</option>}
+                      {cats.map((c) => (
+                        <option key={c} value={c}>{c}</option>
+                      ))}
+                    </select>
                   </td>
-                  <td className="px-2 py-1.5 text-right">
-                    <NumCell value={r.cost} onSave={(v) => patch(r.id, "cost", v)} />
-                  </td>
-                  <td className="px-2 py-1.5 text-right">
-                    <NumCell value={r.consumer_price} onSave={(v) => patch(r.id, "consumer_price", v)} />
-                  </td>
-                  <td className="px-2 py-1.5 text-right">
-                    <NumCell value={r.regular_price} onSave={(v) => patch(r.id, "regular_price", v)} />
-                  </td>
+                  <td className="px-2 py-1.5 text-right"><NumCell value={r.cost} onSave={(v) => patch(r.id, "cost", v)} /></td>
+                  <td className="px-2 py-1.5 text-right"><NumCell value={r.consumer_price} onSave={(v) => patch(r.id, "consumer_price", v)} /></td>
+                  <td className="px-2 py-1.5 text-right"><NumCell value={r.regular_price} onSave={(v) => patch(r.id, "regular_price", v)} /></td>
                   <td className="px-2 py-1.5 text-center">
                     <input
                       type="checkbox"
@@ -206,19 +313,110 @@ export default function ProductsTable({
             })}
             {filtered.length === 0 && (
               <tr>
-                <td colSpan={9} className="px-3 py-8 text-center text-ink-4">조건에 맞는 상품이 없습니다.</td>
+                <td colSpan={10} className="px-3 py-8 text-center text-ink-4">조건에 맞는 상품이 없습니다.</td>
               </tr>
             )}
           </tbody>
         </table>
       </div>
+    </div>
+  );
+}
 
-      {/* 카테고리 자동완성 */}
-      <datalist id="cats">
-        {categories.map((c) => (
-          <option key={c} value={c} />
-        ))}
-      </datalist>
+function CategoryManager({
+  cats,
+  counts,
+  unsetCount,
+  onChange,
+  onError,
+}: {
+  cats: string[];
+  counts: Map<string, number>;
+  unsetCount: number;
+  onChange: (kind: "add" | "rename" | "merge" | "delete", a: string, b?: string) => void;
+  onError: (m: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  async function call(method: string, body: Record<string, unknown>): Promise<boolean> {
+    setBusy(true);
+    onError("");
+    try {
+      const res = await fetch("/api/product-categories", {
+        method,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) throw new Error((await res.json()).error ?? "실패");
+      return true;
+    } catch (e) {
+      onError(e instanceof Error ? e.message : "실패");
+      return false;
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function add() {
+    const n = newName.trim();
+    if (!n) return;
+    if (await call("POST", { name: n })) {
+      onChange("add", n);
+      setNewName("");
+    }
+  }
+  async function rename(from: string) {
+    const to = prompt(`'${from}' → 새 이름 (이미 있는 이름으로 바꾸면 병합됩니다)`, from)?.trim();
+    if (!to || to === from) return;
+    const merge = cats.includes(to);
+    if (await call("PATCH", { from, to })) onChange(merge ? "merge" : "rename", from, to);
+  }
+  async function del(name: string) {
+    const n = counts.get(name) ?? 0;
+    if (!confirm(`'${name}' 카테고리를 삭제할까요?${n > 0 ? ` 이 카테고리 상품 ${n}개는 '미지정'이 됩니다.` : ""}`)) return;
+    if (await call("DELETE", { name })) onChange("delete", name);
+  }
+
+  return (
+    <div className="rounded-2xl card-soft p-4">
+      <button onClick={() => setOpen((o) => !o)} className="flex w-full items-center justify-between">
+        <span className="text-sm font-semibold text-ink-2">
+          카테고리 관리 <span className="font-normal text-ink-4">· {cats.length}종{unsetCount > 0 ? ` · 미지정 ${unsetCount}개` : ""}</span>
+        </span>
+        <span className="text-ink-4">{open ? "▲" : "▼"}</span>
+      </button>
+      {open && (
+        <div className="mt-3">
+          <p className="text-[11px] text-ink-4">
+            이름 변경 시 해당 상품들의 카테고리도 함께 바뀝니다(예: 굿즈 → 집사). 이미 있는 이름으로 바꾸면 두 카테고리가 병합돼요.
+          </p>
+          <ul className="mt-2 flex flex-wrap gap-2">
+            {cats.map((c) => (
+              <li key={c} className="flex items-center gap-1.5 rounded-full border border-line bg-card px-3 py-1 text-sm">
+                <span className="text-ink-2">{c}</span>
+                <span className="text-[11px] text-ink-4">{counts.get(c) ?? 0}</span>
+                <button onClick={() => rename(c)} disabled={busy} className="ml-1 text-[11px] text-brand-600 hover:underline">이름변경</button>
+                <button onClick={() => del(c)} disabled={busy} className="text-[11px] text-red-500 hover:underline">삭제</button>
+              </li>
+            ))}
+            {cats.length === 0 && <li className="text-xs text-ink-4">카테고리가 없습니다.</li>}
+          </ul>
+          <div className="mt-3 flex gap-2">
+            <input
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && add()}
+              placeholder="새 카테고리 (예: 집사)"
+              className="w-48 rounded-lg border border-line bg-card px-3 py-1.5 text-sm focus:border-brand-400 focus:outline-none"
+            />
+            <button onClick={add} disabled={busy || !newName.trim()} className="rounded-lg bg-brand-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-600 disabled:opacity-50">
+              추가
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -227,13 +425,11 @@ function TextCell({
   value,
   placeholder,
   width,
-  list,
   onSave,
 }: {
   value: string | null;
   placeholder?: string;
   width: string;
-  list?: string;
   onSave: (v: string) => void;
 }) {
   const [draft, setDraft] = useState<string | null>(null);
@@ -242,7 +438,6 @@ function TextCell({
     <input
       value={shown}
       placeholder={placeholder}
-      list={list}
       onChange={(e) => setDraft(e.target.value)}
       onBlur={() => {
         if (draft != null && draft !== (value ?? "")) onSave(draft);
@@ -348,7 +543,10 @@ function AddProduct({
         </label>
         <label className="flex flex-col gap-1">
           <span className="text-[11px] text-ink-4">카테고리</span>
-          <input className={`${input} w-28`} list="cats" value={f.category} onChange={(e) => set("category", e.target.value)} />
+          <select className={`${input} w-28`} value={f.category} onChange={(e) => set("category", e.target.value)}>
+            <option value="">미지정</option>
+            {categories.map((c) => <option key={c} value={c}>{c}</option>)}
+          </select>
         </label>
         <label className="flex flex-col gap-1">
           <span className="text-[11px] text-ink-4">원가</span>
@@ -374,7 +572,6 @@ function AddProduct({
         </div>
       </div>
       <p className="mt-2 text-[11px] text-ink-4">접두 ‘(제품)/(세트)/(상품)’=판매상품, ‘(원재료)/(부재료)/(부자재)’=구성품으로 자동 분류됩니다.</p>
-      <datalist id="cats">{categories.map((c) => <option key={c} value={c} />)}</datalist>
     </div>
   );
 }

--- a/promo-analytics/app/(dash)/products/page.tsx
+++ b/promo-analytics/app/(dash)/products/page.tsx
@@ -3,23 +3,29 @@ import ProductsTable, { type ProductRow } from "./ProductsTable";
 
 export const dynamic = "force-dynamic";
 
-// 상품·가격 가이드 — 웹이 단일 출처. SKU 코드·원가·판매가를 직접 추가/수정/삭제.
+// 상품·가격 가이드 — 웹이 단일 출처. SKU 코드·원가·판매가·카테고리를 직접 추가/수정/삭제.
 export default async function ProductsPage() {
   const supabase = await createClient();
-  const { data } = await supabase
-    .from("products")
-    .select("id, base_name, dr_code, category, cost, consumer_price, regular_price, is_subscription")
-    .order("dr_code", { ascending: true, nullsFirst: false })
-    .order("base_name", { ascending: true });
-  const rows = ((data as ProductRow[]) ?? []);
-  const categories = [...new Set(rows.map((r) => r.category).filter((c): c is string => !!c))].sort();
+  const [{ data: prod }, { data: cats }] = await Promise.all([
+    supabase
+      .from("products")
+      .select("id, base_name, dr_code, category, cost, consumer_price, regular_price, is_subscription")
+      .order("dr_code", { ascending: true, nullsFirst: false })
+      .order("base_name", { ascending: true }),
+    supabase.from("product_categories").select("name, sort").order("sort"),
+  ]);
+  const rows = (prod as ProductRow[]) ?? [];
+  // 관리 목록(있으면) 우선, 없으면 상품에서 distinct 로 보완
+  const managed = (cats ?? []).map((c) => c.name as string);
+  const fromProducts = [...new Set(rows.map((r) => r.category).filter((c): c is string => !!c))];
+  const categories = [...new Set([...managed, ...fromProducts])];
 
   return (
     <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
       <h1 className="text-xl font-semibold tracking-tight">상품 · 가격 가이드</h1>
       <p className="mt-1 text-sm text-ink-3">
-        SKU 코드 · 원가 · 소비자가 · 상시 판매가를 <strong>웹에서 직접</strong> 관리합니다(단일 출처).
-        시트는 ‘데이터 업로드’에서 <strong>수동 가져오기</strong>로만 사용해요. 묶음·정기 가격은 각 행의 ‘가격 구성’에서(다음 단계).
+        SKU 코드 · 원가 · 소비자가 · 상시 판매가 · <strong>카테고리</strong>를 웹에서 직접 관리합니다(단일 출처).
+        카테고리는 캠페인 메인 카테고리·서브 수량 예측에 쓰이니 정확히 분류하세요. 묶음·정기 가격은 다음 단계.
       </p>
       <ProductsTable initialRows={rows} categories={categories} />
     </div>

--- a/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
@@ -224,13 +224,15 @@ export default function PlanEditor({
   useEffect(() => {
     let alive = true;
     (async () => {
-      const { data } = await createClient()
-        .from("products")
-        .select("category")
-        .not("category", "is", null);
+      const supabase = createClient();
+      // 관리 카테고리 목록(정렬) 우선, 없으면 상품 distinct 로 보완(0072 미적용 환경 대비)
+      const { data: managed } = await supabase.from("product_categories").select("name, sort").order("sort");
+      const { data } = await supabase.from("products").select("category").not("category", "is", null);
       if (!alive) return;
-      const uniq = [...new Set((data ?? []).map((r) => (r.category as string)?.trim()).filter(Boolean))].sort();
-      setCategories(uniq);
+      const fromProducts = [...new Set((data ?? []).map((r) => (r.category as string)?.trim()).filter(Boolean))];
+      const ordered = (managed ?? []).map((c) => c.name as string);
+      const uniq = [...new Set([...ordered, ...fromProducts])];
+      setCategories(uniq.length > 0 ? uniq : fromProducts.sort());
     })();
     return () => {
       alive = false;

--- a/promo-analytics/app/api/product-categories/route.ts
+++ b/promo-analytics/app/api/product-categories/route.ts
@@ -1,0 +1,96 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export const runtime = "nodejs";
+
+// 상품 카테고리 마스터 관리. products.category(텍스트)가 값의 출처이고,
+// product_categories 는 '관리 목록 + 정렬'. 이름 변경/병합 시 두 곳을 함께 갱신한다.
+
+async function requireUser() {
+  const supabase = await createClient();
+  const { data } = await supabase.auth.getUser();
+  return data.user ? supabase : null;
+}
+
+export async function GET() {
+  const supabase = await requireUser();
+  if (!supabase) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  const { data: cats } = await supabase.from("product_categories").select("name, sort").order("sort");
+  const { data: prods } = await supabase.from("products").select("category");
+  const counts = new Map<string, number>();
+  for (const p of prods ?? []) {
+    const c = (p.category as string | null)?.trim();
+    if (c) counts.set(c, (counts.get(c) ?? 0) + 1);
+  }
+  const list = (cats ?? []).map((c) => ({ name: c.name as string, count: counts.get(c.name as string) ?? 0 }));
+  return NextResponse.json({ categories: list });
+}
+
+export async function POST(req: Request) {
+  const supabase = await requireUser();
+  if (!supabase) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  try {
+    const { name } = (await req.json()) as { name?: string };
+    const n = (name ?? "").trim();
+    if (!n) return NextResponse.json({ error: "카테고리명을 입력하세요." }, { status: 400 });
+    const { data: max } = await supabase
+      .from("product_categories")
+      .select("sort")
+      .order("sort", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    const { error } = await supabase
+      .from("product_categories")
+      .insert({ name: n, sort: ((max?.sort as number | undefined) ?? 0) + 1 });
+    if (error) return NextResponse.json({ error: error.message.includes("duplicate") ? "이미 있는 카테고리입니다." : error.message }, { status: 409 });
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    return NextResponse.json({ error: e instanceof Error ? e.message : "생성 실패" }, { status: 500 });
+  }
+}
+
+// 이름 변경/병합: from → to. to 가 이미 있으면 병합(from 행 삭제), 없으면 이름 변경.
+export async function PATCH(req: Request) {
+  const supabase = await requireUser();
+  if (!supabase) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  try {
+    const { from, to } = (await req.json()) as { from?: string; to?: string };
+    const f = (from ?? "").trim();
+    const t = (to ?? "").trim();
+    if (!f || !t) return NextResponse.json({ error: "변경 전/후 이름이 필요합니다." }, { status: 400 });
+    if (f === t) return NextResponse.json({ ok: true });
+
+    // 1) 상품의 category 문자열 일괄 변경 (값의 출처)
+    const { error: upErr } = await supabase.from("products").update({ category: t }).eq("category", f);
+    if (upErr) throw upErr;
+
+    // 2) 관리 목록 동기화
+    const { data: existsTo } = await supabase.from("product_categories").select("name").eq("name", t).maybeSingle();
+    if (existsTo) {
+      // 병합 — from 행 삭제
+      await supabase.from("product_categories").delete().eq("name", f);
+    } else {
+      const { error: rnErr } = await supabase.from("product_categories").update({ name: t }).eq("name", f);
+      if (rnErr) throw rnErr;
+    }
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    return NextResponse.json({ error: e instanceof Error ? e.message : "변경 실패" }, { status: 500 });
+  }
+}
+
+// 삭제: 관리 목록에서 제거 + 해당 상품들 미지정(null)으로
+export async function DELETE(req: Request) {
+  const supabase = await requireUser();
+  if (!supabase) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  try {
+    const { name } = (await req.json()) as { name?: string };
+    const n = (name ?? "").trim();
+    if (!n) return NextResponse.json({ error: "이름 필요" }, { status: 400 });
+    await supabase.from("products").update({ category: null }).eq("category", n);
+    await supabase.from("product_categories").delete().eq("name", n);
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    return NextResponse.json({ error: e instanceof Error ? e.message : "삭제 실패" }, { status: 500 });
+  }
+}

--- a/promo-analytics/app/api/products/route.ts
+++ b/promo-analytics/app/api/products/route.ts
@@ -68,7 +68,15 @@ export async function PATCH(req: Request) {
   const supabase = await requireUser();
   if (!supabase) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   try {
-    const body = (await req.json()) as Record<string, unknown> & { id?: string };
+    const body = (await req.json()) as Record<string, unknown> & { id?: string; ids?: string[] };
+    // 일괄 카테고리 지정: { ids: [...], category } — 미분류 상품 대량 정리용
+    if (Array.isArray(body.ids)) {
+      if (body.ids.length === 0) return NextResponse.json({ ok: true });
+      const cat = typeof body.category === "string" && body.category.trim() ? body.category.trim() : null;
+      const { error } = await supabase.from("products").update({ category: cat }).in("id", body.ids);
+      if (error) throw error;
+      return NextResponse.json({ ok: true, updated: body.ids.length });
+    }
     const id = body.id;
     if (!id) return NextResponse.json({ error: "id 필요" }, { status: 400 });
     const fields = clean(body);

--- a/promo-analytics/supabase/migrations/0072_product_categories.sql
+++ b/promo-analytics/supabase/migrations/0072_product_categories.sql
@@ -1,0 +1,27 @@
+-- 0072: 상품 카테고리 마스터 (관리 목록)
+-- products.category(텍스트)는 그대로 값의 출처로 유지(모든 벤치마크·필터 RPC가 이 문자열로 동작).
+-- product_categories 는 '관리 가능한 카테고리 목록 + 정렬'만 담는다. 이름 변경/병합은 앱에서
+-- product_categories 와 products.category 를 함께 갱신(문자열 동기화)한다.
+create table if not exists promo.product_categories (
+  id uuid primary key default gen_random_uuid(),
+  name text not null unique,
+  sort int not null default 0,
+  created_at timestamptz not null default now()
+);
+
+-- 기존 products.category 의 distinct 값으로 시드(미지정/공백 제외)
+insert into promo.product_categories (name, sort)
+select c, row_number() over (order by c)
+from (
+  select distinct trim(category) as c from promo.products
+  where category is not null and trim(category) <> ''
+) s
+on conflict (name) do nothing;
+
+alter table promo.product_categories enable row level security;
+drop policy if exists product_categories_auth_all on promo.product_categories;
+create policy product_categories_auth_all on promo.product_categories
+  for all to authenticated using (true) with check (true);
+grant all on promo.product_categories to authenticated, service_role;
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
상품을 나눌 때 **카테고리도 제대로 관리**하도록 추가했습니다.

## 왜
- **229개 코드 상품이 ‘미지정’** — 캠페인 메인 카테고리 기반 서브 수량 예측·필터가 이들을 못 씀.
- **굿즈 → 집사** 처럼 실판매 분류로 바꿔야 함.

(현재 분포: 미지정 255 · 영양케어 58 · 간식 41 · 배변용품 31 · 용품 28 · 굿즈 7)

## 변경
- **`0072` 마이그레이션** — `promo.product_categories`(이름·정렬) 마스터 테이블 + 기존 distinct 시드. `products.category`(텍스트)는 값의 출처로 그대로 두어 기존 벤치마크/필터 RPC 무변경.
- **`/api/product-categories`** — 목록(개수)·추가·**이름변경/병합**(상품 `category` 문자열까지 동기화)·삭제.
- **`/api/products` 일괄 지정** — `{ ids, category }` 로 선택 상품 카테고리 대량 변경.
- **`/products` 페이지**
  - 카테고리 셀을 **드롭다운**으로(오타 방지, ‘미지정’은 노랑 강조)
  - **행 선택 + ‘선택 N개 → 카테고리 일괄 적용’** 툴바 (229개 미분류 빠르게 정리)
  - **‘카테고리 관리’ 패널** — 추가(예: 집사) / 이름변경(굿즈→집사) / 병합 / 삭제, 미지정 개수 표시
  - 카테고리 필터에 ‘미지정(N)’ 추가
- **캠페인 메인 카테고리 선택**(PlanEditor): 관리 목록(정렬) 우선, 없으면 distinct 보완.

운영 DB에 `0072` **적용 완료**(시드: 간식·굿즈·배변용품·영양케어·용품). `tsc`·`build` 통과.

## 사용 흐름 (굿즈→집사 예)
1. ‘카테고리 관리’에서 **집사** 추가하거나, **굿즈 → 이름변경 → 집사** (자동으로 굿즈 상품들이 집사로 이동)
2. 미분류 정리: 필터 ‘미지정’ → 행 선택 → 상단에서 카테고리 일괄 적용

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zkqVzCBpDUh7ntB3EdnLG

---
_Generated by [Claude Code](https://claude.ai/code/session_015zkqVzCBpDUh7ntB3EdnLG)_