### PR TITLE
캠페인: 엑셀 날짜 하루 밀림 수정 + 캠페인 상세 탭 로딩 최적화

### DIFF
--- a/promo-analytics/app/(dash)/plans/loading.tsx
+++ b/promo-analytics/app/(dash)/plans/loading.tsx
@@ -1,0 +1,27 @@
+export default function PlansLoading() {
+  return (
+    <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
+      <div className="h-6 w-28 animate-pulse rounded-full bg-soft" />
+      <div className="mt-2 h-3 w-80 animate-pulse rounded-full bg-soft" />
+
+      <div className="mt-5 flex gap-2">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="h-8 w-24 animate-pulse rounded-xl bg-soft" />
+        ))}
+      </div>
+
+      <div className="mt-5 rounded-2xl p-4 card-soft">
+        <div className="space-y-2.5">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="grid grid-cols-12 items-center gap-3">
+              <div className="col-span-5 h-3.5 animate-pulse rounded-full bg-soft" />
+              <div className="col-span-2 h-3.5 animate-pulse rounded-full bg-soft" />
+              <div className="col-span-2 h-3.5 animate-pulse rounded-full bg-soft" />
+              <div className="col-span-3 h-3.5 animate-pulse rounded-full bg-soft" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/promo-analytics/app/(dash)/predict/loading.tsx
+++ b/promo-analytics/app/(dash)/predict/loading.tsx
@@ -1,0 +1,26 @@
+export default function PredictLoading() {
+  return (
+    <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
+      <div className="h-6 w-32 animate-pulse rounded-full bg-soft" />
+      <div className="mt-2 h-3 w-72 animate-pulse rounded-full bg-soft" />
+
+      <div className="mt-6 grid gap-4 lg:grid-cols-[minmax(0,1fr)_22rem]">
+        <div className="rounded-2xl p-5 card-soft">
+          <div className="space-y-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="h-10 animate-pulse rounded-xl bg-soft" />
+            ))}
+          </div>
+        </div>
+        <div className="rounded-2xl p-5 card-soft">
+          <div className="h-4 w-40 animate-pulse rounded-full bg-soft" />
+          <div className="mt-4 grid grid-cols-3 gap-2">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="h-14 animate-pulse rounded-xl bg-soft" />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/promo-analytics/app/(dash)/prescribe/loading.tsx
+++ b/promo-analytics/app/(dash)/prescribe/loading.tsx
@@ -1,0 +1,19 @@
+export default function PrescribeLoading() {
+  return (
+    <div className="px-4 py-6 sm:px-6 lg:px-8 lg:py-7">
+      <div className="h-6 w-32 animate-pulse rounded-full bg-soft" />
+      <div className="mt-2 h-3 w-72 animate-pulse rounded-full bg-soft" />
+
+      <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="rounded-2xl p-5 card-soft">
+            <div className="h-4 w-32 animate-pulse rounded-full bg-soft" />
+            <div className="mt-3 h-3 w-full animate-pulse rounded-full bg-soft" />
+            <div className="mt-2 h-3 w-4/5 animate-pulse rounded-full bg-soft" />
+            <div className="mt-4 h-8 w-24 animate-pulse rounded-xl bg-soft" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/promo-analytics/app/(dash)/promotions/[id]/page.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/page.tsx
@@ -109,14 +109,30 @@ export default async function PromotionDetail({
   const achSummary = bundle?.rollup?.pva_summary ?? null;
   const achRows = bundle?.rollup?.pva_rows ?? [];
   const achOptions = bundle?.rollup?.pva_options ?? [];
-  // N13 P2: 옵션 단위 실측 공헌 분해 (마이그레이션 미적용 시 함수 부재 → 조용히 빈 배열)
-  const { data: contribData } = await supabase.rpc("sale_option_contribution", { p_id: id });
-  const optionContribs = (contribData as OptionContribRow[] | null) ?? [];
-  // Feature C: 세그먼트 요약 (선택 탭에서만 조회 — 마이그레이션 미적용 시 함수 부재 → null)
-  const segSummary =
+  // 보조 조회를 한 번에 병렬로 — 서로 독립이므로 순차 왕복 대신 Promise.all 로 지연을 줄인다.
+  // 무거운 뷰 전용 RPC(옵션 공헌 분해·세그먼트 요약)는 해당 탭일 때만 호출해 탭 전환을 가볍게 한다.
+  //  · sale_option_contribution: 'SKU·옵션' 탭에서만 사용 → skus 뷰에서만 호출
+  //  · promotion_segment_summary: '세그먼트' 탭에서만 사용 → segment 뷰에서만 호출
+  const [contribRes, segRes, exRes, perfRes] = await Promise.all([
+    view === "skus"
+      ? supabase.rpc("sale_option_contribution", { p_id: id })
+      : Promise.resolve({ data: null }),
     view === "segment"
-      ? (((await supabase.rpc("promotion_segment_summary", { p_id: id })).data) as SegmentSummary | null)
-      : null;
+      ? supabase.rpc("promotion_segment_summary", { p_id: id })
+      : Promise.resolve({ data: null }),
+    supabase
+      .from("promotion_excluded_skus")
+      .select("product_id, products(base_name)")
+      .eq("promotion_id", id),
+    supabase
+      .from("promotions")
+      .select("perf_uploaded_at, perf_source_file")
+      .eq("id", id)
+      .maybeSingle<{ perf_uploaded_at: string | null; perf_source_file: string | null }>(),
+  ]);
+  const optionContribs = (contribRes.data as OptionContribRow[] | null) ?? [];
+  const segSummary = (segRes.data as SegmentSummary | null) ?? null;
+  const perfMeta = perfRes.data;
   const optionInfos = [
     ...new Set(
       (bundle?.option_infos ?? []).map((s) => s.trim()).filter((s) => s.length > 0),
@@ -125,12 +141,8 @@ export default async function PromotionDetail({
   const diagnosticRows = bundle?.rollup?.diagnostic ?? [];
   const skuMappings = bundle?.mappings ?? [];
   // 품절(미판매) 제외 목록 — 플랜·성과·미매칭에서 빠진 SKU (복원용으로 표시)
-  const { data: exData } = await supabase
-    .from("promotion_excluded_skus")
-    .select("product_id, products(base_name)")
-    .eq("promotion_id", id);
   const excludedSkus = (
-    (exData ?? []) as {
+    (exRes.data ?? []) as {
       product_id: string;
       products: { base_name: string } | { base_name: string }[] | null;
     }[]
@@ -138,13 +150,6 @@ export default async function PromotionDetail({
     const pr = Array.isArray(r.products) ? r.products[0] : r.products;
     return { product_id: r.product_id, base_name: pr?.base_name ?? r.product_id };
   });
-
-  // 성과 업로드 메타(파일명·시각) — 0070 미적용 시 컬럼 부재 → null
-  const { data: perfMeta } = await supabase
-    .from("promotions")
-    .select("perf_uploaded_at, perf_source_file")
-    .eq("id", id)
-    .maybeSingle<{ perf_uploaded_at: string | null; perf_source_file: string | null }>();
 
   // 목적별 핵심 지표 (S5.4)
   const ewData = bundle?.weights ?? [];

--- a/promo-analytics/lib/__tests__/campaignTemplate.test.ts
+++ b/promo-analytics/lib/__tests__/campaignTemplate.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import * as XLSX from "xlsx";
+import { parseCampaignMeta } from "../campaignTemplate";
+
+// '캠페인' 시트 1행짜리 워크북을 만들어 buffer 로 반환
+function makeWorkbook(startCell: unknown, endCell: unknown): ArrayBuffer {
+  const header = [
+    "캠페인명",
+    "시작일",
+    "종료일",
+    "혜택유형",
+    "시즌",
+    "판매채널",
+    "대표할인율(%)",
+    "목적_세일즈",
+    "목적_브랜딩",
+    "목적_재고소진",
+  ];
+  const row = ["테스트 캠페인", startCell, endCell, "할인", "여름", "자사몰", 50, 8, "", ""];
+  const wb = XLSX.utils.book_new();
+  const ws = XLSX.utils.aoa_to_sheet([header, row], { cellDates: true });
+  XLSX.utils.book_append_sheet(wb, ws, "캠페인");
+  const out = XLSX.write(wb, { type: "array", bookType: "xlsx" });
+  return (out instanceof Uint8Array ? out.buffer : out) as ArrayBuffer;
+}
+
+describe("parseCampaignMeta 날짜 파싱 (타임존 하루 밀림 방지)", () => {
+  // 실제 엑셀 파일은 날짜를 '시리얼 숫자'(타임존 독립)로 저장한다. 46160 = 2026-05-18.
+  it("엑셀 날짜 시리얼을 하루 밀리지 않고 정확히 복원한다", () => {
+    const meta = parseCampaignMeta(makeWorkbook(46160, 46161));
+    expect(meta).not.toBeNull();
+    expect(meta!.start_date).toBe("2026-05-18");
+    expect(meta!.end_date).toBe("2026-05-19");
+  });
+
+  it("문자열 날짜도 그대로 복원한다", () => {
+    const meta = parseCampaignMeta(makeWorkbook("2026-05-18", "2026-05-19"));
+    expect(meta!.start_date).toBe("2026-05-18");
+    expect(meta!.end_date).toBe("2026-05-19");
+  });
+});

--- a/promo-analytics/lib/campaignTemplate.ts
+++ b/promo-analytics/lib/campaignTemplate.ts
@@ -55,16 +55,24 @@ function numOrNull(v: unknown): number | null {
 }
 function ymd(v: unknown): string | null {
   if (v == null || v === "") return null;
+  const p = (n: number) => String(n).padStart(2, "0");
+  // 엑셀 날짜 시리얼(숫자) — 타임존과 무관하게 순수 산술로 달력 날짜 복원.
+  // (cellDates 로 만든 Date 는 KST 등에서 미세 드리프트로 하루 앞당겨지는 문제가 있어 시리얼을 우선 사용)
+  if (typeof v === "number" && Number.isFinite(v)) {
+    const d = XLSX.SSF.parse_date_code(v);
+    if (d && d.y) return `${d.y}-${p(d.m)}-${p(d.d)}`;
+  }
   if (v instanceof Date) {
-    const p = (n: number) => String(n).padStart(2, "0");
-    return `${v.getFullYear()}-${p(v.getMonth() + 1)}-${p(v.getDate())}`;
+    // cellDates 결과가 Date 로 온 경우: 12시간 보정 후 UTC 기준으로 달력 날짜를 읽어
+    // 타임존 오프셋·시리얼 드리프트에 의한 하루 밀림을 방지.
+    const adj = new Date(v.getTime() + 12 * 60 * 60 * 1000);
+    return `${adj.getUTCFullYear()}-${p(adj.getUTCMonth() + 1)}-${p(adj.getUTCDate())}`;
   }
   const s = String(v).replace(/\s+/g, "");
   const m = s.match(/(\d{4})[.\-/](\d{1,2})[.\-/](\d{1,2})/);
   if (m) return `${m[1]}-${m[2].padStart(2, "0")}-${m[3].padStart(2, "0")}`;
   const d = new Date(String(v).trim());
   if (isNaN(d.getTime())) return null;
-  const p = (n: number) => String(n).padStart(2, "0");
   return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
 }
 
@@ -72,10 +80,11 @@ function ymd(v: unknown): string | null {
 function readBook(buf: ArrayBuffer): XLSX.WorkBook {
   const bytes = new Uint8Array(buf);
   const isZip = bytes[0] === 0x50 && bytes[1] === 0x4b;
-  if (isZip) return XLSX.read(buf, { cellDates: true });
+  // cellDates:false → 날짜 셀을 엑셀 시리얼(숫자) 그대로 받아 ymd()에서 타임존 무관하게 변환.
+  if (isZip) return XLSX.read(buf, { cellDates: false });
   let text = new TextDecoder("utf-8").decode(bytes);
   if (text.charCodeAt(0) === 0xfeff) text = text.slice(1);
-  return XLSX.read(text, { type: "string", cellDates: true });
+  return XLSX.read(text, { type: "string", cellDates: false });
 }
 
 /** '캠페인' 시트 → 폼 자동 채움값. 시트가 없으면 첫 시트의 헤더+1행을 시도. */


### PR DESCRIPTION
두 가지 요청을 반영했습니다.

## 1. 새 캠페인 엑셀 불러오기 — 날짜 하루 밀림 수정
- **원인**: `cellDates`로 엑셀 날짜를 JS `Date`로 읽으면 SheetJS의 시리얼 변환 미세 드리프트로 KST에서 `2026-05-18`이 `…T14:59:08Z`(= 5/17 23:59 KST)가 되어 **하루 앞당겨짐**.
- **수정**: 날짜 셀을 **엑셀 시리얼(숫자) 그대로** 받아 `XLSX.SSF.parse_date_code`로 **타임존과 무관하게** 달력 날짜를 복원. `Date`로 들어온 경우에도 12시간 보정+UTC 기준으로 방어.
- **검증**: 실제 첨부 파일(시리얼 46160 → 2026-05-18) 및 신규 테스트를 UTC/Asia\_Seoul/America\_New\_York/Pacific\_Kiritimati 4개 타임존에서 통과.

## 2. 캠페인 메뉴 로딩 속도 최적화
- **캠페인 상세 탭 전환**: `?view=` 전환마다 무거운 RPC를 매번 순차 호출하던 것을 개선.
  - `sale_option_contribution`(‘SKU·옵션’ 탭 전용)·`promotion_segment_summary`(‘세그먼트’ 탭 전용)는 **해당 탭일 때만** 호출.
  - 나머지 보조 쿼리(제외 SKU·성과 메타)는 **`Promise.all`로 병렬화**해 순차 왕복 지연 제거.
- **하위 페이지 즉시 피드백**: `캠페인`·`성과 예측`·`캠페인 추천` 진입 시 **로딩 스켈레톤** 추가로 체감 속도 개선.

## 검증
- `vitest run` 18 파일 / 90 테스트 통과(날짜 파싱 타임존 테스트 추가).
- `tsc --noEmit` 통과, 변경 파일 신규 lint 오류 없음, `next build` 성공.

참고: 서버 RPC 자체의 쿼리 비용을 더 줄이려면 DB 인덱스·함수 튜닝이 필요하며, 이번 변경은 앱 레이어(호출 게이팅·병렬화·스켈레톤)에서 안전하게 얻을 수 있는 개선에 집중했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kt8NuE7rRQ6iDnm52fQ1d

---
_Generated by [Claude Code](https://claude.ai/code/session_014kt8NuE7rRQ6iDnm52fQ1d)_