### PR TITLE
상품·가격 매트릭스 — 시트형 가격표(상시/정기×묶음) + 브랜드 + 자동계산

### DIFF
--- a/promo-analytics/app/(dash)/products/PriceConfigDrawer.tsx
+++ b/promo-analytics/app/(dash)/products/PriceConfigDrawer.tsx
@@ -3,46 +3,49 @@
 import { useEffect, useState } from "react";
 import { Drawer, DrawerContent } from "@/components/ui/Drawer";
 import { won, pctFloor } from "@/lib/format";
+import {
+  TIER_QTY,
+  SANGSI_TIERS,
+  JEONGGI_TIERS,
+  discountVsConsumer,
+  contribution,
+  contributionRate,
+} from "@/lib/pricing";
 
-const TIERS = ["단품", "2묶음", "3묶음", "4묶음", "5묶음", "정기"] as const;
-type Tier = (typeof TIERS)[number];
+export type DrawerProduct = {
+  id: string;
+  base_name: string;
+  consumer_price: number | null;
+  regular_price: number | null;
+  cost: number | null;
+};
 
 type Config = {
   id: string;
+  sale_mode: string;
   config_type: string;
-  pack_count: number | null;
   sale_price: number | null;
   list_price: number | null;
   free_shipping: boolean;
-  discount_rate_consumer: number | null;
-  discount_rate_regular: number | null;
 };
 
 export default function PriceConfigDrawer({
   product,
+  mult,
   onClose,
 }: {
-  product: { id: string; base_name: string } | null;
+  product: DrawerProduct | null;
+  mult: number;
   onClose: () => void;
 }) {
   const [configs, setConfigs] = useState<Config[]>([]);
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
-  const [savingType, setSavingType] = useState<string | null>(null);
-  // 새 구성 추가 폼
-  const [addType, setAddType] = useState<Tier | "">("");
-  const [addSale, setAddSale] = useState("");
-  const [addList, setAddList] = useState("");
-  const [addFree, setAddFree] = useState(false);
 
   useEffect(() => {
     if (!product) return;
     setErr(null);
     setLoading(true);
-    setAddType("");
-    setAddSale("");
-    setAddList("");
-    setAddFree(false);
     (async () => {
       try {
         const res = await fetch(`/api/products/configs?product_id=${product.id}`);
@@ -57,105 +60,72 @@ export default function PriceConfigDrawer({
     })();
   }, [product]);
 
-  async function save(config_type: string, sale_price: string, list_price: string, free_shipping: boolean) {
+  async function save(sale_mode: string, config_type: string, sale: string, list: string, free: boolean) {
     if (!product) return;
     setErr(null);
-    setSavingType(config_type);
-    try {
-      const res = await fetch("/api/products/configs", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ product_id: product.id, config_type, sale_price, list_price, free_shipping }),
-      });
-      if (!res.ok) throw new Error((await res.json()).error ?? "저장 실패");
-      // 갱신
-      const r2 = await fetch(`/api/products/configs?product_id=${product.id}`);
-      setConfigs((await r2.json()).configs ?? []);
-      return true;
-    } catch (e) {
-      setErr(e instanceof Error ? e.message : "저장 실패");
-      return false;
-    } finally {
-      setSavingType(null);
+    const res = await fetch("/api/products/configs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ product_id: product.id, sale_mode, config_type, sale_price: sale, list_price: list, free_shipping: free }),
+    });
+    if (!res.ok) {
+      setErr((await res.json()).error ?? "저장 실패");
+      return;
     }
+    const r2 = await fetch(`/api/products/configs?product_id=${product.id}`);
+    setConfigs((await r2.json()).configs ?? []);
   }
-
   async function del(id: string) {
     setErr(null);
-    try {
-      const res = await fetch("/api/products/configs", {
-        method: "DELETE",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ id }),
-      });
-      if (!res.ok) throw new Error((await res.json()).error ?? "삭제 실패");
-      setConfigs((cs) => cs.filter((c) => c.id !== id));
-    } catch (e) {
-      setErr(e instanceof Error ? e.message : "삭제 실패");
+    const res = await fetch("/api/products/configs", {
+      method: "DELETE",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id }),
+    });
+    if (!res.ok) {
+      setErr((await res.json()).error ?? "삭제 실패");
+      return;
     }
+    setConfigs((cs) => cs.filter((c) => c.id !== id));
   }
 
-  const usedTypes = new Set(configs.map((c) => c.config_type));
-  const addableTiers = TIERS.filter((t) => !usedTypes.has(t));
-  const ordered = [...configs].sort((a, b) => TIERS.indexOf(a.config_type as Tier) - TIERS.indexOf(b.config_type as Tier));
-
-  async function submitAdd() {
-    if (!addType) return;
-    const ok = await save(addType, addSale, addList, addFree);
-    if (ok) {
-      setAddType("");
-      setAddSale("");
-      setAddList("");
-      setAddFree(false);
-    }
-  }
+  const find = (mode: string, type: string) => configs.find((c) => c.sale_mode === mode && c.config_type === type) ?? null;
 
   return (
     <Drawer open={!!product} onOpenChange={(o) => !o && onClose()}>
       {product && (
-        <DrawerContent side="right" title="가격 구성" description={product.base_name}>
+        <DrawerContent side="right" title="가격 구성" description={product.base_name} className="w-[min(560px,calc(100vw-2rem))]">
           {loading ? (
             <p className="text-sm text-ink-4">불러오는 중…</p>
           ) : (
-            <div className="space-y-3">
+            <div className="space-y-5">
               {err && <p className="text-sm text-danger">{err}</p>}
-              {ordered.length === 0 && <p className="text-sm text-ink-4">등록된 가격 구성이 없습니다. 아래에서 추가하세요.</p>}
-              {ordered.map((c) => (
-                <ConfigRow key={c.id} c={c} busy={savingType === c.config_type} onSave={save} onDelete={() => del(c.id)} />
-              ))}
+              <div className="rounded-lg bg-soft px-3 py-2 text-[11px] text-ink-4">
+                소비자가 {won(product.consumer_price)} · 원가 {won(product.cost)} · 상시가 {won(product.regular_price)} · 공헌승수 {mult.toFixed(3)}
+                <br />가격(세트당)만 입력하면 할인율·공헌이익은 자동 계산됩니다. 기본값(소비자가·원가·상시가)은 ‘편집표’에서 수정하세요.
+              </div>
 
-              {/* 새 구성 추가 */}
-              {addableTiers.length > 0 && (
-                <div className="rounded-xl border border-dashed border-line p-3">
-                  <div className="text-[11px] font-medium text-ink-4">구성 추가</div>
-                  <div className="mt-2 flex flex-wrap items-end gap-2">
-                    <select value={addType} onChange={(e) => setAddType(e.target.value as Tier)} className="rounded-lg border border-line bg-card px-2.5 py-1.5 text-sm">
-                      <option value="">종류…</option>
-                      {addableTiers.map((t) => (
-                        <option key={t} value={t}>{t}</option>
-                      ))}
-                    </select>
-                    <label className="flex flex-col gap-1">
-                      <span className="text-[10px] text-ink-4">판매가</span>
-                      <input value={addSale} onChange={(e) => setAddSale(e.target.value.replace(/[^0-9]/g, ""))} inputMode="numeric" placeholder="필수" className="w-28 rounded-lg border border-line bg-card px-2.5 py-1.5 text-right text-sm tabular-nums" />
-                    </label>
-                    <label className="flex flex-col gap-1">
-                      <span className="text-[10px] text-ink-4">정가(선택)</span>
-                      <input value={addList} onChange={(e) => setAddList(e.target.value.replace(/[^0-9]/g, ""))} inputMode="numeric" className="w-28 rounded-lg border border-line bg-card px-2.5 py-1.5 text-right text-sm tabular-nums" />
-                    </label>
-                    <label className="flex items-center gap-1.5 pb-2 text-xs text-ink-3">
-                      <input type="checkbox" checked={addFree} onChange={(e) => setAddFree(e.target.checked)} />
-                      무료배송
-                    </label>
-                    <button onClick={submitAdd} disabled={!addType || !addSale || savingType === addType} className="mb-1 rounded-lg bg-brand-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-600 disabled:opacity-50">
-                      추가
-                    </button>
-                  </div>
-                </div>
-              )}
-              <p className="text-[11px] text-ink-4">
-                판매가는 ‘세트당’(묶음/정기 포함) 가격입니다. 할인율은 소비자가 × 수량 기준으로 자동 계산됩니다.
-              </p>
+              <Section
+                title="상시 판매"
+                tiers={SANGSI_TIERS as readonly string[]}
+                mode="상시"
+                product={product}
+                mult={mult}
+                find={find}
+                onSave={save}
+                onDelete={del}
+                showFree
+              />
+              <Section
+                title="정기구독 (무료배송)"
+                tiers={JEONGGI_TIERS as readonly string[]}
+                mode="정기"
+                product={product}
+                mult={mult}
+                find={find}
+                onSave={save}
+                onDelete={del}
+              />
             </div>
           )}
         </DrawerContent>
@@ -164,53 +134,133 @@ export default function PriceConfigDrawer({
   );
 }
 
-function ConfigRow({
-  c,
-  busy,
+function Section({
+  title,
+  tiers,
+  mode,
+  product,
+  mult,
+  find,
   onSave,
   onDelete,
+  showFree,
 }: {
-  c: Config;
-  busy: boolean;
-  onSave: (type: string, sale: string, list: string, free: boolean) => Promise<boolean | undefined>;
-  onDelete: () => void;
+  title: string;
+  tiers: readonly string[];
+  mode: string;
+  product: DrawerProduct;
+  mult: number;
+  find: (mode: string, type: string) => Config | null;
+  onSave: (mode: string, type: string, sale: string, list: string, free: boolean) => void;
+  onDelete: (id: string) => void;
+  showFree?: boolean;
 }) {
-  const [sale, setSale] = useState(c.sale_price != null ? String(c.sale_price) : "");
-  const [list, setList] = useState(c.list_price != null ? String(c.list_price) : "");
-  const [free, setFree] = useState(c.free_shipping);
-  const dirty = sale !== (c.sale_price != null ? String(c.sale_price) : "") || list !== (c.list_price != null ? String(c.list_price) : "") || free !== c.free_shipping;
+  return (
+    <div>
+      <h3 className="text-sm font-semibold text-ink-2">{title}</h3>
+      <div className="mt-2 space-y-2">
+        {tiers.map((t) => (
+          <TierRow
+            key={t}
+            tier={t}
+            mode={mode}
+            cfg={find(mode, t)}
+            product={product}
+            mult={mult}
+            onSave={onSave}
+            onDelete={onDelete}
+            showFree={showFree}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TierRow({
+  tier,
+  mode,
+  cfg,
+  product,
+  mult,
+  onSave,
+  onDelete,
+  showFree,
+}: {
+  tier: string;
+  mode: string;
+  cfg: Config | null;
+  product: DrawerProduct;
+  mult: number;
+  onSave: (mode: string, type: string, sale: string, list: string, free: boolean) => void;
+  onDelete: (id: string) => void;
+  showFree?: boolean;
+}) {
+  const [sale, setSale] = useState(cfg?.sale_price != null ? String(cfg.sale_price) : "");
+  const [list, setList] = useState(cfg?.list_price != null ? String(cfg.list_price) : "");
+  const [free, setFree] = useState(cfg?.free_shipping ?? mode === "정기");
+  useEffect(() => {
+    setSale(cfg?.sale_price != null ? String(cfg.sale_price) : "");
+    setList(cfg?.list_price != null ? String(cfg.list_price) : "");
+    setFree(cfg?.free_shipping ?? mode === "정기");
+  }, [cfg, mode]);
+
+  const qty = TIER_QTY[tier] ?? 1;
+  const saleNum = sale.trim() === "" ? null : Number(sale.replace(/[^0-9.]/g, ""));
+  const disc = discountVsConsumer(saleNum, product.consumer_price, qty);
+  const contrib = contribution(saleNum, product.cost, qty, mult);
+  const cRate = contributionRate(saleNum, product.cost, qty, mult);
+  const dirty =
+    sale !== (cfg?.sale_price != null ? String(cfg.sale_price) : "") ||
+    list !== (cfg?.list_price != null ? String(cfg.list_price) : "") ||
+    free !== (cfg?.free_shipping ?? mode === "정기");
 
   return (
-    <div className="rounded-xl card-soft p-3">
-      <div className="flex items-center justify-between">
-        <span className="rounded-full bg-brand-50 px-2 py-0.5 text-xs font-semibold text-brand-700">{c.config_type}</span>
-        <button onClick={onDelete} className="text-[11px] text-red-500 hover:underline">삭제</button>
-      </div>
-      <div className="mt-2 flex flex-wrap items-end gap-2">
-        <label className="flex flex-col gap-1">
-          <span className="text-[10px] text-ink-4">판매가</span>
-          <input value={sale ? Number(sale).toLocaleString("ko-KR") : ""} onChange={(e) => setSale(e.target.value.replace(/[^0-9]/g, ""))} inputMode="numeric" className="w-28 rounded-lg border border-line bg-card px-2.5 py-1.5 text-right text-sm tabular-nums" />
+    <div className="rounded-xl border border-line p-2.5">
+      <div className="flex flex-wrap items-end gap-2">
+        <span className="w-12 shrink-0 pb-1.5 text-xs font-semibold text-ink-2">{tier}</span>
+        <label className="flex flex-col gap-0.5">
+          <span className="text-[10px] text-ink-4">판매가(세트)</span>
+          <input
+            value={saleNum != null ? saleNum.toLocaleString("ko-KR") : sale}
+            onChange={(e) => setSale(e.target.value.replace(/[^0-9]/g, ""))}
+            inputMode="numeric"
+            className="w-28 rounded-lg border border-line bg-card px-2.5 py-1.5 text-right text-sm tabular-nums"
+          />
         </label>
-        <label className="flex flex-col gap-1">
-          <span className="text-[10px] text-ink-4">정가</span>
-          <input value={list ? Number(list).toLocaleString("ko-KR") : ""} onChange={(e) => setList(e.target.value.replace(/[^0-9]/g, ""))} inputMode="numeric" className="w-28 rounded-lg border border-line bg-card px-2.5 py-1.5 text-right text-sm tabular-nums" />
+        <label className="flex flex-col gap-0.5">
+          <span className="text-[10px] text-ink-4">정가(선택)</span>
+          <input
+            value={list ? Number(list).toLocaleString("ko-KR") : ""}
+            onChange={(e) => setList(e.target.value.replace(/[^0-9]/g, ""))}
+            inputMode="numeric"
+            className="w-24 rounded-lg border border-line bg-card px-2.5 py-1.5 text-right text-sm tabular-nums"
+          />
         </label>
-        <label className="flex items-center gap-1.5 pb-2 text-xs text-ink-3">
-          <input type="checkbox" checked={free} onChange={(e) => setFree(e.target.checked)} />
-          무료배송
-        </label>
+        {showFree && (
+          <label className="flex items-center gap-1 pb-2 text-[11px] text-ink-3">
+            <input type="checkbox" checked={free} onChange={(e) => setFree(e.target.checked)} />
+            무배
+          </label>
+        )}
         <button
-          onClick={() => onSave(c.config_type, sale, list, free)}
-          disabled={!dirty || busy}
-          className="mb-1 rounded-lg border border-line px-3 py-1.5 text-sm font-medium text-ink-2 hover:bg-soft disabled:opacity-40"
+          onClick={() => onSave(mode, tier, sale, list, free)}
+          disabled={!dirty || saleNum == null}
+          className="mb-1 rounded-lg border border-line px-2.5 py-1.5 text-xs font-medium text-ink-2 hover:bg-soft disabled:opacity-40"
         >
-          {busy ? "저장 중…" : dirty ? "저장" : "저장됨"}
+          {dirty ? "저장" : "저장됨"}
         </button>
+        {cfg && (
+          <button onClick={() => onDelete(cfg.id)} className="mb-1 rounded-lg px-2 py-1.5 text-xs text-red-500 hover:bg-red-50">
+            지우기
+          </button>
+        )}
       </div>
-      <div className="mt-1 text-[11px] text-ink-4">
-        소비자가 대비 할인 {pctFloor(c.discount_rate_consumer)}
-        {c.sale_price != null ? ` · 세트가 ${won(c.sale_price)}` : ""}
-      </div>
+      {saleNum != null && (
+        <div className="mt-1 text-[11px] text-ink-4">
+          소비자가 대비 {pctFloor(disc)} · 공헌이익 {won(contrib)} ({pctFloor(cRate)})
+        </div>
+      )}
     </div>
   );
 }

--- a/promo-analytics/app/(dash)/products/PriceMatrix.tsx
+++ b/promo-analytics/app/(dash)/products/PriceMatrix.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { won, pctFloor } from "@/lib/format";
+import {
+  TIER_QTY,
+  discountVsConsumer,
+  marginRate,
+  addonUnitPrice,
+  contribution,
+  contributionRate,
+} from "@/lib/pricing";
+import type { ProductRow, ConfigLite } from "./ProductsTable";
+
+const SANGSI_BUNDLES = ["2묶음", "3묶음", "4묶음", "5묶음", "6묶음"];
+const JEONGGI = ["단품", "2묶음", "4묶음"];
+
+// 시트형 가격 매트릭스(읽기). 가격만 보고, 행 클릭 시 가격 구성 편집 드로어 열림.
+export default function PriceMatrix({
+  rows,
+  configsByProduct,
+  mult,
+  onOpen,
+}: {
+  rows: ProductRow[];
+  configsByProduct: Record<string, ConfigLite[]>;
+  mult: number;
+  onOpen: (r: ProductRow) => void;
+}) {
+  const price = (pid: string, mode: string, type: string): number | null => {
+    const c = (configsByProduct[pid] ?? []).find((x) => x.sale_mode === mode && x.config_type === type);
+    return c?.sale_price ?? null;
+  };
+
+  const th = "border border-line/60 px-2 py-1 font-medium whitespace-nowrap";
+  const td = "border border-line/50 px-2 py-1 text-right tabular-nums whitespace-nowrap";
+  const tdL = "border border-line/50 px-2 py-1 text-left whitespace-nowrap";
+
+  return (
+    <div className="mt-3 overflow-x-auto rounded-2xl card-soft">
+      <table className="min-w-[1600px] border-collapse text-[11px]">
+        <thead>
+          <tr className="bg-soft text-ink-3">
+            <th className={th} colSpan={4}>기본</th>
+            <th className={`${th} bg-neutral-50`} colSpan={6}>상시 단가</th>
+            <th className={`${th} bg-green-50`} colSpan={SANGSI_BUNDLES.length}>묶음 (상시)</th>
+            <th className={`${th} bg-purple-50`} colSpan={JEONGGI.length}>정기구독</th>
+            <th className={`${th} bg-rose-50`} colSpan={2}>공헌(상시)</th>
+            <th className={`${th} bg-rose-50`} colSpan={JEONGGI.length}>공헌(정기)</th>
+          </tr>
+          <tr className="bg-soft/70 text-ink-3">
+            <th className={th}>품목코드</th>
+            <th className={th}>브랜드</th>
+            <th className={th}>카테고리</th>
+            <th className={th}>상품명</th>
+            <th className={th}>소비자가</th>
+            <th className={th}>원가</th>
+            <th className={th}>상시가</th>
+            <th className={th}>할인율</th>
+            <th className={th}>마진율</th>
+            <th className={th}>추가구성</th>
+            {SANGSI_BUNDLES.map((t) => (
+              <th key={t} className={`${th} bg-green-50/50`}>{t}</th>
+            ))}
+            {JEONGGI.map((t) => (
+              <th key={t} className={`${th} bg-purple-50/50`}>{t}</th>
+            ))}
+            <th className={`${th} bg-rose-50/50`}>이익액</th>
+            <th className={`${th} bg-rose-50/50`}>이익률</th>
+            {JEONGGI.map((t) => (
+              <th key={t} className={`${th} bg-rose-50/50`}>{t}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => {
+            const consumer = r.consumer_price;
+            const regular = r.regular_price;
+            const cost = r.cost;
+            return (
+              <tr
+                key={r.id}
+                onClick={() => onOpen(r)}
+                className="cursor-pointer text-ink-2 hover:bg-brand-50/40"
+                title="클릭하면 가격 구성 편집"
+              >
+                <td className={tdL}>{r.dr_code ?? "—"}</td>
+                <td className={tdL}>{r.brand ?? "—"}</td>
+                <td className={tdL}>{r.category ?? "—"}</td>
+                <td className={`${tdL} max-w-[260px] truncate`} title={r.base_name}>{r.base_name}</td>
+                <td className={td}>{won(consumer)}</td>
+                <td className={td}>{won(cost)}</td>
+                <td className={td}>{won(regular)}</td>
+                <td className={td}>{pctFloor(discountVsConsumer(regular, consumer, 1))}</td>
+                <td className={td}>{pctFloor(marginRate(regular, cost))}</td>
+                <td className={td}>{won(addonUnitPrice(regular))}</td>
+                {SANGSI_BUNDLES.map((t) => {
+                  const p = price(r.id, "상시", t);
+                  return (
+                    <td key={t} className={`${td} bg-green-50/30`}>
+                      {p != null ? (
+                        <>
+                          {won(p)}
+                          <span className="ml-1 text-[10px] text-ink-4">{pctFloor(discountVsConsumer(p, consumer, TIER_QTY[t]))}</span>
+                        </>
+                      ) : "—"}
+                    </td>
+                  );
+                })}
+                {JEONGGI.map((t) => {
+                  const p = price(r.id, "정기", t);
+                  return (
+                    <td key={t} className={`${td} bg-purple-50/30`}>
+                      {p != null ? (
+                        <>
+                          {won(p)}
+                          <span className="ml-1 text-[10px] text-ink-4">{pctFloor(discountVsConsumer(p, consumer, TIER_QTY[t]))}</span>
+                        </>
+                      ) : "—"}
+                    </td>
+                  );
+                })}
+                <td className={`${td} bg-rose-50/30`}>{won(contribution(regular, cost, 1, mult))}</td>
+                <td className={`${td} bg-rose-50/30`}>{pctFloor(contributionRate(regular, cost, 1, mult))}</td>
+                {JEONGGI.map((t) => {
+                  const p = price(r.id, "정기", t);
+                  return (
+                    <td key={t} className={`${td} bg-rose-50/30`}>
+                      {p != null ? won(contribution(p, cost, TIER_QTY[t], mult)) : "—"}
+                    </td>
+                  );
+                })}
+              </tr>
+            );
+          })}
+          {rows.length === 0 && (
+            <tr>
+              <td className="px-3 py-8 text-center text-ink-4" colSpan={20}>상품이 없습니다.</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/promo-analytics/app/(dash)/products/ProductsTable.tsx
+++ b/promo-analytics/app/(dash)/products/ProductsTable.tsx
@@ -4,16 +4,24 @@ import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { productKind, type ProductKind, SELLABLE_KINDS, COMPONENT_KINDS } from "@/lib/products";
 import PriceConfigDrawer from "./PriceConfigDrawer";
+import PriceMatrix from "./PriceMatrix";
 
 export type ProductRow = {
   id: string;
   base_name: string;
   dr_code: string | null;
   category: string | null;
+  brand: string | null;
   cost: number | null;
   consumer_price: number | null;
   regular_price: number | null;
   is_subscription: boolean;
+};
+export type ConfigLite = {
+  sale_mode: string;
+  config_type: string;
+  sale_price: number | null;
+  free_shipping: boolean;
 };
 
 type Field = keyof Omit<ProductRow, "id">;
@@ -35,13 +43,20 @@ const UNSET = "(미지정)";
 export default function ProductsTable({
   initialRows,
   categories,
+  brands,
+  configsByProduct,
+  mult,
 }: {
   initialRows: ProductRow[];
   categories: string[];
+  brands: string[];
+  configsByProduct: Record<string, ConfigLite[]>;
+  mult: number;
 }) {
   const router = useRouter();
   const [rows, setRows] = useState<ProductRow[]>(initialRows);
   const [cats, setCats] = useState<string[]>(categories);
+  const [view, setView] = useState<"edit" | "matrix">("edit");
   const [q, setQ] = useState("");
   const [kindF, setKindF] = useState<KindFilter>("전체");
   const [catF, setCatF] = useState<string>("전체");
@@ -51,7 +66,7 @@ export default function ProductsTable({
   const [err, setErr] = useState<string | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [bulkCat, setBulkCat] = useState<string>("");
-  const [configFor, setConfigFor] = useState<{ id: string; base_name: string } | null>(null);
+  const [configFor, setConfigFor] = useState<ProductRow | null>(null);
 
   const filtered = useMemo(() => {
     const term = q.trim();
@@ -181,9 +196,29 @@ export default function ProductsTable({
 
   return (
     <div className="mt-5 space-y-4">
+      {/* 보기 전환 */}
+      <div className="inline-flex rounded-xl border border-line p-0.5 text-sm">
+        <button
+          onClick={() => setView("edit")}
+          className={`rounded-lg px-3 py-1.5 font-medium ${view === "edit" ? "bg-brand-500 text-white" : "text-ink-3 hover:bg-soft"}`}
+        >
+          편집표
+        </button>
+        <button
+          onClick={() => setView("matrix")}
+          className={`rounded-lg px-3 py-1.5 font-medium ${view === "matrix" ? "bg-brand-500 text-white" : "text-ink-3 hover:bg-soft"}`}
+        >
+          가격표(매트릭스)
+        </button>
+      </div>
+
       <CategoryManager cats={cats} counts={catCounts} unsetCount={unsetCount} onChange={applyCatChange} onError={setErr} />
 
-      <AddProduct categories={cats} onCreated={onCreated} onError={setErr} />
+      {view === "matrix" ? (
+        <PriceMatrix rows={rows} configsByProduct={configsByProduct} mult={mult} onOpen={setConfigFor} />
+      ) : (
+      <>
+      <AddProduct categories={cats} brands={brands} onCreated={onCreated} onError={setErr} />
 
       {/* 검색·필터 */}
       <div className="flex flex-wrap items-center gap-2">
@@ -247,6 +282,7 @@ export default function ProductsTable({
               <th className="px-3 py-2.5 font-medium">SKU 코드</th>
               <th className="px-3 py-2.5 font-medium">상품명</th>
               <th className="px-3 py-2.5 font-medium">카테고리</th>
+              <th className="px-3 py-2.5 font-medium">브랜드</th>
               <th className="px-3 py-2.5 text-right font-medium">원가</th>
               <th className="px-3 py-2.5 text-right font-medium">소비자가</th>
               <th className="px-3 py-2.5 text-right font-medium">상시 판매가</th>
@@ -296,6 +332,9 @@ export default function ProductsTable({
                       ))}
                     </select>
                   </td>
+                  <td className="px-2 py-1.5">
+                    <TextCell value={r.brand} placeholder="—" width="w-28" list="brands" onSave={(v) => patch(r.id, "brand", v)} />
+                  </td>
                   <td className="px-2 py-1.5 text-right"><NumCell value={r.cost} onSave={(v) => patch(r.id, "cost", v)} /></td>
                   <td className="px-2 py-1.5 text-right"><NumCell value={r.consumer_price} onSave={(v) => patch(r.id, "consumer_price", v)} /></td>
                   <td className="px-2 py-1.5 text-right"><NumCell value={r.regular_price} onSave={(v) => patch(r.id, "regular_price", v)} /></td>
@@ -308,7 +347,7 @@ export default function ProductsTable({
                     />
                   </td>
                   <td className="px-2 py-1.5 text-right whitespace-nowrap">
-                    <button onClick={() => setConfigFor({ id: r.id, base_name: r.base_name })} className="rounded px-1.5 py-0.5 text-xs text-brand-600 hover:bg-brand-50">구성</button>
+                    <button onClick={() => setConfigFor(r)} className="rounded px-1.5 py-0.5 text-xs text-brand-600 hover:bg-brand-50">구성</button>
                     <button onClick={() => remove(r)} className="rounded px-1.5 py-0.5 text-xs text-red-500 hover:bg-red-50">삭제</button>
                   </td>
                 </tr>
@@ -316,14 +355,28 @@ export default function ProductsTable({
             })}
             {filtered.length === 0 && (
               <tr>
-                <td colSpan={10} className="px-3 py-8 text-center text-ink-4">조건에 맞는 상품이 없습니다.</td>
+                <td colSpan={11} className="px-3 py-8 text-center text-ink-4">조건에 맞는 상품이 없습니다.</td>
               </tr>
             )}
           </tbody>
         </table>
       </div>
+      <datalist id="brands">{brands.map((b) => <option key={b} value={b} />)}</datalist>
+      </>
+      )}
 
-      <PriceConfigDrawer product={configFor} onClose={() => setConfigFor(null)} />
+      <PriceConfigDrawer
+        product={
+          configFor
+            ? { id: configFor.id, base_name: configFor.base_name, consumer_price: configFor.consumer_price, regular_price: configFor.regular_price, cost: configFor.cost }
+            : null
+        }
+        mult={mult}
+        onClose={() => {
+          setConfigFor(null);
+          router.refresh();
+        }}
+      />
     </div>
   );
 }
@@ -430,17 +483,20 @@ function TextCell({
   value,
   placeholder,
   width,
+  list,
   onSave,
 }: {
   value: string | null;
   placeholder?: string;
   width: string;
+  list?: string;
   onSave: (v: string) => void;
 }) {
   const [draft, setDraft] = useState<string | null>(null);
   const shown = draft ?? value ?? "";
   return (
     <input
+      list={list}
       value={shown}
       placeholder={placeholder}
       onChange={(e) => setDraft(e.target.value)}
@@ -481,16 +537,18 @@ function NumCell({ value, onSave }: { value: number | null; onSave: (v: string) 
 
 function AddProduct({
   categories,
+  brands,
   onCreated,
   onError,
 }: {
   categories: string[];
+  brands: string[];
   onCreated: (r: ProductRow) => void;
   onError: (m: string) => void;
 }) {
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
-  const [f, setF] = useState({ base_name: "", dr_code: "", category: "", cost: "", consumer_price: "", regular_price: "", is_subscription: false });
+  const [f, setF] = useState({ base_name: "", dr_code: "", category: "", brand: "", cost: "", consumer_price: "", regular_price: "", is_subscription: false });
   const set = (k: keyof typeof f, v: string | boolean) => setF((s) => ({ ...s, [k]: v }));
 
   async function submit() {
@@ -513,12 +571,13 @@ function AddProduct({
         base_name: f.base_name.trim(),
         dr_code: f.dr_code.trim() || null,
         category: f.category.trim() || null,
+        brand: f.brand.trim() || null,
         cost: num(f.cost),
         consumer_price: num(f.consumer_price),
         regular_price: num(f.regular_price),
         is_subscription: f.is_subscription,
       });
-      setF({ base_name: "", dr_code: "", category: "", cost: "", consumer_price: "", regular_price: "", is_subscription: false });
+      setF({ base_name: "", dr_code: "", category: "", brand: "", cost: "", consumer_price: "", regular_price: "", is_subscription: false });
       setOpen(false);
     } catch (e) {
       onError(e instanceof Error ? e.message : "생성 실패");
@@ -552,6 +611,11 @@ function AddProduct({
             <option value="">미지정</option>
             {categories.map((c) => <option key={c} value={c}>{c}</option>)}
           </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-[11px] text-ink-4">브랜드</span>
+          <input className={`${input} w-28`} list="brands-add" value={f.brand} onChange={(e) => set("brand", e.target.value)} placeholder="(선택)" />
+          <datalist id="brands-add">{brands.map((b) => <option key={b} value={b} />)}</datalist>
         </label>
         <label className="flex flex-col gap-1">
           <span className="text-[11px] text-ink-4">원가</span>

--- a/promo-analytics/app/(dash)/products/page.tsx
+++ b/promo-analytics/app/(dash)/products/page.tsx
@@ -1,33 +1,58 @@
 import { createClient } from "@/lib/supabase/server";
-import ProductsTable, { type ProductRow } from "./ProductsTable";
+import ProductsTable, { type ProductRow, type ConfigLite } from "./ProductsTable";
 
 export const dynamic = "force-dynamic";
 
-// 상품·가격 가이드 — 웹이 단일 출처. SKU 코드·원가·판매가·카테고리를 직접 추가/수정/삭제.
+// 상품·가격 가이드 — 웹이 단일 출처. 기본정보·카테고리·브랜드·원가·상시/정기/묶음 가격을 직접 관리.
 export default async function ProductsPage() {
   const supabase = await createClient();
-  const [{ data: prod }, { data: cats }] = await Promise.all([
+  const [{ data: prod }, { data: cats }, { data: cfgs }, { data: rc }] = await Promise.all([
     supabase
       .from("products")
-      .select("id, base_name, dr_code, category, cost, consumer_price, regular_price, is_subscription")
+      .select("id, base_name, dr_code, category, brand, cost, consumer_price, regular_price, is_subscription")
       .order("dr_code", { ascending: true, nullsFirst: false })
       .order("base_name", { ascending: true }),
     supabase.from("product_categories").select("name, sort").order("sort"),
+    supabase.from("product_price_configs").select("product_id, sale_mode, config_type, sale_price, free_shipping"),
+    supabase
+      .from("rate_card")
+      .select("fee_rate, ad_rate, logistics_rate, reward_rate")
+      .eq("is_current", true)
+      .order("effective_from", { ascending: false })
+      .limit(1)
+      .maybeSingle(),
   ]);
   const rows = (prod as ProductRow[]) ?? [];
-  // 관리 목록(있으면) 우선, 없으면 상품에서 distinct 로 보완
   const managed = (cats ?? []).map((c) => c.name as string);
   const fromProducts = [...new Set(rows.map((r) => r.category).filter((c): c is string => !!c))];
   const categories = [...new Set([...managed, ...fromProducts])];
+  const brands = [...new Set(rows.map((r) => r.brand).filter((b): b is string => !!b))].sort();
+
+  const configsByProduct: Record<string, ConfigLite[]> = {};
+  for (const c of (cfgs as (ConfigLite & { product_id: string })[]) ?? []) {
+    (configsByProduct[c.product_id] ??= []).push({
+      sale_mode: c.sale_mode,
+      config_type: c.config_type,
+      sale_price: c.sale_price,
+      free_shipping: c.free_shipping,
+    });
+  }
+  const mult = rc ? 1 - (Number(rc.fee_rate) + Number(rc.ad_rate) + Number(rc.logistics_rate) + Number(rc.reward_rate)) : 0.715;
 
   return (
     <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
       <h1 className="text-xl font-semibold tracking-tight">상품 · 가격 가이드</h1>
       <p className="mt-1 text-sm text-ink-3">
-        SKU 코드 · 원가 · 소비자가 · 상시 판매가 · <strong>카테고리</strong>를 웹에서 직접 관리합니다(단일 출처).
-        카테고리는 캠페인 메인 카테고리·서브 수량 예측에 쓰이니 정확히 분류하세요. 묶음·정기 가격은 다음 단계.
+        SKU 코드·카테고리·브랜드·원가·소비자가·상시/정기/묶음 가격을 <strong>웹에서 직접</strong> 관리합니다(단일 출처).
+        가격만 입력하면 할인율·마진율·공헌이익은 자동 계산돼요. ‘가격표’ 보기로 시트형 매트릭스를 볼 수 있습니다.
       </p>
-      <ProductsTable initialRows={rows} categories={categories} />
+      <ProductsTable
+        initialRows={rows}
+        categories={categories}
+        brands={brands}
+        configsByProduct={configsByProduct}
+        mult={mult}
+      />
     </div>
   );
 }

--- a/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
@@ -1754,6 +1754,7 @@ function AddSku({ onAdd }: { onAdd: (it: ItemState) => void }) {
       .select("id, sale_price")
       .eq("product_id", h.id)
       .eq("config_type", "단품")
+      .eq("sale_mode", "상시")
       .limit(1)
       .maybeSingle();
     const seed =

--- a/promo-analytics/app/api/products/configs/route.ts
+++ b/promo-analytics/app/api/products/configs/route.ts
@@ -6,7 +6,7 @@ export const runtime = "nodejs";
 // SKU별 가격 구성(product_price_configs) 편집 — 단품/2~5묶음/정기 판매가.
 // products.consumer_price/regular_price 기준으로 할인율을 자동 계산해 함께 저장.
 
-const PACK: Record<string, number> = { 단품: 1, "2묶음": 2, "3묶음": 3, "4묶음": 4, "5묶음": 5, 정기: 1 };
+const PACK: Record<string, number> = { 단품: 1, "2묶음": 2, "3묶음": 3, "4묶음": 4, "5묶음": 5, "6묶음": 6 };
 
 async function requireUser() {
   const supabase = await createClient();
@@ -21,18 +21,19 @@ export async function GET(req: Request) {
   if (!pid) return NextResponse.json({ error: "product_id 필요" }, { status: 400 });
   const { data } = await supabase
     .from("product_price_configs")
-    .select("id, config_type, pack_count, sale_price, list_price, free_shipping, discount_rate_consumer, discount_rate_regular")
+    .select("id, sale_mode, config_type, pack_count, sale_price, list_price, free_shipping, discount_rate_consumer, discount_rate_regular")
     .eq("product_id", pid);
   return NextResponse.json({ configs: data ?? [] });
 }
 
-// 구성 추가/수정 (config_type 기준 upsert)
+// 구성 추가/수정 (sale_mode + config_type 기준 upsert)
 export async function POST(req: Request) {
   const supabase = await requireUser();
   if (!supabase) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   try {
     const b = (await req.json()) as {
       product_id?: string;
+      sale_mode?: string;
       config_type?: string;
       sale_price?: unknown;
       list_price?: unknown;
@@ -40,6 +41,7 @@ export async function POST(req: Request) {
     };
     if (!b.product_id || !b.config_type)
       return NextResponse.json({ error: "product_id·config_type 필요" }, { status: 400 });
+    const sale_mode = b.sale_mode === "정기" ? "정기" : "상시";
     const { data: prod } = await supabase
       .from("products")
       .select("base_name, consumer_price, regular_price")
@@ -53,24 +55,26 @@ export async function POST(req: Request) {
     };
     const sale = num(b.sale_price);
     const list = num(b.list_price);
+    const qty = PACK[b.config_type] ?? 1;
     const consumer = prod.consumer_price as number | null;
     const regular = prod.regular_price as number | null;
     const row = {
       product_id: b.product_id,
       base_name: prod.base_name as string,
+      sale_mode,
       config_type: b.config_type,
-      pack_count: PACK[b.config_type] ?? 1,
+      pack_count: qty,
       sale_price: sale,
       list_price: list,
-      free_shipping: !!b.free_shipping,
-      discount_rate_consumer: sale != null && consumer ? 1 - sale / (consumer * (PACK[b.config_type] ?? 1)) : null,
-      discount_rate_regular: sale != null && regular ? 1 - sale / (regular * (PACK[b.config_type] ?? 1)) : null,
+      free_shipping: sale_mode === "정기" ? true : !!b.free_shipping,
+      discount_rate_consumer: sale != null && consumer ? 1 - sale / (consumer * qty) : null,
+      discount_rate_regular: sale != null && regular ? 1 - sale / (regular * qty) : null,
       source_file: "web",
       updated_at: new Date().toISOString(),
     };
     const { error } = await supabase
       .from("product_price_configs")
-      .upsert(row, { onConflict: "product_id,config_type" });
+      .upsert(row, { onConflict: "product_id,sale_mode,config_type" });
     if (error) throw error;
     return NextResponse.json({ ok: true });
   } catch (e) {

--- a/promo-analytics/app/api/products/route.ts
+++ b/promo-analytics/app/api/products/route.ts
@@ -11,6 +11,7 @@ const ALLOWED = [
   "base_name",
   "dr_code",
   "category",
+  "brand",
   "cost",
   "consumer_price",
   "regular_price",

--- a/promo-analytics/lib/__tests__/pricing.test.ts
+++ b/promo-analytics/lib/__tests__/pricing.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import {
+  discountVsConsumer,
+  marginRate,
+  addonUnitPrice,
+  contribution,
+  contributionRate,
+} from "../pricing";
+
+// 시트 실데이터(DR10071): 소비자가 21,800 · 원가 4,512 · 상시가 12,900 · 할인 41% · 마진 65% · 추가구성 12,200
+describe("가격 매트릭스 계산 (시트와 동일)", () => {
+  it("상시가 할인율 = 1 − 상시가/소비자가", () => {
+    expect(discountVsConsumer(12900, 21800, 1)).toBeCloseTo(0.408, 3);
+  });
+  it("묶음 할인율은 소비자가×수량 기준", () => {
+    // DR10081 2묶음 47,300 / (24,900? no) — 소비자가 42,800 ×2
+    expect(discountVsConsumer(47300, 42800, 2)).toBeCloseTo(0.4474, 3);
+  });
+  it("마진율 = (상시가 − 원가)/상시가", () => {
+    expect(marginRate(12900, 4512)).toBeCloseTo(0.650, 3);
+  });
+  it("추가구성 = 상시가 × 0.95, 100원 내림", () => {
+    expect(addonUnitPrice(12900)).toBe(12200); // 12,255 → 12,200
+    expect(addonUnitPrice(24900)).toBe(23600); // 23,655 → 23,600
+  });
+  it("공헌이익 = 세트가 × mult − 원가 × 수량", () => {
+    expect(contribution(12900, 4512, 1, 0.715)).toBeCloseTo(12900 * 0.715 - 4512, 2);
+    expect(contributionRate(12900, 4512, 1, 0.715)).toBeCloseTo((12900 * 0.715 - 4512) / 12900, 4);
+  });
+  it("값 없으면 null", () => {
+    expect(discountVsConsumer(null, 1000, 1)).toBeNull();
+    expect(marginRate(null, 100)).toBeNull();
+    expect(addonUnitPrice(null)).toBeNull();
+    expect(contribution(null, 100, 1, 0.715)).toBeNull();
+  });
+});

--- a/promo-analytics/lib/priceMasterSync.ts
+++ b/promo-analytics/lib/priceMasterSync.ts
@@ -126,6 +126,7 @@ export async function applyPriceMasterCsv(
     recMap.set(`${match.id}::${c.config_type}`, {
       product_id: match.id,
       base_name: match.base_name,
+      sale_mode: "상시",
       config_type: c.config_type,
       pack_count: c.pack_count,
       free_shipping: c.free_shipping,
@@ -145,7 +146,7 @@ export async function applyPriceMasterCsv(
   for (const batch of chunk(records, 500)) {
     const { error } = await supabase
       .from("product_price_configs")
-      .upsert(batch, { onConflict: "product_id,config_type" });
+      .upsert(batch, { onConflict: "product_id,sale_mode,config_type" });
     if (error) throw new Error(error.message);
   }
 

--- a/promo-analytics/lib/pricing.ts
+++ b/promo-analytics/lib/pricing.ts
@@ -1,0 +1,49 @@
+// 가격 매트릭스 계산 — 입력값은 가격(원)만, 할인율·마진율·추가구성·공헌이익은 모두 자동 산출.
+// rate card 승수(mult, 기본 0.715) 기준. 시트(가격 마스터)와 동일한 식.
+
+export const ADDON_DISCOUNT = 0.05; // 추가구성 기본 할인 5%
+
+/** 묶음 종류 → 수량 */
+export const TIER_QTY: Record<string, number> = {
+  단품: 1,
+  "2묶음": 2,
+  "3묶음": 3,
+  "4묶음": 4,
+  "5묶음": 5,
+  "6묶음": 6,
+};
+export const SALE_MODES = ["상시", "정기"] as const;
+export type SaleMode = (typeof SALE_MODES)[number];
+export const SANGSI_TIERS = ["단품", "2묶음", "3묶음", "4묶음", "5묶음", "6묶음"] as const;
+export const JEONGGI_TIERS = ["단품", "2묶음", "4묶음"] as const; // 정기는 고정
+
+/** 소비자가 대비 할인율 (세트가 / (소비자가×수량)). 값이 없으면 null. */
+export function discountVsConsumer(setPrice: number | null, consumer: number | null, qty: number): number | null {
+  if (setPrice == null || !consumer || qty <= 0) return null;
+  return 1 - setPrice / (consumer * qty);
+}
+
+/** 마진율 = (상시가 − 원가) / 상시가 */
+export function marginRate(regular: number | null, cost: number | null): number | null {
+  if (!regular) return null;
+  return (regular - (cost ?? 0)) / regular;
+}
+
+/** 추가구성 1개당 단가 = 상시가 × (1 − 추가할인). 100원 단위 내림(시트와 동일). */
+export function addonUnitPrice(regular: number | null, discount = ADDON_DISCOUNT): number | null {
+  if (!regular) return null;
+  return Math.floor((regular * (1 - discount)) / 100) * 100;
+}
+
+/** 세트 공헌이익액 = 세트가 × mult − 원가 × 수량 */
+export function contribution(setPrice: number | null, cost: number | null, qty: number, mult: number): number | null {
+  if (setPrice == null) return null;
+  return setPrice * mult - (cost ?? 0) * qty;
+}
+
+/** 세트 공헌이익률 = 공헌이익액 / 세트가 */
+export function contributionRate(setPrice: number | null, cost: number | null, qty: number, mult: number): number | null {
+  if (!setPrice) return null;
+  const c = contribution(setPrice, cost, qty, mult);
+  return c == null ? null : c / setPrice;
+}

--- a/promo-analytics/supabase/migrations/0073_price_matrix.sql
+++ b/promo-analytics/supabase/migrations/0073_price_matrix.sql
@@ -1,0 +1,21 @@
+-- 0073: 가격 매트릭스 — 브랜드(카테고리 하위) + 상시/정기 모드 × 묶음 tier
+--
+-- products.brand: 카테고리 하위의 기초 상품 브랜드(퓨저나이트·카사벤토·포캣츄…).
+-- product_price_configs.sale_mode: '상시' | '정기'. config_type 은 묶음 tier(단품/2~6묶음).
+--   기존 단품/N묶음 = 상시, 기존 '정기'(0050~2단계) → sale_mode='정기', config_type='단품'.
+-- unique 키를 (product_id, sale_mode, config_type) 로 확장.
+
+alter table promo.products add column if not exists brand text;
+
+alter table promo.product_price_configs add column if not exists sale_mode text not null default '상시';
+
+-- 기존 '정기' 단일 tier → 정기 단품으로 이관
+update promo.product_price_configs set sale_mode='정기', config_type='단품' where config_type='정기';
+
+-- unique 키 교체 (sale_mode 포함) — 재실행 안전하게 새 제약도 먼저 drop
+alter table promo.product_price_configs drop constraint if exists product_price_configs_product_id_config_type_key;
+alter table promo.product_price_configs drop constraint if exists product_price_configs_pid_mode_type_key;
+alter table promo.product_price_configs
+  add constraint product_price_configs_pid_mode_type_key unique (product_id, sale_mode, config_type);
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
MD가 쓰는 **가격 마스터 시트 레이아웃**을 앱에 재현했습니다. 핵심 원칙: **가격만 입력 → 할인율·마진율·추가구성·공헌이익은 전부 자동계산**(레이트카드 0.715, 시트와 동일).

## 데이터 모델 (0073, 적용 완료)
- `products.brand` — 카테고리 **하위** 브랜드(퓨저나이트·카사벤토·포캣츄…)
- `product_price_configs.sale_mode` `'상시'|'정기'`, unique `(product_id, sale_mode, config_type)`. 묶음 tier 단품/2~6묶음. 기존 '정기' → 정기 단품으로 이관.

## 화면 (`/products`)
- **‘가격표(매트릭스)’ 보기 토글** — 시트와 같은 그룹 헤더: 기본 / 상시 단가 / 묶음(2~6) / 정기구독(단품·2·4묶음) / 공헌(상시·정기). 행 클릭 → 가격 구성 편집.
- **‘편집표’** — 기존 인라인 편집 + **브랜드 컬럼** 추가.
- **가격 구성 드로어** — 상시(단품/2~6묶음) + 정기(단품/2묶음/4묶음) tier별 판매가·정가·무배 입력, 할인율·공헌이익 라이브 표시.

## 계산 (`lib/pricing`, 시트 실데이터로 검증)
- 할인율 `1 − 세트가/(소비자가×수량)`, 마진율 `(상시가−원가)/상시가`
- **추가구성 = 상시가 × 0.95, 100원 내림** (예 12,900→12,200 ✓ 시트 일치)
- 공헌이익 `세트가 × 0.715 − 원가×수량`, 공헌이익률

## 검증
운영 DB 0073 적용 완료. `tsc`·`build` 통과, `npm run test` **88 passed**.

## 다음(원하시면)
- 매트릭스 **인라인 셀 편집**(현재는 드로어로 편집)
- 시트 import에 정기·묶음 매핑 확장
- 앞서 보류한 **비B2C 정리 / 세트 구성 / 품절 상태**도 이 모델 위에 얹기

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zkqVzCBpDUh7ntB3EdnLG

---
_Generated by [Claude Code](https://claude.ai/code/session_015zkqVzCBpDUh7ntB3EdnLG)_