### PR TITLE
가격 가이드 2단계 — SKU별 가격 구성(단품/묶음/정기) 편집 + 사은품 원가 인라인

### DIFF
--- a/promo-analytics/app/(dash)/products/PriceConfigDrawer.tsx
+++ b/promo-analytics/app/(dash)/products/PriceConfigDrawer.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Drawer, DrawerContent } from "@/components/ui/Drawer";
+import { won, pctFloor } from "@/lib/format";
+
+const TIERS = ["단품", "2묶음", "3묶음", "4묶음", "5묶음", "정기"] as const;
+type Tier = (typeof TIERS)[number];
+
+type Config = {
+  id: string;
+  config_type: string;
+  pack_count: number | null;
+  sale_price: number | null;
+  list_price: number | null;
+  free_shipping: boolean;
+  discount_rate_consumer: number | null;
+  discount_rate_regular: number | null;
+};
+
+export default function PriceConfigDrawer({
+  product,
+  onClose,
+}: {
+  product: { id: string; base_name: string } | null;
+  onClose: () => void;
+}) {
+  const [configs, setConfigs] = useState<Config[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [savingType, setSavingType] = useState<string | null>(null);
+  // 새 구성 추가 폼
+  const [addType, setAddType] = useState<Tier | "">("");
+  const [addSale, setAddSale] = useState("");
+  const [addList, setAddList] = useState("");
+  const [addFree, setAddFree] = useState(false);
+
+  useEffect(() => {
+    if (!product) return;
+    setErr(null);
+    setLoading(true);
+    setAddType("");
+    setAddSale("");
+    setAddList("");
+    setAddFree(false);
+    (async () => {
+      try {
+        const res = await fetch(`/api/products/configs?product_id=${product.id}`);
+        const json = await res.json();
+        if (!res.ok) throw new Error(json.error ?? "불러오기 실패");
+        setConfigs(json.configs ?? []);
+      } catch (e) {
+        setErr(e instanceof Error ? e.message : "불러오기 실패");
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [product]);
+
+  async function save(config_type: string, sale_price: string, list_price: string, free_shipping: boolean) {
+    if (!product) return;
+    setErr(null);
+    setSavingType(config_type);
+    try {
+      const res = await fetch("/api/products/configs", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ product_id: product.id, config_type, sale_price, list_price, free_shipping }),
+      });
+      if (!res.ok) throw new Error((await res.json()).error ?? "저장 실패");
+      // 갱신
+      const r2 = await fetch(`/api/products/configs?product_id=${product.id}`);
+      setConfigs((await r2.json()).configs ?? []);
+      return true;
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "저장 실패");
+      return false;
+    } finally {
+      setSavingType(null);
+    }
+  }
+
+  async function del(id: string) {
+    setErr(null);
+    try {
+      const res = await fetch("/api/products/configs", {
+        method: "DELETE",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id }),
+      });
+      if (!res.ok) throw new Error((await res.json()).error ?? "삭제 실패");
+      setConfigs((cs) => cs.filter((c) => c.id !== id));
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "삭제 실패");
+    }
+  }
+
+  const usedTypes = new Set(configs.map((c) => c.config_type));
+  const addableTiers = TIERS.filter((t) => !usedTypes.has(t));
+  const ordered = [...configs].sort((a, b) => TIERS.indexOf(a.config_type as Tier) - TIERS.indexOf(b.config_type as Tier));
+
+  async function submitAdd() {
+    if (!addType) return;
+    const ok = await save(addType, addSale, addList, addFree);
+    if (ok) {
+      setAddType("");
+      setAddSale("");
+      setAddList("");
+      setAddFree(false);
+    }
+  }
+
+  return (
+    <Drawer open={!!product} onOpenChange={(o) => !o && onClose()}>
+      {product && (
+        <DrawerContent side="right" title="가격 구성" description={product.base_name}>
+          {loading ? (
+            <p className="text-sm text-ink-4">불러오는 중…</p>
+          ) : (
+            <div className="space-y-3">
+              {err && <p className="text-sm text-danger">{err}</p>}
+              {ordered.length === 0 && <p className="text-sm text-ink-4">등록된 가격 구성이 없습니다. 아래에서 추가하세요.</p>}
+              {ordered.map((c) => (
+                <ConfigRow key={c.id} c={c} busy={savingType === c.config_type} onSave={save} onDelete={() => del(c.id)} />
+              ))}
+
+              {/* 새 구성 추가 */}
+              {addableTiers.length > 0 && (
+                <div className="rounded-xl border border-dashed border-line p-3">
+                  <div className="text-[11px] font-medium text-ink-4">구성 추가</div>
+                  <div className="mt-2 flex flex-wrap items-end gap-2">
+                    <select value={addType} onChange={(e) => setAddType(e.target.value as Tier)} className="rounded-lg border border-line bg-card px-2.5 py-1.5 text-sm">
+                      <option value="">종류…</option>
+                      {addableTiers.map((t) => (
+                        <option key={t} value={t}>{t}</option>
+                      ))}
+                    </select>
+                    <label className="flex flex-col gap-1">
+                      <span className="text-[10px] text-ink-4">판매가</span>
+                      <input value={addSale} onChange={(e) => setAddSale(e.target.value.replace(/[^0-9]/g, ""))} inputMode="numeric" placeholder="필수" className="w-28 rounded-lg border border-line bg-card px-2.5 py-1.5 text-right text-sm tabular-nums" />
+                    </label>
+                    <label className="flex flex-col gap-1">
+                      <span className="text-[10px] text-ink-4">정가(선택)</span>
+                      <input value={addList} onChange={(e) => setAddList(e.target.value.replace(/[^0-9]/g, ""))} inputMode="numeric" className="w-28 rounded-lg border border-line bg-card px-2.5 py-1.5 text-right text-sm tabular-nums" />
+                    </label>
+                    <label className="flex items-center gap-1.5 pb-2 text-xs text-ink-3">
+                      <input type="checkbox" checked={addFree} onChange={(e) => setAddFree(e.target.checked)} />
+                      무료배송
+                    </label>
+                    <button onClick={submitAdd} disabled={!addType || !addSale || savingType === addType} className="mb-1 rounded-lg bg-brand-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-600 disabled:opacity-50">
+                      추가
+                    </button>
+                  </div>
+                </div>
+              )}
+              <p className="text-[11px] text-ink-4">
+                판매가는 ‘세트당’(묶음/정기 포함) 가격입니다. 할인율은 소비자가 × 수량 기준으로 자동 계산됩니다.
+              </p>
+            </div>
+          )}
+        </DrawerContent>
+      )}
+    </Drawer>
+  );
+}
+
+function ConfigRow({
+  c,
+  busy,
+  onSave,
+  onDelete,
+}: {
+  c: Config;
+  busy: boolean;
+  onSave: (type: string, sale: string, list: string, free: boolean) => Promise<boolean | undefined>;
+  onDelete: () => void;
+}) {
+  const [sale, setSale] = useState(c.sale_price != null ? String(c.sale_price) : "");
+  const [list, setList] = useState(c.list_price != null ? String(c.list_price) : "");
+  const [free, setFree] = useState(c.free_shipping);
+  const dirty = sale !== (c.sale_price != null ? String(c.sale_price) : "") || list !== (c.list_price != null ? String(c.list_price) : "") || free !== c.free_shipping;
+
+  return (
+    <div className="rounded-xl card-soft p-3">
+      <div className="flex items-center justify-between">
+        <span className="rounded-full bg-brand-50 px-2 py-0.5 text-xs font-semibold text-brand-700">{c.config_type}</span>
+        <button onClick={onDelete} className="text-[11px] text-red-500 hover:underline">삭제</button>
+      </div>
+      <div className="mt-2 flex flex-wrap items-end gap-2">
+        <label className="flex flex-col gap-1">
+          <span className="text-[10px] text-ink-4">판매가</span>
+          <input value={sale ? Number(sale).toLocaleString("ko-KR") : ""} onChange={(e) => setSale(e.target.value.replace(/[^0-9]/g, ""))} inputMode="numeric" className="w-28 rounded-lg border border-line bg-card px-2.5 py-1.5 text-right text-sm tabular-nums" />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-[10px] text-ink-4">정가</span>
+          <input value={list ? Number(list).toLocaleString("ko-KR") : ""} onChange={(e) => setList(e.target.value.replace(/[^0-9]/g, ""))} inputMode="numeric" className="w-28 rounded-lg border border-line bg-card px-2.5 py-1.5 text-right text-sm tabular-nums" />
+        </label>
+        <label className="flex items-center gap-1.5 pb-2 text-xs text-ink-3">
+          <input type="checkbox" checked={free} onChange={(e) => setFree(e.target.checked)} />
+          무료배송
+        </label>
+        <button
+          onClick={() => onSave(c.config_type, sale, list, free)}
+          disabled={!dirty || busy}
+          className="mb-1 rounded-lg border border-line px-3 py-1.5 text-sm font-medium text-ink-2 hover:bg-soft disabled:opacity-40"
+        >
+          {busy ? "저장 중…" : dirty ? "저장" : "저장됨"}
+        </button>
+      </div>
+      <div className="mt-1 text-[11px] text-ink-4">
+        소비자가 대비 할인 {pctFloor(c.discount_rate_consumer)}
+        {c.sale_price != null ? ` · 세트가 ${won(c.sale_price)}` : ""}
+      </div>
+    </div>
+  );
+}

--- a/promo-analytics/app/(dash)/products/ProductsTable.tsx
+++ b/promo-analytics/app/(dash)/products/ProductsTable.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { productKind, type ProductKind, SELLABLE_KINDS, COMPONENT_KINDS } from "@/lib/products";
+import PriceConfigDrawer from "./PriceConfigDrawer";
 
 export type ProductRow = {
   id: string;
@@ -50,6 +51,7 @@ export default function ProductsTable({
   const [err, setErr] = useState<string | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [bulkCat, setBulkCat] = useState<string>("");
+  const [configFor, setConfigFor] = useState<{ id: string; base_name: string } | null>(null);
 
   const filtered = useMemo(() => {
     const term = q.trim();
@@ -305,7 +307,8 @@ export default function ProductsTable({
                       onChange={(e) => patch(r.id, "is_subscription", e.target.checked)}
                     />
                   </td>
-                  <td className="px-2 py-1.5 text-right">
+                  <td className="px-2 py-1.5 text-right whitespace-nowrap">
+                    <button onClick={() => setConfigFor({ id: r.id, base_name: r.base_name })} className="rounded px-1.5 py-0.5 text-xs text-brand-600 hover:bg-brand-50">구성</button>
                     <button onClick={() => remove(r)} className="rounded px-1.5 py-0.5 text-xs text-red-500 hover:bg-red-50">삭제</button>
                   </td>
                 </tr>
@@ -319,6 +322,8 @@ export default function ProductsTable({
           </tbody>
         </table>
       </div>
+
+      <PriceConfigDrawer product={configFor} onClose={() => setConfigFor(null)} />
     </div>
   );
 }

--- a/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
@@ -1595,8 +1595,8 @@ function FreebieRow({
           </button>
         )}
       </div>
-      <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-3">
-        <div className="relative sm:col-span-2">
+      <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-4">
+        <div className="relative col-span-2">
           <span className={labelCls}>사은품 SKU</span>
           {entry.product_id ? (
             <div className="mt-0.5 flex items-center justify-between gap-2 rounded-lg border border-line bg-card px-2.5 py-1.5 text-sm text-ink">
@@ -1639,6 +1639,18 @@ function FreebieRow({
           )}
         </div>
         <label className="block">
+          <span className={labelCls}>원가 (차감 기준)</span>
+          <input
+            type="text"
+            inputMode="numeric"
+            disabled={readOnly}
+            value={entry.cost ? entry.cost.toLocaleString("ko-KR") : ""}
+            onChange={(e) => onPatch({ cost: Number(e.target.value.replace(/[^0-9]/g, "")) || 0 })}
+            placeholder="자동·직접입력"
+            className={`${fieldCls} text-right`}
+          />
+        </label>
+        <label className="block">
           <span className={labelCls}>수량 (한정)</span>
           <input
             type="number"
@@ -1652,7 +1664,7 @@ function FreebieRow({
       </div>
       <p className="mt-1.5 text-[11px] text-ink-4">
         차감액 = 원가 {won(entry.cost)} × 수량 {num(entry.qty)} = <b className="text-ink-2">−{won(deduction)}</b>{" "}
-        (동봉 발송이라 물류비·광고비는 제외)
+        (동봉 발송이라 물류비·광고비는 제외). 원가가 비어 있으면 직접 입력하세요.
       </p>
     </li>
   );

--- a/promo-analytics/app/api/products/configs/route.ts
+++ b/promo-analytics/app/api/products/configs/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export const runtime = "nodejs";
+
+// SKU별 가격 구성(product_price_configs) 편집 — 단품/2~5묶음/정기 판매가.
+// products.consumer_price/regular_price 기준으로 할인율을 자동 계산해 함께 저장.
+
+const PACK: Record<string, number> = { 단품: 1, "2묶음": 2, "3묶음": 3, "4묶음": 4, "5묶음": 5, 정기: 1 };
+
+async function requireUser() {
+  const supabase = await createClient();
+  const { data } = await supabase.auth.getUser();
+  return data.user ? supabase : null;
+}
+
+export async function GET(req: Request) {
+  const supabase = await requireUser();
+  if (!supabase) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  const pid = new URL(req.url).searchParams.get("product_id");
+  if (!pid) return NextResponse.json({ error: "product_id 필요" }, { status: 400 });
+  const { data } = await supabase
+    .from("product_price_configs")
+    .select("id, config_type, pack_count, sale_price, list_price, free_shipping, discount_rate_consumer, discount_rate_regular")
+    .eq("product_id", pid);
+  return NextResponse.json({ configs: data ?? [] });
+}
+
+// 구성 추가/수정 (config_type 기준 upsert)
+export async function POST(req: Request) {
+  const supabase = await requireUser();
+  if (!supabase) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  try {
+    const b = (await req.json()) as {
+      product_id?: string;
+      config_type?: string;
+      sale_price?: unknown;
+      list_price?: unknown;
+      free_shipping?: unknown;
+    };
+    if (!b.product_id || !b.config_type)
+      return NextResponse.json({ error: "product_id·config_type 필요" }, { status: 400 });
+    const { data: prod } = await supabase
+      .from("products")
+      .select("base_name, consumer_price, regular_price")
+      .eq("id", b.product_id)
+      .maybeSingle();
+    if (!prod) return NextResponse.json({ error: "상품을 찾을 수 없습니다." }, { status: 404 });
+
+    const num = (v: unknown) => {
+      const s = String(v ?? "").replace(/[^0-9.-]/g, "");
+      return s.trim() === "" ? null : Number(s);
+    };
+    const sale = num(b.sale_price);
+    const list = num(b.list_price);
+    const consumer = prod.consumer_price as number | null;
+    const regular = prod.regular_price as number | null;
+    const row = {
+      product_id: b.product_id,
+      base_name: prod.base_name as string,
+      config_type: b.config_type,
+      pack_count: PACK[b.config_type] ?? 1,
+      sale_price: sale,
+      list_price: list,
+      free_shipping: !!b.free_shipping,
+      discount_rate_consumer: sale != null && consumer ? 1 - sale / (consumer * (PACK[b.config_type] ?? 1)) : null,
+      discount_rate_regular: sale != null && regular ? 1 - sale / (regular * (PACK[b.config_type] ?? 1)) : null,
+      source_file: "web",
+      updated_at: new Date().toISOString(),
+    };
+    const { error } = await supabase
+      .from("product_price_configs")
+      .upsert(row, { onConflict: "product_id,config_type" });
+    if (error) throw error;
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    return NextResponse.json({ error: e instanceof Error ? e.message : "저장 실패" }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: Request) {
+  const supabase = await requireUser();
+  if (!supabase) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  try {
+    const { id } = (await req.json()) as { id?: string };
+    if (!id) return NextResponse.json({ error: "id 필요" }, { status: 400 });
+    const { error } = await supabase.from("product_price_configs").delete().eq("id", id);
+    if (error) throw error;
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    return NextResponse.json({ error: e instanceof Error ? e.message : "삭제 실패" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
가격 가이드 웹 편집기 **2단계**입니다. 1단계(상품 기본 필드)·카테고리 관리에 이어, SKU별 **가격 구성**과 **사은품 원가**를 채웠습니다.

## 변경
- **`/api/products/configs`** — SKU별 `product_price_configs` GET/POST(upsert)/DELETE. 저장 시 **소비자가 × 수량** 기준 할인율 자동 계산. `config_type`에 **‘정기’(정기배송)** 추가(테이블에 CHECK 제약 없음 확인).
- **`/products` 각 행 ‘구성’ 버튼 → 가격 구성 Drawer**
  - **단품 / 2~5묶음 / 정기** 판매가 · 정가 · 무료배송을 추가/수정/삭제
  - 세트당 가격 입력, 할인율은 자동 표시
- **사은품 원가 인라인**(PlanEditor 사은품 행): 상품 원가 자동 + **누락 시 직접 입력/수정** → 동봉 차감액 정확도 향상

`tsc` · `build` 통과 · `npm run test` 82 passed. 데이터 모델 변경 없음(기존 `product_price_configs` 사용, 값만 웹에서 편집).

## 이걸로 마무리되는 것
- 상시/정기/사은품/묶음 가격을 **웹에서 직접** 관리 → 데이터 혼용 정리 완료(1·2단계 + 카테고리).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zkqVzCBpDUh7ntB3EdnLG

---
_Generated by [Claude Code](https://claude.ai/code/session_015zkqVzCBpDUh7ntB3EdnLG)_