### PR TITLE
판매 채널 + 상품 상태 — B2C 기본 표시 / 품절·단종 표기 / 상품명 전체 보기

### DIFF
--- a/promo-analytics/app/(dash)/products/PriceMatrix.tsx
+++ b/promo-analytics/app/(dash)/products/PriceMatrix.tsx
@@ -86,7 +86,12 @@ export default function PriceMatrix({
                 <td className={tdL}>{r.dr_code ?? "—"}</td>
                 <td className={tdL}>{r.brand ?? "—"}</td>
                 <td className={tdL}>{r.category ?? "—"}</td>
-                <td className={`${tdL} max-w-[260px] truncate`} title={r.base_name}>{r.base_name}</td>
+                <td className={`${tdL} max-w-[280px]`} title={r.base_name}>
+                  <span className="block truncate">{r.base_name}</span>
+                  {r.status !== "판매중" && (
+                    <span className="rounded bg-amber-100 px-1 text-[10px] text-amber-700">{r.status}</span>
+                  )}
+                </td>
                 <td className={td}>{won(consumer)}</td>
                 <td className={td}>{won(cost)}</td>
                 <td className={td}>{won(regular)}</td>

--- a/promo-analytics/app/(dash)/products/ProductsTable.tsx
+++ b/promo-analytics/app/(dash)/products/ProductsTable.tsx
@@ -12,10 +12,19 @@ export type ProductRow = {
   dr_code: string | null;
   category: string | null;
   brand: string | null;
+  channel: string;
+  status: string;
   cost: number | null;
   consumer_price: number | null;
   regular_price: number | null;
   is_subscription: boolean;
+};
+
+const STATUSES = ["판매중", "품절", "단종"] as const;
+const STATUS_TONE: Record<string, string> = {
+  판매중: "bg-success-soft text-success",
+  품절: "bg-amber-100 text-amber-700",
+  단종: "bg-neutral-200 text-neutral-600",
 };
 export type ConfigLite = {
   sale_mode: string;
@@ -44,12 +53,14 @@ export default function ProductsTable({
   initialRows,
   categories,
   brands,
+  channels,
   configsByProduct,
   mult,
 }: {
   initialRows: ProductRow[];
   categories: string[];
   brands: string[];
+  channels: string[];
   configsByProduct: Record<string, ConfigLite[]>;
   mult: number;
 }) {
@@ -57,6 +68,8 @@ export default function ProductsTable({
   const [rows, setRows] = useState<ProductRow[]>(initialRows);
   const [cats, setCats] = useState<string[]>(categories);
   const [view, setView] = useState<"edit" | "matrix">("edit");
+  const [channelF, setChannelF] = useState<string>("B2C");
+  const [statusF, setStatusF] = useState<string>("전체");
   const [q, setQ] = useState("");
   const [kindF, setKindF] = useState<KindFilter>("전체");
   const [catF, setCatF] = useState<string>("전체");
@@ -68,9 +81,15 @@ export default function ProductsTable({
   const [bulkCat, setBulkCat] = useState<string>("");
   const [configFor, setConfigFor] = useState<ProductRow | null>(null);
 
+  // 채널 필터(B2C 기본) — 편집표·가격표 공통 적용
+  const channelRows = useMemo(
+    () => (channelF === "전체" ? rows : rows.filter((r) => r.channel === channelF)),
+    [rows, channelF],
+  );
+
   const filtered = useMemo(() => {
     const term = q.trim();
-    return rows.filter((r) => {
+    return channelRows.filter((r) => {
       if (term && !(r.base_name.includes(term) || (r.dr_code ?? "").includes(term))) return false;
       const k = productKind(r.base_name);
       if (kindF === "판매" && !SELLABLE_KINDS.includes(k)) return false;
@@ -78,10 +97,11 @@ export default function ProductsTable({
       if (kindF === "기타" && k !== "기타") return false;
       if (catF === UNSET && r.category) return false;
       if (catF !== "전체" && catF !== UNSET && (r.category ?? "") !== catF) return false;
+      if (statusF !== "전체" && r.status !== statusF) return false;
       if (missingOnly && r.cost != null && r.consumer_price != null && r.regular_price != null) return false;
       return true;
     });
-  }, [rows, q, kindF, catF, missingOnly]);
+  }, [channelRows, q, kindF, catF, statusF, missingOnly]);
 
   const catCounts = useMemo(() => {
     const m = new Map<string, number>();
@@ -215,7 +235,19 @@ export default function ProductsTable({
       <CategoryManager cats={cats} counts={catCounts} unsetCount={unsetCount} onChange={applyCatChange} onError={setErr} />
 
       {view === "matrix" ? (
-        <PriceMatrix rows={rows} configsByProduct={configsByProduct} mult={mult} onOpen={setConfigFor} />
+        <>
+          <div className="flex flex-wrap items-center gap-2">
+            <select value={channelF} onChange={(e) => setChannelF(e.target.value)} className="rounded-xl border border-line bg-card px-2.5 py-2 text-sm">
+              <option value="B2C">B2C (기본)</option>
+              <option value="전체">채널 전체</option>
+              {channels.filter((c) => c !== "B2C").map((c) => (
+                <option key={c} value={c}>{c}</option>
+              ))}
+            </select>
+            <span className="text-xs text-ink-4">{channelRows.length}개</span>
+          </div>
+          <PriceMatrix rows={channelRows} configsByProduct={configsByProduct} mult={mult} onOpen={setConfigFor} />
+        </>
       ) : (
       <>
       <AddProduct categories={cats} brands={brands} onCreated={onCreated} onError={setErr} />
@@ -241,11 +273,24 @@ export default function ProductsTable({
             <option key={c} value={c}>{c} ({catCounts.get(c) ?? 0})</option>
           ))}
         </select>
+        <select value={channelF} onChange={(e) => setChannelF(e.target.value)} className="rounded-xl border border-line bg-card px-2.5 py-2 text-sm">
+          <option value="B2C">B2C (기본)</option>
+          <option value="전체">채널 전체</option>
+          {channels.filter((c) => c !== "B2C").map((c) => (
+            <option key={c} value={c}>{c}</option>
+          ))}
+        </select>
+        <select value={statusF} onChange={(e) => setStatusF(e.target.value)} className="rounded-xl border border-line bg-card px-2.5 py-2 text-sm">
+          <option value="전체">상태 전체</option>
+          {STATUSES.map((s) => (
+            <option key={s} value={s}>{s}</option>
+          ))}
+        </select>
         <label className="flex items-center gap-1.5 text-sm text-ink-3">
           <input type="checkbox" checked={missingOnly} onChange={(e) => setMissingOnly(e.target.checked)} />
           가격·원가 누락만
         </label>
-        <span className="ml-auto text-xs text-ink-4">{filtered.length} / {rows.length}개</span>
+        <span className="ml-auto text-xs text-ink-4">{filtered.length} / {channelRows.length}개</span>
       </div>
 
       {/* 선택 일괄 카테고리 적용 */}
@@ -274,7 +319,7 @@ export default function ProductsTable({
       {err && <p className="text-sm text-danger">{err}</p>}
 
       <div className="overflow-x-auto rounded-2xl card-soft">
-        <table className="w-full min-w-[980px] text-sm">
+        <table className="w-full min-w-[1180px] text-sm">
           <thead className="bg-soft/60 text-left text-xs text-ink-3">
             <tr>
               <th className="px-3 py-2.5"><input type="checkbox" checked={allSelected} onChange={toggleAll} aria-label="전체 선택" /></th>
@@ -283,6 +328,7 @@ export default function ProductsTable({
               <th className="px-3 py-2.5 font-medium">상품명</th>
               <th className="px-3 py-2.5 font-medium">카테고리</th>
               <th className="px-3 py-2.5 font-medium">브랜드</th>
+              <th className="px-3 py-2.5 font-medium">상태</th>
               <th className="px-3 py-2.5 text-right font-medium">원가</th>
               <th className="px-3 py-2.5 text-right font-medium">소비자가</th>
               <th className="px-3 py-2.5 text-right font-medium">상시 판매가</th>
@@ -316,7 +362,7 @@ export default function ProductsTable({
                     <TextCell value={r.dr_code} placeholder="없음" width="w-24" onSave={(v) => patch(r.id, "dr_code", v)} />
                   </td>
                   <td className="px-2 py-1.5">
-                    <TextCell value={r.base_name} width="w-72" onSave={(v) => patch(r.id, "base_name", v)} />
+                    <TextCell value={r.base_name} width="w-[26rem]" onSave={(v) => patch(r.id, "base_name", v)} />
                   </td>
                   <td className="px-2 py-1.5">
                     <select
@@ -334,6 +380,18 @@ export default function ProductsTable({
                   </td>
                   <td className="px-2 py-1.5">
                     <TextCell value={r.brand} placeholder="—" width="w-28" list="brands" onSave={(v) => patch(r.id, "brand", v)} />
+                  </td>
+                  <td className="px-2 py-1.5">
+                    <select
+                      value={r.status}
+                      disabled={savingId === r.id}
+                      onChange={(e) => patch(r.id, "status", e.target.value)}
+                      className={`rounded-full px-2 py-0.5 text-[11px] font-medium focus:outline-none ${STATUS_TONE[r.status] ?? "bg-neutral-100 text-neutral-500"}`}
+                    >
+                      {STATUSES.map((s) => (
+                        <option key={s} value={s}>{s}</option>
+                      ))}
+                    </select>
                   </td>
                   <td className="px-2 py-1.5 text-right"><NumCell value={r.cost} onSave={(v) => patch(r.id, "cost", v)} /></td>
                   <td className="px-2 py-1.5 text-right"><NumCell value={r.consumer_price} onSave={(v) => patch(r.id, "consumer_price", v)} /></td>
@@ -355,7 +413,7 @@ export default function ProductsTable({
             })}
             {filtered.length === 0 && (
               <tr>
-                <td colSpan={11} className="px-3 py-8 text-center text-ink-4">조건에 맞는 상품이 없습니다.</td>
+                <td colSpan={12} className="px-3 py-8 text-center text-ink-4">조건에 맞는 상품이 없습니다.</td>
               </tr>
             )}
           </tbody>
@@ -572,6 +630,8 @@ function AddProduct({
         dr_code: f.dr_code.trim() || null,
         category: f.category.trim() || null,
         brand: f.brand.trim() || null,
+        channel: "B2C",
+        status: "판매중",
         cost: num(f.cost),
         consumer_price: num(f.consumer_price),
         regular_price: num(f.regular_price),

--- a/promo-analytics/app/(dash)/products/page.tsx
+++ b/promo-analytics/app/(dash)/products/page.tsx
@@ -9,7 +9,7 @@ export default async function ProductsPage() {
   const [{ data: prod }, { data: cats }, { data: cfgs }, { data: rc }] = await Promise.all([
     supabase
       .from("products")
-      .select("id, base_name, dr_code, category, brand, cost, consumer_price, regular_price, is_subscription")
+      .select("id, base_name, dr_code, category, brand, channel, status, cost, consumer_price, regular_price, is_subscription")
       .order("dr_code", { ascending: true, nullsFirst: false })
       .order("base_name", { ascending: true }),
     supabase.from("product_categories").select("name, sort").order("sort"),
@@ -27,6 +27,7 @@ export default async function ProductsPage() {
   const fromProducts = [...new Set(rows.map((r) => r.category).filter((c): c is string => !!c))];
   const categories = [...new Set([...managed, ...fromProducts])];
   const brands = [...new Set(rows.map((r) => r.brand).filter((b): b is string => !!b))].sort();
+  const channels = [...new Set(rows.map((r) => r.channel).filter(Boolean))].sort();
 
   const configsByProduct: Record<string, ConfigLite[]> = {};
   for (const c of (cfgs as (ConfigLite & { product_id: string })[]) ?? []) {
@@ -50,6 +51,7 @@ export default async function ProductsPage() {
         initialRows={rows}
         categories={categories}
         brands={brands}
+        channels={channels}
         configsByProduct={configsByProduct}
         mult={mult}
       />

--- a/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
@@ -1716,6 +1716,8 @@ type SearchHit = {
   consumer_price: number | null;
   regular_price: number | null;
   cost: number | null;
+  channel?: string | null;
+  status?: string | null;
 };
 
 function AddSku({ onAdd }: { onAdd: (it: ItemState) => void }) {
@@ -1733,14 +1735,17 @@ function AddSku({ onAdd }: { onAdd: (it: ItemState) => void }) {
     const safe = v.replace(/[,()%]/g, " ").trim();
     const { data } = await supabase
       .from("products")
-      .select("id, base_name, dr_code, consumer_price, regular_price, cost")
+      .select("id, base_name, dr_code, consumer_price, regular_price, cost, channel, status")
       .or(`base_name.ilike.%${safe}%,dr_code.ilike.%${safe}%`)
-      .limit(30);
+      .limit(40);
     const clear = ((data as SearchHit[]) ?? []).filter(
       // 불분명 품목(상품코드·소비자가·상시가 전부 없는, 성과에서 이름만 자동생성된 것) 숨김
       (h) => (h.dr_code || h.consumer_price || h.regular_price) &&
         // 원재료·부재료·부자재(비판매 구성품)는 옵션에 담지 않으므로 제외
-        !isComponentName(h.base_name),
+        !isComponentName(h.base_name) &&
+        // 비B2C 채널·품절·단종은 옵션에서 제외(채널 미지정=구버전 데이터는 허용)
+        (h.channel == null || h.channel === "B2C") &&
+        h.status !== "품절" && h.status !== "단종",
     );
     setHits(clear.slice(0, 8));
     setOpen(true);

--- a/promo-analytics/app/api/products/route.ts
+++ b/promo-analytics/app/api/products/route.ts
@@ -12,6 +12,8 @@ const ALLOWED = [
   "dr_code",
   "category",
   "brand",
+  "channel",
+  "status",
   "cost",
   "consumer_price",
   "regular_price",

--- a/promo-analytics/supabase/migrations/0074_channel_status.sql
+++ b/promo-analytics/supabase/migrations/0074_channel_status.sql
@@ -1,0 +1,13 @@
+-- 0074: 판매 채널 + 상품 상태 (B2C MD 운영 정리)
+-- channel: 'B2C'(기본) 외 다이소·대만 등 비B2C 채널 구분 → B2C MD 화면은 B2C만 기본 노출.
+-- status: '판매중'(기본)/'품절'/'단종' → 뱃지·필터, 품절·단종은 옵션 검색에서 자동 제외.
+alter table promo.products add column if not exists channel text not null default 'B2C';
+alter table promo.products add column if not exists status  text not null default '판매중';
+
+-- 이름 마커로 1차 백필 (이후 웹에서 직접 수정)
+update promo.products set channel='다이소' where channel='B2C' and base_name ilike '%다이소%';
+update promo.products set channel='대만'   where channel='B2C' and base_name ilike '%대만%';
+update promo.products set status='단종' where status='판매중' and base_name ilike '%단종%';
+update promo.products set status='품절' where status='판매중' and base_name ilike '%품절%';
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
B2C 브랜드팀 MD가 **자기 채널만 깔끔하게** 보고, **품절·단종**을 표기·관리하도록 — 앞서 보류했던 운영 정리입니다.

## 변경
- **`0074` 마이그레이션** — `products.channel`(`'B2C'` 기본) + `products.status`(`'판매중'|'품절'|'단종'`). 이름 마커로 1차 백필(다이소 7 · 대만 17 · 단종 1, 나머지 B2C 396).
- **비B2C 채널 분리** — `/products`에 **채널 필터(B2C 기본)**. 편집표·가격표 공통, 비B2C는 ‘채널 전체’/해당 채널로만 노출(삭제 아님, 데이터 보존·되돌리기 쉬움). ※ 다른 채널은 채널 컬럼에서 직접 지정.
- **품절/단종 표기** — 상태 컬럼(뱃지 + 드롭다운 편집) + 상태 필터. 가격표에는 품절/단종 뱃지.
- **상품명 전체 보기** — 컬럼 폭 확대.
- **캠페인 옵션 검색에서 자동 제외** — 비B2C 채널·품절·단종 SKU는 옵션 추가 검색에 안 뜸(구버전 채널 미지정 데이터는 허용).
- API `products`: `channel`·`status` 허용.

운영 DB `0074` **적용 완료**. `tsc`·`build` 통과, `npm run test` **88 passed**.

## 처리 방식 메모
비B2C는 **삭제 대신 채널 구분으로 숨김**(추천안)으로 갔습니다 — 미참조라 삭제도 가능하지만, 시트 재가져오기 시 되살아나고 복구가 안 돼서요. 영구 삭제를 원하시면 말씀해 주세요.

## 남은 다음 단계
- 세트 구성(BOM) 편집 · 매트릭스 인라인 셀 편집

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zkqVzCBpDUh7ntB3EdnLG

---
_Generated by [Claude Code](https://claude.ai/code/session_015zkqVzCBpDUh7ntB3EdnLG)_