### PR TITLE
세트 구성(BOM) + 가격 매트릭스 인라인 편집

### DIFF
--- a/promo-analytics/app/(dash)/products/PriceConfigDrawer.tsx
+++ b/promo-analytics/app/(dash)/products/PriceConfigDrawer.tsx
@@ -2,7 +2,9 @@
 
 import { useEffect, useState } from "react";
 import { Drawer, DrawerContent } from "@/components/ui/Drawer";
-import { won, pctFloor } from "@/lib/format";
+import { createClient } from "@/lib/supabase/client";
+import { won, pctFloor, num } from "@/lib/format";
+import { productKind } from "@/lib/products";
 import {
   TIER_QTY,
   SANGSI_TIERS,
@@ -126,6 +128,8 @@ export default function PriceConfigDrawer({
                 onSave={save}
                 onDelete={del}
               />
+
+              {productKind(product.base_name) === "세트" && <SetItems setProduct={product} />}
             </div>
           )}
         </DrawerContent>
@@ -259,6 +263,127 @@ function TierRow({
       {saleNum != null && (
         <div className="mt-1 text-[11px] text-ink-4">
           소비자가 대비 {pctFloor(disc)} · 공헌이익 {won(contrib)} ({pctFloor(cRate)})
+        </div>
+      )}
+    </div>
+  );
+}
+
+type SetItem = { id: string; child_product_id: string; qty: number; base_name: string; dr_code: string | null; cost: number | null };
+type ChildHit = { id: string; base_name: string; dr_code: string | null; cost: number | null };
+
+function SetItems({ setProduct }: { setProduct: DrawerProduct }) {
+  const [items, setItems] = useState<SetItem[]>([]);
+  const [err, setErr] = useState<string | null>(null);
+  const [q, setQ] = useState("");
+  const [hits, setHits] = useState<ChildHit[]>([]);
+  const [open, setOpen] = useState(false);
+
+  async function load() {
+    const res = await fetch(`/api/products/set-items?set_id=${setProduct.id}`);
+    if (res.ok) setItems((await res.json()).items ?? []);
+  }
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [setProduct.id]);
+
+  async function search(v: string) {
+    setQ(v);
+    if (v.trim().length < 1) { setHits([]); return; }
+    const safe = v.replace(/[,()%]/g, " ").trim();
+    const { data } = await createClient()
+      .from("products")
+      .select("id, base_name, dr_code, cost")
+      .or(`base_name.ilike.%${safe}%,dr_code.ilike.%${safe}%`)
+      .limit(8);
+    setHits((data as ChildHit[]) ?? []);
+    setOpen(true);
+  }
+  async function add(h: ChildHit) {
+    setErr(null);
+    setQ(""); setHits([]); setOpen(false);
+    const res = await fetch("/api/products/set-items", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ set_product_id: setProduct.id, child_product_id: h.id, qty: 1 }),
+    });
+    if (!res.ok) { setErr((await res.json()).error ?? "추가 실패"); return; }
+    load();
+  }
+  async function setQty(it: SetItem, qty: number) {
+    setItems((xs) => xs.map((x) => (x.id === it.id ? { ...x, qty } : x)));
+    await fetch("/api/products/set-items", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ set_product_id: setProduct.id, child_product_id: it.child_product_id, qty }),
+    });
+  }
+  async function remove(id: string) {
+    setItems((xs) => xs.filter((x) => x.id !== id));
+    await fetch("/api/products/set-items", { method: "DELETE", headers: { "content-type": "application/json" }, body: JSON.stringify({ id }) });
+  }
+  async function fillCost() {
+    const res = await fetch("/api/products", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: setProduct.id, cost: totalCost }),
+    });
+    if (!res.ok) setErr((await res.json()).error ?? "원가 반영 실패");
+  }
+
+  const totalCost = items.reduce((s, it) => s + (it.cost ?? 0) * it.qty, 0);
+
+  return (
+    <div>
+      <h3 className="text-sm font-semibold text-ink-2">세트 구성 (BOM)</h3>
+      {err && <p className="mt-1 text-xs text-danger">{err}</p>}
+      <div className="mt-2 space-y-1.5">
+        {items.map((it) => (
+          <div key={it.id} className="flex items-center gap-2 rounded-lg border border-line px-2.5 py-1.5 text-sm">
+            <span className="min-w-0 flex-1 truncate" title={it.base_name}>{it.base_name}</span>
+            <span className="shrink-0 text-[11px] text-ink-4">원가 {won(it.cost)}</span>
+            <input
+              type="number"
+              min={1}
+              value={it.qty}
+              onChange={(e) => setQty(it, Math.max(1, Number(e.target.value) || 1))}
+              className="w-14 shrink-0 rounded border border-line px-1.5 py-1 text-right text-sm"
+            />
+            <button onClick={() => remove(it.id)} className="shrink-0 text-xs text-red-500 hover:underline">✕</button>
+          </div>
+        ))}
+        {items.length === 0 && <p className="text-xs text-ink-4">구성 SKU가 없습니다. 아래에서 추가하세요.</p>}
+      </div>
+
+      <div className="relative mt-2">
+        <input
+          value={q}
+          onChange={(e) => search(e.target.value)}
+          onFocus={() => hits.length && setOpen(true)}
+          placeholder="+ 구성 SKU 추가 — 품목명/코드 검색"
+          className="w-full rounded-lg border border-line bg-card px-2.5 py-1.5 text-sm focus:border-brand-400 focus:outline-none"
+        />
+        {open && hits.length > 0 && (
+          <ul className="absolute z-10 mt-1 max-h-56 w-full overflow-auto rounded-lg border border-neutral-200 bg-white shadow-lg">
+            {hits.map((h) => (
+              <li key={h.id}>
+                <button onClick={() => add(h)} className="flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left text-sm hover:bg-neutral-50">
+                  <span className="truncate">{h.base_name}</span>
+                  <span className="shrink-0 text-xs text-neutral-400">원가 {won(h.cost)}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {items.length > 0 && (
+        <div className="mt-2 flex items-center justify-between text-[11px] text-ink-4">
+          <span>구성 원가 합 = <b className="text-ink-2">{won(totalCost)}</b> (구성 {num(items.length)}종)</span>
+          <button onClick={fillCost} className="rounded-lg border border-line px-2.5 py-1 font-medium text-ink-2 hover:bg-soft">
+            세트 원가로 반영
+          </button>
         </div>
       )}
     </div>

--- a/promo-analytics/app/(dash)/products/PriceMatrix.tsx
+++ b/promo-analytics/app/(dash)/products/PriceMatrix.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { won, pctFloor } from "@/lib/format";
 import {
   TIER_QTY,
@@ -14,17 +15,24 @@ import type { ProductRow, ConfigLite } from "./ProductsTable";
 const SANGSI_BUNDLES = ["2묶음", "3묶음", "4묶음", "5묶음", "6묶음"];
 const JEONGGI = ["단품", "2묶음", "4묶음"];
 
-// 시트형 가격 매트릭스(읽기). 가격만 보고, 행 클릭 시 가격 구성 편집 드로어 열림.
+type BaseField = "consumer_price" | "cost" | "regular_price";
+
+// 시트형 가격 매트릭스. 가격 셀(소비자가·원가·상시가 + 묶음/정기 판매가)은 인라인 편집,
+// 할인율·마진율·추가구성·공헌이익은 자동 계산(읽기).
 export default function PriceMatrix({
   rows,
   configsByProduct,
   mult,
   onOpen,
+  onPatchBase,
+  onSaveConfig,
 }: {
   rows: ProductRow[];
   configsByProduct: Record<string, ConfigLite[]>;
   mult: number;
   onOpen: (r: ProductRow) => void;
+  onPatchBase: (id: string, field: BaseField, value: string) => void;
+  onSaveConfig: (id: string, mode: string, type: string, value: string) => void;
 }) {
   const price = (pid: string, mode: string, type: string): number | null => {
     const c = (configsByProduct[pid] ?? []).find((x) => x.sale_mode === mode && x.config_type === type);
@@ -32,16 +40,17 @@ export default function PriceMatrix({
   };
 
   const th = "border border-line/60 px-2 py-1 font-medium whitespace-nowrap";
-  const td = "border border-line/50 px-2 py-1 text-right tabular-nums whitespace-nowrap";
+  const td = "border border-line/50 px-1 py-0.5 text-right tabular-nums whitespace-nowrap";
   const tdL = "border border-line/50 px-2 py-1 text-left whitespace-nowrap";
 
   return (
     <div className="mt-3 overflow-x-auto rounded-2xl card-soft">
-      <table className="min-w-[1600px] border-collapse text-[11px]">
+      <p className="px-3 pt-2 text-[11px] text-ink-4">파란 셀은 클릭해 바로 수정(가격만). 할인율·마진율·공헌이익은 자동 계산돼요.</p>
+      <table className="min-w-[1680px] border-collapse text-[11px]">
         <thead>
           <tr className="bg-soft text-ink-3">
-            <th className={th} colSpan={4}>기본</th>
-            <th className={`${th} bg-neutral-50`} colSpan={6}>상시 단가</th>
+            <th className={th} colSpan={5}>기본</th>
+            <th className={`${th} bg-neutral-50`} colSpan={4}>상시 단가</th>
             <th className={`${th} bg-green-50`} colSpan={SANGSI_BUNDLES.length}>묶음 (상시)</th>
             <th className={`${th} bg-purple-50`} colSpan={JEONGGI.length}>정기구독</th>
             <th className={`${th} bg-rose-50`} colSpan={2}>공헌(상시)</th>
@@ -52,12 +61,11 @@ export default function PriceMatrix({
             <th className={th}>브랜드</th>
             <th className={th}>카테고리</th>
             <th className={th}>상품명</th>
+            <th className={th}></th>
             <th className={th}>소비자가</th>
             <th className={th}>원가</th>
             <th className={th}>상시가</th>
-            <th className={th}>할인율</th>
-            <th className={th}>마진율</th>
-            <th className={th}>추가구성</th>
+            <th className={th}>할인/마진/추가</th>
             {SANGSI_BUNDLES.map((t) => (
               <th key={t} className={`${th} bg-green-50/50`}>{t}</th>
             ))}
@@ -77,61 +85,41 @@ export default function PriceMatrix({
             const regular = r.regular_price;
             const cost = r.cost;
             return (
-              <tr
-                key={r.id}
-                onClick={() => onOpen(r)}
-                className="cursor-pointer text-ink-2 hover:bg-brand-50/40"
-                title="클릭하면 가격 구성 편집"
-              >
+              <tr key={r.id} className="text-ink-2 hover:bg-soft/30">
                 <td className={tdL}>{r.dr_code ?? "—"}</td>
                 <td className={tdL}>{r.brand ?? "—"}</td>
                 <td className={tdL}>{r.category ?? "—"}</td>
-                <td className={`${tdL} max-w-[280px]`} title={r.base_name}>
+                <td className={`${tdL} max-w-[260px]`} title={r.base_name}>
                   <span className="block truncate">{r.base_name}</span>
-                  {r.status !== "판매중" && (
-                    <span className="rounded bg-amber-100 px-1 text-[10px] text-amber-700">{r.status}</span>
-                  )}
+                  {r.status !== "판매중" && <span className="rounded bg-amber-100 px-1 text-[10px] text-amber-700">{r.status}</span>}
                 </td>
-                <td className={td}>{won(consumer)}</td>
-                <td className={td}>{won(cost)}</td>
-                <td className={td}>{won(regular)}</td>
-                <td className={td}>{pctFloor(discountVsConsumer(regular, consumer, 1))}</td>
-                <td className={td}>{pctFloor(marginRate(regular, cost))}</td>
-                <td className={td}>{won(addonUnitPrice(regular))}</td>
-                {SANGSI_BUNDLES.map((t) => {
-                  const p = price(r.id, "상시", t);
-                  return (
-                    <td key={t} className={`${td} bg-green-50/30`}>
-                      {p != null ? (
-                        <>
-                          {won(p)}
-                          <span className="ml-1 text-[10px] text-ink-4">{pctFloor(discountVsConsumer(p, consumer, TIER_QTY[t]))}</span>
-                        </>
-                      ) : "—"}
-                    </td>
-                  );
-                })}
-                {JEONGGI.map((t) => {
-                  const p = price(r.id, "정기", t);
-                  return (
-                    <td key={t} className={`${td} bg-purple-50/30`}>
-                      {p != null ? (
-                        <>
-                          {won(p)}
-                          <span className="ml-1 text-[10px] text-ink-4">{pctFloor(discountVsConsumer(p, consumer, TIER_QTY[t]))}</span>
-                        </>
-                      ) : "—"}
-                    </td>
-                  );
-                })}
+                <td className="border border-line/50 px-1 py-0.5 text-center">
+                  <button onClick={() => onOpen(r)} className="rounded px-1 text-[10px] text-brand-600 hover:bg-brand-50" title="가격 구성·세트 편집">구성</button>
+                </td>
+                <td className={td}><EditNum value={consumer} onSave={(v) => onPatchBase(r.id, "consumer_price", v)} /></td>
+                <td className={td}><EditNum value={cost} onSave={(v) => onPatchBase(r.id, "cost", v)} /></td>
+                <td className={td}><EditNum value={regular} onSave={(v) => onPatchBase(r.id, "regular_price", v)} /></td>
+                <td className={`${td} text-[10px] text-ink-4`}>
+                  {pctFloor(discountVsConsumer(regular, consumer, 1))} / {pctFloor(marginRate(regular, cost))} / {won(addonUnitPrice(regular))}
+                </td>
+                {SANGSI_BUNDLES.map((t) => (
+                  <td key={t} className={`${td} bg-green-50/30`}>
+                    <EditNum value={price(r.id, "상시", t)} onSave={(v) => onSaveConfig(r.id, "상시", t, v)} />
+                    <span className="block text-[10px] text-ink-4">{pctFloor(discountVsConsumer(price(r.id, "상시", t), consumer, TIER_QTY[t]))}</span>
+                  </td>
+                ))}
+                {JEONGGI.map((t) => (
+                  <td key={t} className={`${td} bg-purple-50/30`}>
+                    <EditNum value={price(r.id, "정기", t)} onSave={(v) => onSaveConfig(r.id, "정기", t, v)} />
+                    <span className="block text-[10px] text-ink-4">{pctFloor(discountVsConsumer(price(r.id, "정기", t), consumer, TIER_QTY[t]))}</span>
+                  </td>
+                ))}
                 <td className={`${td} bg-rose-50/30`}>{won(contribution(regular, cost, 1, mult))}</td>
                 <td className={`${td} bg-rose-50/30`}>{pctFloor(contributionRate(regular, cost, 1, mult))}</td>
                 {JEONGGI.map((t) => {
                   const p = price(r.id, "정기", t);
                   return (
-                    <td key={t} className={`${td} bg-rose-50/30`}>
-                      {p != null ? won(contribution(p, cost, TIER_QTY[t], mult)) : "—"}
-                    </td>
+                    <td key={t} className={`${td} bg-rose-50/30`}>{p != null ? won(contribution(p, cost, TIER_QTY[t], mult)) : "—"}</td>
                   );
                 })}
               </tr>
@@ -145,5 +133,28 @@ export default function PriceMatrix({
         </tbody>
       </table>
     </div>
+  );
+}
+
+// 인라인 숫자 셀 — 콤마 표시, 변경 시 blur 저장.
+function EditNum({ value, onSave }: { value: number | null; onSave: (v: string) => void }) {
+  const [draft, setDraft] = useState<string | null>(null);
+  const shown = draft ?? (value != null ? value.toLocaleString("ko-KR") : "");
+  return (
+    <input
+      value={shown}
+      inputMode="numeric"
+      placeholder="—"
+      onChange={(e) => setDraft(e.target.value.replace(/[^0-9.]/g, ""))}
+      onBlur={() => {
+        if (draft != null && Number(draft || "0") !== (value ?? 0)) onSave(draft);
+        setDraft(null);
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") (e.target as HTMLInputElement).blur();
+        if (e.key === "Escape") setDraft(null);
+      }}
+      className="w-20 rounded border border-transparent bg-blue-50/40 px-1 py-0.5 text-right tabular-nums hover:border-line focus:border-brand-400 focus:bg-card focus:outline-none"
+    />
   );
 }

--- a/promo-analytics/app/(dash)/products/ProductsTable.tsx
+++ b/promo-analytics/app/(dash)/products/ProductsTable.tsx
@@ -80,6 +80,26 @@ export default function ProductsTable({
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [bulkCat, setBulkCat] = useState<string>("");
   const [configFor, setConfigFor] = useState<ProductRow | null>(null);
+  const [configs, setConfigs] = useState<Record<string, ConfigLite[]>>(configsByProduct);
+
+  // 가격표 인라인: tier 판매가 저장 + 로컬 반영
+  async function saveConfig(productId: string, sale_mode: string, config_type: string, sale: string) {
+    setErr(null);
+    const saleNum = sale.trim() === "" ? null : Number(sale.replace(/[^0-9.]/g, ""));
+    setConfigs((prev) => {
+      const list = [...(prev[productId] ?? [])];
+      const i = list.findIndex((c) => c.sale_mode === sale_mode && c.config_type === config_type);
+      if (i >= 0) list[i] = { ...list[i], sale_price: saleNum };
+      else list.push({ sale_mode, config_type, sale_price: saleNum, free_shipping: sale_mode === "정기" });
+      return { ...prev, [productId]: list };
+    });
+    const res = await fetch("/api/products/configs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ product_id: productId, sale_mode, config_type, sale_price: sale, free_shipping: sale_mode === "정기" }),
+    });
+    if (!res.ok) setErr((await res.json()).error ?? "가격 저장 실패");
+  }
 
   // 채널 필터(B2C 기본) — 편집표·가격표 공통 적용
   const channelRows = useMemo(
@@ -246,7 +266,14 @@ export default function ProductsTable({
             </select>
             <span className="text-xs text-ink-4">{channelRows.length}개</span>
           </div>
-          <PriceMatrix rows={channelRows} configsByProduct={configsByProduct} mult={mult} onOpen={setConfigFor} />
+          <PriceMatrix
+            rows={channelRows}
+            configsByProduct={configs}
+            mult={mult}
+            onOpen={setConfigFor}
+            onPatchBase={(id, field, val) => patch(id, field, val)}
+            onSaveConfig={saveConfig}
+          />
         </>
       ) : (
       <>

--- a/promo-analytics/app/api/products/set-items/route.ts
+++ b/promo-analytics/app/api/products/set-items/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export const runtime = "nodejs";
+
+// 세트 구성(BOM) — (세트) 상품의 자식 SKU + 수량.
+async function requireUser() {
+  const supabase = await createClient();
+  const { data } = await supabase.auth.getUser();
+  return data.user ? supabase : null;
+}
+
+export async function GET(req: Request) {
+  const supabase = await requireUser();
+  if (!supabase) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  const setId = new URL(req.url).searchParams.get("set_id");
+  if (!setId) return NextResponse.json({ error: "set_id 필요" }, { status: 400 });
+  const { data } = await supabase
+    .from("product_set_items")
+    .select("id, child_product_id, qty, sort, child:products!product_set_items_child_product_id_fkey(base_name, dr_code, cost)")
+    .eq("set_product_id", setId)
+    .order("sort");
+  const items = (data ?? []).map((r) => {
+    const child = Array.isArray(r.child) ? r.child[0] : r.child;
+    return {
+      id: r.id as string,
+      child_product_id: r.child_product_id as string,
+      qty: r.qty as number,
+      base_name: (child?.base_name as string) ?? "",
+      dr_code: (child?.dr_code as string | null) ?? null,
+      cost: (child?.cost as number | null) ?? null,
+    };
+  });
+  return NextResponse.json({ items });
+}
+
+export async function POST(req: Request) {
+  const supabase = await requireUser();
+  if (!supabase) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  try {
+    const b = (await req.json()) as { set_product_id?: string; child_product_id?: string; qty?: unknown };
+    if (!b.set_product_id || !b.child_product_id)
+      return NextResponse.json({ error: "set_product_id·child_product_id 필요" }, { status: 400 });
+    if (b.set_product_id === b.child_product_id)
+      return NextResponse.json({ error: "세트 자신을 구성으로 넣을 수 없습니다." }, { status: 400 });
+    const qty = Math.max(1, Number(b.qty) || 1);
+    const { error } = await supabase
+      .from("product_set_items")
+      .upsert(
+        { set_product_id: b.set_product_id, child_product_id: b.child_product_id, qty },
+        { onConflict: "set_product_id,child_product_id" },
+      );
+    if (error) throw error;
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    return NextResponse.json({ error: e instanceof Error ? e.message : "저장 실패" }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: Request) {
+  const supabase = await requireUser();
+  if (!supabase) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  try {
+    const { id } = (await req.json()) as { id?: string };
+    if (!id) return NextResponse.json({ error: "id 필요" }, { status: 400 });
+    const { error } = await supabase.from("product_set_items").delete().eq("id", id);
+    if (error) throw error;
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    return NextResponse.json({ error: e instanceof Error ? e.message : "삭제 실패" }, { status: 500 });
+  }
+}

--- a/promo-analytics/supabase/migrations/0075_product_set_items.sql
+++ b/promo-analytics/supabase/migrations/0075_product_set_items.sql
@@ -1,0 +1,19 @@
+-- 0075: 세트 구성(BOM) — (세트) 상품이 어떤 SKU 로 구성되는지(자식 SKU + 수량)
+create table if not exists promo.product_set_items (
+  id uuid primary key default gen_random_uuid(),
+  set_product_id   uuid not null references promo.products(id) on delete cascade,
+  child_product_id uuid not null references promo.products(id) on delete cascade,
+  qty integer not null default 1,
+  sort int not null default 0,
+  created_at timestamptz not null default now(),
+  unique (set_product_id, child_product_id)
+);
+create index if not exists product_set_items_set_idx on promo.product_set_items (set_product_id);
+
+alter table promo.product_set_items enable row level security;
+drop policy if exists product_set_items_auth_all on promo.product_set_items;
+create policy product_set_items_auth_all on promo.product_set_items
+  for all to authenticated using (true) with check (true);
+grant all on promo.product_set_items to authenticated, service_role;
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
남은 두 단계를 한 번에 마무리했습니다.

## 1) 세트 구성 (BOM)
- **`0075`** — `product_set_items`(세트 상품 → 자식 SKU + 수량).
- **`/api/products/set-items`** — GET/POST(upsert)/DELETE.
- **가격 구성 드로어**에 `(세트)` 상품일 때 **‘세트 구성(BOM)’ 섹션** — 자식 SKU 검색·수량·삭제, **구성 원가 합** + **‘세트 원가로 반영’**.

## 2) 가격 매트릭스 인라인 편집
- 매트릭스의 **소비자가·원가·상시가 + 묶음(2~6)·정기(단품/2/4) 판매가**를 **셀에서 바로 수정**(파란 셀, blur 저장·낙관적 반영). 할인율·마진율·추가구성·공헌이익 자동 재계산. 행 **‘구성’** 버튼으로 드로어.

운영 DB `0075` 적용 완료. `tsc`·`build` 통과, `npm run test` **88 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zkqVzCBpDUh7ntB3EdnLG

---
_Generated by [Claude Code](https://claude.ai/code/session_015zkqVzCBpDUh7ntB3EdnLG)_