### PR TITLE
상품·가격: 서브 브랜드 마스터 + 중요도순 정렬

### DIFF
--- a/promo-analytics/app/(dash)/products/page.tsx
+++ b/promo-analytics/app/(dash)/products/page.tsx
@@ -6,13 +6,14 @@ export const dynamic = "force-dynamic";
 // 상품·가격 가이드 — 웹이 단일 출처. 기본정보·카테고리·브랜드·원가·상시/정기/묶음 가격을 직접 관리.
 export default async function ProductsPage() {
   const supabase = await createClient();
-  const [{ data: prod }, { data: cats }, { data: cfgs }, { data: rc }] = await Promise.all([
+  const [{ data: prod }, { data: cats }, { data: brs }, { data: cfgs }, { data: rc }] = await Promise.all([
     supabase
       .from("products")
       .select("id, base_name, dr_code, category, brand, channel, status, cost, consumer_price, regular_price, is_subscription")
       .order("dr_code", { ascending: true, nullsFirst: false })
       .order("base_name", { ascending: true }),
     supabase.from("product_categories").select("name, sort").order("sort"),
+    supabase.from("product_brands").select("name, sort").order("sort"),
     supabase.from("product_price_configs").select("product_id, sale_mode, config_type, sale_price, free_shipping"),
     supabase
       .from("rate_card")
@@ -22,12 +23,23 @@ export default async function ProductsPage() {
       .limit(1)
       .maybeSingle(),
   ]);
-  const rows = (prod as ProductRow[]) ?? [];
+  const unsorted = (prod as ProductRow[]) ?? [];
   const managed = (cats ?? []).map((c) => c.name as string);
-  const fromProducts = [...new Set(rows.map((r) => r.category).filter((c): c is string => !!c))];
+  const fromProducts = [...new Set(unsorted.map((r) => r.category).filter((c): c is string => !!c))];
   const categories = [...new Set([...managed, ...fromProducts])];
-  const brands = [...new Set(rows.map((r) => r.brand).filter((b): b is string => !!b))].sort();
-  const channels = [...new Set(rows.map((r) => r.channel).filter(Boolean))].sort();
+  // 서브 브랜드 중요도 순(시트와 동일) → 같은 브랜드 안에서는 품목코드 순. 브랜드 없으면 맨 뒤.
+  const brandOrder = new Map<string, number>((brs ?? []).map((b) => [b.name as string, b.sort as number]));
+  const brands = [
+    ...(brs ?? []).map((b) => b.name as string),
+    ...[...new Set(unsorted.map((r) => r.brand).filter((b): b is string => !!b))].filter((b) => !brandOrder.has(b)),
+  ];
+  const rows = [...unsorted].sort((a, b) => {
+    const ba = a.brand ? brandOrder.get(a.brand) ?? 900 : 999;
+    const bb = b.brand ? brandOrder.get(b.brand) ?? 900 : 999;
+    if (ba !== bb) return ba - bb;
+    return (a.dr_code ?? "￿").localeCompare(b.dr_code ?? "￿");
+  });
+  const channels = [...new Set(unsorted.map((r) => r.channel).filter(Boolean))].sort();
 
   const configsByProduct: Record<string, ConfigLite[]> = {};
   for (const c of (cfgs as (ConfigLite & { product_id: string })[]) ?? []) {

--- a/promo-analytics/supabase/migrations/0076_product_brands.sql
+++ b/promo-analytics/supabase/migrations/0076_product_brands.sql
@@ -1,0 +1,38 @@
+-- 0076: 서브 브랜드 마스터(중요도 순) + 상품 브랜드 배정
+-- 가격표를 시트처럼 '서브 브랜드 중요도 순 → 품목코드 순'으로 정렬하기 위함.
+-- product_brands 는 카테고리 하위의 서브 브랜드 목록 + 정렬(중요도). products.brand 는 그 이름.
+
+create table if not exists promo.product_brands (
+  id uuid primary key default gen_random_uuid(),
+  name text not null unique,
+  sort int not null default 0,
+  created_at timestamptz not null default now()
+);
+
+alter table promo.product_brands enable row level security;
+drop policy if exists product_brands_auth_all on promo.product_brands;
+create policy product_brands_auth_all on promo.product_brands
+  for all to authenticated using (true) with check (true);
+grant all on promo.product_brands to authenticated, service_role;
+
+-- 중요도 순 시드 (시트 순서)
+insert into promo.product_brands (name, sort) values
+  ('퓨저나이트', 1), ('카사벤토', 2), ('영양케어', 3), ('포캣츄', 4), ('포캣트릿', 5),
+  ('체험팩', 6), ('바이바이배드', 7), ('애착박스', 8), ('캣트리스', 9), ('포캣네스트', 10),
+  ('사은품/굿즈', 11)
+on conflict (name) do update set sort = excluded.sort;
+
+-- 품목코드 기준 브랜드 배정 (시트 기준)
+update promo.products set brand='퓨저나이트'  where dr_code in ('DR10071','DR10081');
+update promo.products set brand='카사벤토'    where dr_code in ('DR10030','DR10040','DR10036','DR10033','DR10041');
+update promo.products set brand='영양케어'    where dr_code in ('DR10067','DR10068','DR10063','DR10064','DR10038','DR10039','DR10011','DR10021','DR10012','DR10022','DR10072');
+update promo.products set brand='포캣츄'      where dr_code in ('DR10043','DR10044','DR10042');
+update promo.products set brand='포캣트릿'    where dr_code in ('DR10007','DR10008','DR10010','DR10019','DR10020','DR10023','DR10024');
+update promo.products set brand='체험팩'      where dr_code in ('DR10025','DR10055','DR10065','DR10069','DR10073','DR10045');
+update promo.products set brand='바이바이배드' where dr_code in ('DR10066');
+update promo.products set brand='애착박스'    where dr_code in ('DR10034','DR10035','DR10061');
+update promo.products set brand='캣트리스'    where dr_code in ('DR10006','DR10005','DR10003','DR10004');
+update promo.products set brand='포캣네스트'  where dr_code in ('DR10026','DR10027');
+update promo.products set brand='사은품/굿즈' where dr_code in ('DR10059','DR10060');
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## 무엇을

가격표(매트릭스/목록)를 실제 가격 시트와 동일하게 **서브 브랜드 중요도 순 → 같은 브랜드 안에서는 품목코드 순**으로 정렬합니다.

기존에는 서브 브랜드 정보가 없어 품목코드 순으로만 나열됐는데, 시트처럼 브랜드를 중요도(시트 순서)대로 묶어 보여줍니다.

## 변경 사항

- **`product_brands` 마스터 테이블 추가** (`0076_product_brands.sql`)
  - 카테고리 하위의 서브 브랜드 목록 + 중요도(`sort`).
  - 시트 순서대로 시드: 퓨저나이트(1) · 카사벤토(2) · 영양케어(3) · 포캣츄(4) · 포캣트릿(5) · 체험팩(6) · 바이바이배드(7) · 애착박스(8) · 캣트리스(9) · 포캣네스트(10) · 사은품/굿즈(11).
- **상품별 브랜드 배정**: 시트 기준 품목코드로 `products.brand` 채움 (B2C 판매 SKU 46종).
- **`/products` 페이지 정렬**: `product_brands` 정렬을 불러와 행을 `(브랜드 중요도, 품목코드)` 순으로 정렬. 브랜드 입력 datalist 도 중요도 순으로 노출, 미지정 브랜드는 맨 뒤로.

## 검증

- `npx tsc --noEmit` · `npm run test` (88 passed) · `npm run build` 통과.
- DB 배정 확인: 11개 브랜드에 46 SKU 가 중요도 순으로 배정됨(퓨저나이트 2 / 카사벤토 5 / 영양케어 11 / 포캣츄 3 / 포캣트릿 7 / 체험팩 6 / 바이바이배드 1 / 애착박스 3 / 캣트리스 4 / 포캣네스트 2 / 사은품/굿즈 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015zkqVzCBpDUh7ntB3EdnLG)_