### PR TITLE
플랜 쿠폰: 중복(유형) 규칙 + 자사 부담율(공헌이익 정확도)

### DIFF
--- a/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
+++ b/promo-analytics/app/(dash)/promotions/[id]/plan/PlanEditor.tsx
@@ -103,6 +103,9 @@ type CouponEntry = {
   max: number; // 정률 캡 (원, 0=무제한)
   flat: number; // 정액 할인 (원)
   label: string;
+  group: string; // 유형(중복 규칙 그룹). 비면 독립(항상 중첩)
+  stackSame: boolean; // 동일유형 중복 허용(금액대별 발행 케이스)
+  burdenPct: number; // 자사 부담율 % (기본 100 = 전액 자사 부담)
 };
 type FreebieEntry = {
   id: string;
@@ -147,6 +150,10 @@ function initialExtras(plan: {
             max: Number((e as CouponEntry).max) || 0,
             flat: Number((e as CouponEntry).flat) || 0,
             label: (e as CouponEntry).label ?? "",
+            group: (e as CouponEntry).group ?? "",
+            stackSame: !!(e as CouponEntry).stackSame,
+            burdenPct:
+              (e as CouponEntry).burdenPct == null ? 100 : Number((e as CouponEntry).burdenPct),
           };
         return null;
       })
@@ -164,6 +171,9 @@ function initialExtras(plan: {
         max: Number(plan?.coupon_max) || 0,
         flat: 0,
         label: "",
+        group: "",
+        stackSame: false,
+        burdenPct: 100,
       },
     ];
   }
@@ -178,6 +188,9 @@ function entryToCoupon(e: CouponEntry): Coupon {
     max_discount_amount: e.max,
     flat_amount: e.flat,
     label: e.label,
+    group: e.group,
+    stack_same: e.stackSame,
+    burden_rate: (e.burdenPct == null ? 100 : e.burdenPct) / 100,
   };
 }
 
@@ -390,7 +403,7 @@ export default function PlanEditor({
     setDirty(true);
     setExtras((prev) => [
       ...prev,
-      { id: uid(), type: "coupon", kind: "rate", min: 50000, ratePct: 5, max: 0, flat: 0, label: "" },
+      { id: uid(), type: "coupon", kind: "rate", min: 50000, ratePct: 5, max: 0, flat: 0, label: "", group: "", stackSame: false, burdenPct: 100 },
     ]);
   };
   const addFreebieEntry = () => {
@@ -558,7 +571,7 @@ export default function PlanEditor({
       extras: extras.map((e) =>
         isFreebie(e)
           ? { type: "freebie", product_id: e.product_id, base_name: e.base_name, qty: e.qty, cost: e.cost }
-          : { type: "coupon", kind: e.kind, min: e.min, ratePct: e.ratePct, max: e.max, flat: e.flat, label: e.label },
+          : { type: "coupon", kind: e.kind, min: e.min, ratePct: e.ratePct, max: e.max, flat: e.flat, label: e.label, group: e.group, stackSame: e.stackSame, burdenPct: e.burdenPct },
       ),
       options: options.map((o, i) => ({
         option_label: o.option_label,
@@ -873,6 +886,11 @@ export default function PlanEditor({
             )}
           </ul>
         )}
+        <datalist id="coupon-groups">
+          {[...new Set(extras.filter(isCoupon).map((e) => e.group).filter(Boolean))].map((g) => (
+            <option key={g} value={g} />
+          ))}
+        </datalist>
 
         {!confirmed && (
           <div className="mt-3 flex flex-wrap gap-2">
@@ -1539,6 +1557,50 @@ function CouponRow({
           </label>
         )}
       </div>
+
+      {/* 중복(스택) 규칙 + 자사 부담율 */}
+      <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-3">
+        <label className="block">
+          <span className={labelCls}>유형(중복 그룹)</span>
+          <input
+            type="text"
+            list="coupon-groups"
+            disabled={readOnly}
+            value={entry.group}
+            onChange={(e) => onPatch({ group: e.target.value })}
+            placeholder="예: 기본할인 / 카톡 / 네이버"
+            className={fieldCls}
+          />
+        </label>
+        <label className="block">
+          <span className={labelCls}>자사 부담율 (%)</span>
+          <input
+            type="number"
+            min={0}
+            max={100}
+            inputMode="numeric"
+            disabled={readOnly}
+            value={entry.burdenPct}
+            onChange={(e) => onPatch({ burdenPct: Math.max(0, Math.min(100, Number(e.target.value) || 0)) })}
+            placeholder="100"
+            className={`${fieldCls} text-right`}
+          />
+        </label>
+        <label className="flex items-end gap-1.5 pb-1.5 text-xs text-ink-3">
+          <input
+            type="checkbox"
+            disabled={readOnly || !entry.group.trim()}
+            checked={entry.stackSame}
+            onChange={(e) => onPatch({ stackSame: e.target.checked })}
+          />
+          동일유형 중복 허용
+        </label>
+      </div>
+      <p className="mt-1 text-[11px] text-ink-4">
+        같은 <b>유형</b>끼리는 기본 <b>중복 불가</b>(가장 큰 할인 1개만) · 다른 유형은 중첩. 금액대별로 여러 개 발행돼 모두 적용되면
+        ‘동일유형 중복 허용’을 켜세요. 부담율 100%=우리가 전액, <b>네이버 100% 지원=0%</b>, 5:5 분담=50%.
+        (매출은 전체 할인 반영, <b>공헌이익만</b> 부담율로 보정)
+      </p>
     </li>
   );
 }

--- a/promo-analytics/app/api/promotions/[id]/plan/route.ts
+++ b/promo-analytics/app/api/promotions/[id]/plan/route.ts
@@ -28,7 +28,18 @@ type OptionIn = {
 };
 // 사은품・추가 할인 쿠폰 항목 (PlanEditor extras 직렬화)
 type ExtraIn =
-  | { type: "coupon"; kind: "rate" | "flat"; min: number; ratePct: number; max: number; flat: number; label?: string }
+  | {
+      type: "coupon";
+      kind: "rate" | "flat";
+      min: number;
+      ratePct: number;
+      max: number;
+      flat: number;
+      label?: string;
+      group?: string;
+      stackSame?: boolean;
+      burdenPct?: number;
+    }
   | { type: "freebie"; product_id: string | null; base_name: string; qty: number; cost: number };
 
 // N5: POST(빈 draft 자동 생성)는 제거됐다 — 플랜은 ⑤ 가이드 업로드로만 생성(plan-only).
@@ -60,6 +71,9 @@ export async function PATCH(
         max_discount_amount: Number(e.max) || 0,
         flat_amount: Number(e.flat) || 0,
         label: e.label,
+        group: e.group ?? "",
+        stack_same: !!e.stackSame,
+        burden_rate: (e.burdenPct == null ? 100 : Number(e.burdenPct)) / 100,
       }));
     if (couponList.length === 0 && body.coupon && body.coupon.rate > 0) {
       couponList.push({

--- a/promo-analytics/lib/__tests__/plan.test.ts
+++ b/promo-analytics/lib/__tests__/plan.test.ts
@@ -102,6 +102,62 @@ describe("computeOptionTotals — 다중 쿠폰 배열 + coupon_amounts", () => 
   });
 });
 
+describe("stackedCoupons — 중복(스택) 규칙 (유형/그룹)", () => {
+  const g = (over: Partial<Coupon>): Coupon => ({
+    kind: "rate", min_order_amount: 0, discount_rate: 0.05, max_discount_amount: 0, flat_amount: 0, ...over,
+  });
+  it("동일유형(같은 group) 중복 불가 → 가장 큰 할인 1개만", () => {
+    const c5 = g({ group: "기본", discount_rate: 0.05 });
+    const c10 = g({ group: "기본", discount_rate: 0.1 });
+    const { total, per } = stackedCoupons(80000, [c5, c10]);
+    expect(per).toEqual([0, 8000]); // 5% 탈락, 10%만 적용
+    expect(total).toBe(8000);
+  });
+  it("동일유형 '중복 허용'(stack_same) → 모두 중첩", () => {
+    const c5 = g({ group: "기본", discount_rate: 0.05, stack_same: true });
+    const c10 = g({ group: "기본", discount_rate: 0.1, stack_same: true });
+    const { total, per } = stackedCoupons(80000, [c5, c10]);
+    expect(per).toEqual([4000, 7600]); // 4,000 → running 76,000 → 10% 7,600
+    expect(total).toBe(11600);
+  });
+  it("다른 유형(다른 group)은 항상 중첩", () => {
+    const a = g({ group: "A", discount_rate: 0.05 });
+    const b = g({ group: "B", kind: "flat", flat_amount: 5000 });
+    const { total } = stackedCoupons(80000, [a, b]);
+    expect(total).toBe(9000); // 4,000 + 5,000
+  });
+  it("group 미지정(독립)은 기존처럼 모두 중첩", () => {
+    const a = g({ discount_rate: 0.05 });
+    const b = g({ kind: "flat", flat_amount: 5000 });
+    const { total } = stackedCoupons(80000, [a, b]);
+    expect(total).toBe(9000);
+  });
+});
+
+describe("computeOptionTotals — 자사 부담율 (공헌이익만 보정)", () => {
+  const cp = (burden: number): Coupon[] => [
+    { kind: "rate", min_order_amount: 40000, discount_rate: 0.1, max_discount_amount: 0, flat_amount: 0, burden_rate: burden },
+  ];
+  it("네이버 100% 지원(부담율 0) → 매출은 할인 반영, 공헌이익은 무변", () => {
+    const t = computeOptionTotals(ITEMS, MULT, QTY, cp(0));
+    expect(t.net_price).toBe(45000); // 고객 결제가(전체 할인)
+    expect(t.expected_revenue).toBe(450000);
+    expect(t.our_net_price).toBe(50000); // 자사 부담 0 → 공헌 기준가 무변
+    expect(t.expected_contribution).toBeCloseTo(30000, 4); // 쿠폰 없을 때와 동일
+  });
+  it("5:5 분담(부담율 0.5)", () => {
+    const t = computeOptionTotals(ITEMS, MULT, QTY, cp(0.5));
+    expect(t.expected_revenue).toBe(450000);
+    expect(t.our_net_price).toBe(47500); // 50,000 − 5,000×0.5
+    expect(t.expected_contribution).toBeCloseTo(12500, 4);
+  });
+  it("전액 자사 부담(기본 1) → 기존 계산과 동일", () => {
+    const t = computeOptionTotals(ITEMS, MULT, QTY, cp(1));
+    expect(t.our_net_price).toBe(45000);
+    expect(t.expected_contribution).toBeCloseTo(-5000, 4);
+  });
+});
+
 describe("freebieDeduction — 사은품 차감 (원가×수량)", () => {
   it("원가×수량 합", () => {
     expect(

--- a/promo-analytics/lib/plan.ts
+++ b/promo-analytics/lib/plan.ts
@@ -74,6 +74,12 @@ export type Coupon = {
   max_discount_amount: number; // 정률 캡 (0=무제한)
   flat_amount: number; // 정액 할인 (원)
   label?: string;
+  // 중복(스택) 규칙 — group(유형)이 같은 쿠폰끼리는 기본 '중복 불가'(가장 큰 할인 1개만),
+  // stack_same=true 면 같은 group 도 모두 중복 적용(금액대별 발행 케이스). group 이 비면 독립(항상 중첩).
+  group?: string;
+  stack_same?: boolean;
+  // 자사 부담율 (0~1, 기본 1=전액 자사 부담). 매출은 전체 할인 반영, 공헌이익만 자사 부담분으로 계산.
+  burden_rate?: number;
 };
 
 /** 사은품 1건 — 동봉 발송. 차감액 = 원가(VAT+) × 수량 (물류비·광고비·수수료 미반영). */
@@ -99,19 +105,72 @@ export function couponAmount(setPrice: number, running: number, c: Coupon): numb
   return Math.round(Math.max(0, Math.min(d, running)));
 }
 
-/** 쿠폰들을 순차 중첩 적용 — 정률은 직전까지 차감된 running price 기준. 쿠폰별 할인액 배열도 반환. */
+/** 쿠폰 1건이 gross set_price 단독 적용 시 할인액 (동일유형 '가장 큰 할인' 선택 기준). */
+function standaloneDiscount(setPrice: number, c: Coupon): number {
+  return couponAmount(setPrice, setPrice, c);
+}
+
+/** 중복(스택) 규칙 적용 후 실제 반영할 쿠폰만 표시하는 boolean 배열.
+   · group 이 비면 독립 → 항상 적용
+   · 같은 group 이 여럿이고 모두 stack_same → 모두 적용
+   · 그 외 같은 group → 조건 충족 중 '가장 큰 할인' 1개만(동점=먼저 입력한 것) */
+export function selectSurvivors(setPrice: number, coupons: Coupon[]): boolean[] {
+  const survive = new Array<boolean>(coupons.length).fill(false);
+  const groups = new Map<string, number[]>();
+  coupons.forEach((c, i) => {
+    const g = (c.group ?? "").trim();
+    if (!g) {
+      survive[i] = true; // 독립 쿠폰(유형 미지정)은 항상 중첩
+      return;
+    }
+    (groups.get(g) ?? groups.set(g, []).get(g)!).push(i);
+  });
+  for (const idxs of groups.values()) {
+    if (idxs.length === 1) {
+      survive[idxs[0]] = true;
+      continue;
+    }
+    if (idxs.every((i) => coupons[i].stack_same)) {
+      idxs.forEach((i) => (survive[i] = true));
+      continue;
+    }
+    // 동일유형 중복 불가 → 가장 큰 할인 1개만
+    let best = -1;
+    let bestAmt = 0;
+    for (const i of idxs) {
+      const amt = standaloneDiscount(setPrice, coupons[i]);
+      if (amt > bestAmt) {
+        bestAmt = amt;
+        best = i;
+      }
+    }
+    if (best >= 0) survive[best] = true;
+  }
+  return survive;
+}
+
+/** 쿠폰들을 중복 규칙 적용 후 순차 중첩 — 정률은 직전까지 차감된 running price 기준.
+   per: 쿠폰별 할인액(적용 안 됨=0), ourTotal: 자사 부담율 가중 할인액 합(공헌이익용). */
 export function stackedCoupons(
   setPrice: number,
   coupons: Coupon[],
-): { total: number; per: number[] } {
+): { total: number; per: number[]; ourTotal: number } {
+  const survive = selectSurvivors(setPrice, coupons);
   let running = setPrice;
+  let ourTotal = 0;
   const per: number[] = [];
-  for (const c of coupons) {
+  coupons.forEach((c, i) => {
+    if (!survive[i]) {
+      per.push(0);
+      return;
+    }
     const d = couponAmount(setPrice, running, c);
     per.push(d);
     running -= d;
-  }
-  return { total: setPrice - running, per };
+    const burden = c.burden_rate == null ? 1 : Math.max(0, Math.min(1, c.burden_rate));
+    ourTotal += d * burden;
+  });
+  return { total: setPrice - running, per, ourTotal };
 }
 
 /** 사은품 총 차감액 = Σ(원가 × 수량) — 공헌이익에서 일괄 차감(플랜 단위). */
@@ -124,7 +183,8 @@ export type OptionTotals = {
   set_price: number; // Σ(sku_qty × unit_sale_price) — 쿠폰 전 세트 단가
   coupon_discount: number; // 이 옵션에 적용된 쿠폰 할인액 합계 (없으면 0)
   coupon_amounts: number[]; // 쿠폰별 할인액 (입력 순서, 적용 안 됨=0) — '쿠폰1/2' 배지용
-  net_price: number; // set_price − coupon_discount — 쿠폰 적용 후 실혜택가
+  net_price: number; // set_price − coupon_discount — 쿠폰 적용 후 실혜택가(고객 결제가)
+  our_net_price: number; // set_price − 자사부담 할인액 — 공헌이익 계산용(부담율 반영)
   consumer_total: number; // Σ(consumer_price × sku_qty)
   regular_total: number; // Σ(regular_price × sku_qty)
   cost_total: number; // Σ(cost × sku_qty)
@@ -170,13 +230,15 @@ export function computeOptionTotals(
           },
         ]
       : [];
-  const { total: coupon_discount, per: coupon_amounts } = stackedCoupons(set_price, coupons);
-  const net_price = set_price - coupon_discount;
+  const { total: coupon_discount, per: coupon_amounts, ourTotal } = stackedCoupons(set_price, coupons);
+  const net_price = set_price - coupon_discount; // 고객 결제가(전체 할인 반영)
+  const our_net_price = set_price - ourTotal; // 공헌이익 기준가(자사 부담분만 차감)
   return {
     set_price,
     coupon_discount,
     coupon_amounts,
     net_price,
+    our_net_price,
     consumer_total,
     regular_total,
     cost_total,
@@ -184,9 +246,11 @@ export function computeOptionTotals(
     discount_rate_regular: regular_total > 0 ? 1 - set_price / regular_total : null,
     discount_rate_consumer_net:
       consumer_total > 0 ? 1 - net_price / consumer_total : null,
+    // 매출은 고객 결제가 기준(성과 결제금액과 비교 가능)
     expected_revenue: net_price * expQty,
-    // 물류비 12%는 mult에 일괄 반영 — 무료배송 여부와 무관하게 고정
-    expected_contribution: (net_price * mult - cost_total) * expQty,
+    // 공헌이익은 자사 부담분만 반영 — 채널(네이버 등) 부담 쿠폰은 공헌이익에서 덜 깎인다.
+    // 물류비 12%는 mult에 일괄 반영 — 무료배송 여부와 무관하게 고정.
+    expected_contribution: (our_net_price * mult - cost_total) * expQty,
     free_shipping: net_price >= FREE_SHIP_THRESHOLD,
   };
 }

--- a/promo-analytics/supabase/migrations/0079_coupon_stack_burden.sql
+++ b/promo-analytics/supabase/migrations/0079_coupon_stack_burden.sql
@@ -1,0 +1,279 @@
+-- 0079: 쿠폰 중복(스택) 규칙 + 자사 부담율 (공헌이익 정확도)
+--
+-- 1) 중복 규칙: extras 쿠폰에 group(유형)·stackSame·burdenPct 필드 추가(스키마 변경 없음, jsonb).
+--    · group 이 비면 독립 → 항상 중첩
+--    · 같은 group 이 여럿이고 모두 stackSame → 모두 중첩(금액대별 발행 케이스)
+--    · 그 외 같은 group → 조건 충족 중 '가장 큰 할인' 1개만
+-- 2) 부담율: 매출은 전체 할인 반영(고객 결제가), 공헌이익만 자사 부담분(할인×부담율)으로 보정.
+--    네이버 등 채널 부담 쿠폰은 공헌이익에서 덜 깎인다. 부담율 기본 100%면 기존과 동일.
+-- lib/plan.ts(selectSurvivors/stackedCoupons/computeOptionTotals)와 식 동일.
+
+-- 중복 규칙 적용 후 [customer(고객 할인총액), our(자사 부담 할인총액)] 반환
+create or replace function promo.apply_extras_coupons_v2(p_set_price numeric, p_extras jsonb)
+returns table(customer numeric, our numeric)
+language plpgsql
+immutable
+set search_path = ''
+as $$
+declare
+  n int;
+  i int;
+  j int;
+  kinds text[] := '{}';
+  mins numeric[] := '{}';
+  rates numeric[] := '{}';
+  maxs numeric[] := '{}';
+  flats numeric[] := '{}';
+  grps text[] := '{}';
+  stacks boolean[] := '{}';
+  burdens numeric[] := '{}';
+  standalone numeric[];
+  survive boolean[];
+  c jsonb;
+  running numeric;
+  d numeric;
+  cust numeric := 0;
+  ourt numeric := 0;
+  g text;
+  all_stack boolean;
+  best int;
+  best_amt numeric;
+begin
+  customer := 0;
+  our := 0;
+  if p_extras is null or jsonb_typeof(p_extras) <> 'array' then
+    return next;
+    return;
+  end if;
+
+  for c in select value from jsonb_array_elements(p_extras) where value->>'type' = 'coupon'
+  loop
+    kinds   := kinds   || coalesce(c->>'kind', 'rate');
+    mins    := mins    || coalesce((c->>'min')::numeric, 0);
+    rates   := rates   || (coalesce((c->>'ratePct')::numeric, 0) / 100.0);
+    maxs    := maxs    || coalesce((c->>'max')::numeric, 0);
+    flats   := flats   || coalesce((c->>'flat')::numeric, 0);
+    grps    := grps    || btrim(coalesce(c->>'group', ''));
+    stacks  := stacks  || coalesce((c->>'stackSame')::boolean, false);
+    burdens := burdens || least(1, greatest(0, coalesce((c->>'burdenPct')::numeric, 100) / 100.0));
+  end loop;
+
+  n := coalesce(array_length(kinds, 1), 0);
+  if n = 0 then
+    return next;
+    return;
+  end if;
+
+  -- gross set_price 기준 단독 할인액 (동일유형 '가장 큰 할인' 선택 기준, min 게이팅)
+  standalone := array_fill(0::numeric, array[n]);
+  survive := array_fill(false, array[n]);
+  for i in 1..n loop
+    if p_set_price >= mins[i] then
+      if kinds[i] = 'flat' then
+        d := least(flats[i], p_set_price);
+      elsif rates[i] > 0 then
+        d := p_set_price * rates[i];
+        if maxs[i] > 0 then d := least(d, maxs[i]); end if;
+        d := least(d, p_set_price);
+      else
+        d := 0;
+      end if;
+      standalone[i] := round(greatest(d, 0));
+    end if;
+  end loop;
+
+  -- 독립(그룹 미지정)은 항상 적용
+  for i in 1..n loop
+    if grps[i] = '' then survive[i] := true; end if;
+  end loop;
+
+  -- 각 그룹을 첫 등장 지점에서 한 번만 처리
+  for i in 1..n loop
+    g := grps[i];
+    if g = '' then continue; end if;
+    if exists (select 1 from generate_series(1, i - 1) k(idx) where grps[k.idx] = g) then
+      continue;
+    end if;
+    all_stack := true;
+    for j in 1..n loop
+      if grps[j] = g and not stacks[j] then all_stack := false; end if;
+    end loop;
+    if all_stack then
+      for j in 1..n loop
+        if grps[j] = g then survive[j] := true; end if;
+      end loop;
+    else
+      best := 0;
+      best_amt := 0;
+      for j in 1..n loop
+        if grps[j] = g and standalone[j] > best_amt then
+          best_amt := standalone[j];
+          best := j;
+        end if;
+      end loop;
+      if best > 0 then survive[best] := true; end if;
+    end if;
+  end loop;
+
+  -- 살아남은 쿠폰만 입력 순서로 순차 중첩(정률은 running 기준)
+  running := p_set_price;
+  for i in 1..n loop
+    if not survive[i] then continue; end if;
+    if p_set_price < mins[i] then continue; end if;
+    if kinds[i] = 'flat' then
+      d := least(flats[i], running);
+    elsif rates[i] > 0 then
+      d := running * rates[i];
+      if maxs[i] > 0 then d := least(d, maxs[i]); end if;
+      d := least(d, running);
+    else
+      d := 0;
+    end if;
+    d := round(greatest(d, 0));
+    running := running - d;
+    cust := cust + d;
+    ourt := ourt + d * burdens[i];
+  end loop;
+
+  customer := cust;
+  our := ourt;
+  return next;
+end;
+$$;
+
+-- confirm_plan: 매출=고객 할인(customer), 공헌이익=자사 부담 할인(our) 기준
+create or replace function promo.confirm_plan(p_plan_id uuid)
+ returns void
+ language plpgsql
+ set search_path to ''
+as $function$
+declare
+  v_promo uuid;
+  v_rc record;
+  v_fee numeric;
+  v_mult numeric;
+  v_snapshot jsonb;
+  v_opt_count int;
+  v_bad_opt int;
+  v_rev_total numeric;
+  v_contrib_total numeric;
+  v_cmin numeric;
+  v_crate numeric;
+  v_cmax numeric;
+  v_extras jsonb;
+  v_has_extra_coupon boolean;
+begin
+  select promotion_id, coalesce(coupon_min_order,0), coalesce(coupon_rate,0), coalesce(coupon_max,0),
+         coalesce(extras, '[]'::jsonb)
+    into v_promo, v_cmin, v_crate, v_cmax, v_extras
+  from promo.campaign_plans where id = p_plan_id;
+  if v_promo is null then
+    raise exception 'plan % not found', p_plan_id;
+  end if;
+
+  v_has_extra_coupon := exists (
+    select 1 from jsonb_array_elements(v_extras) where value->>'type' = 'coupon'
+  );
+
+  select count(*) into v_opt_count
+  from promo.campaign_plan_options
+  where campaign_plan_id = p_plan_id and expected_option_qty > 0;
+  if v_opt_count = 0 then
+    raise exception '확정하려면 예상 세트수가 1 이상인 옵션이 최소 1개 필요합니다';
+  end if;
+
+  select count(*) into v_bad_opt
+  from promo.campaign_plan_options o
+  where o.campaign_plan_id = p_plan_id
+    and not exists (
+      select 1 from promo.campaign_plan_option_items i
+      where i.campaign_plan_option_id = o.id
+    );
+  if v_bad_opt > 0 then
+    raise exception '구성 SKU가 없는 옵션이 % 개 있습니다', v_bad_opt;
+  end if;
+
+  select * into v_rc from promo.rate_card where is_current order by effective_from desc limit 1;
+  if v_rc is null then
+    raise exception 'current rate_card 가 없습니다';
+  end if;
+  select cf.fee_rate into v_fee
+  from promo.promotions pr
+  left join promo.channel_fees cf on cf.channel = pr.channel
+  where pr.id = v_promo;
+  v_fee := coalesce(v_fee, v_rc.fee_rate);
+  v_mult := 1 - (v_fee + v_rc.ad_rate + v_rc.logistics_rate + v_rc.reward_rate);
+  v_snapshot := jsonb_build_object(
+    'fee_rate', v_fee, 'ad_rate', v_rc.ad_rate,
+    'logistics_rate', v_rc.logistics_rate, 'reward_rate', v_rc.reward_rate,
+    'mult', v_mult, 'rate_card_id', v_rc.id, 'snapped_at', now()
+  );
+
+  update promo.campaign_plan_option_items i
+  set frozen_consumer_price = p.consumer_price,
+      frozen_regular_price  = p.regular_price,
+      frozen_cost           = p.cost,
+      updated_at = now()
+  from promo.products p
+  where i.product_id = p.id
+    and i.campaign_plan_option_id in (
+      select id from promo.campaign_plan_options where campaign_plan_id = p_plan_id
+    );
+
+  update promo.campaign_plan_options o
+  set set_price = agg.set_price,
+      consumer_total = agg.consumer_total,
+      regular_total = agg.regular_total,
+      discount_rate_consumer = case when agg.consumer_total > 0 then 1 - agg.set_price/agg.consumer_total else null end,
+      discount_rate_regular  = case when agg.regular_total  > 0 then 1 - agg.set_price/agg.regular_total  else null end,
+      expected_revenue = (agg.set_price - agg.cust_disc) * o.expected_option_qty,
+      expected_contribution = ((agg.set_price - agg.our_disc) * v_mult - agg.cost_total) * o.expected_option_qty,
+      updated_at = now()
+  from (
+    select a.oid, a.set_price, a.consumer_total, a.regular_total, a.cost_total,
+           cp.cust_disc, cp.our_disc
+    from (
+      select i.campaign_plan_option_id as oid,
+             sum(i.sku_qty_per_option * i.unit_sale_price)                   as set_price,
+             sum(i.sku_qty_per_option * coalesce(i.frozen_consumer_price,0)) as consumer_total,
+             sum(i.sku_qty_per_option * coalesce(i.frozen_regular_price,0))  as regular_total,
+             sum(i.sku_qty_per_option * coalesce(i.frozen_cost,0))           as cost_total
+      from promo.campaign_plan_option_items i
+      group by i.campaign_plan_option_id
+    ) a
+    cross join lateral (
+      select
+        case when v_has_extra_coupon then v2.customer
+             when v_crate > 0 and a.set_price >= v_cmin
+               then round(least(a.set_price * v_crate, case when v_cmax > 0 then v_cmax else a.set_price * v_crate end))
+             else 0 end as cust_disc,
+        case when v_has_extra_coupon then v2.our
+             when v_crate > 0 and a.set_price >= v_cmin
+               then round(least(a.set_price * v_crate, case when v_cmax > 0 then v_cmax else a.set_price * v_crate end))
+             else 0 end as our_disc
+      from promo.apply_extras_coupons_v2(a.set_price, v_extras) v2
+    ) cp
+  ) agg
+  where o.id = agg.oid and o.campaign_plan_id = p_plan_id;
+
+  select coalesce(sum(expected_revenue),0), coalesce(sum(expected_contribution),0)
+  into v_rev_total, v_contrib_total
+  from promo.campaign_plan_options where campaign_plan_id = p_plan_id;
+
+  -- 사은품 동봉 차감 (원가×수량)
+  v_contrib_total := v_contrib_total - promo.extras_freebie_total(v_extras);
+
+  update promo.campaign_plans
+  set is_current = false, updated_at = now()
+  where promotion_id = v_promo and is_current and id <> p_plan_id;
+
+  update promo.campaign_plans
+  set status='confirmed', confirmed_at=now(), rate_card_id=v_rc.id,
+      rate_card_snapshot=v_snapshot, expected_revenue_total=v_rev_total,
+      expected_contribution_total=v_contrib_total, is_current=true, updated_at=now()
+  where id = p_plan_id;
+end;
+$function$;
+
+grant execute on all functions in schema promo to authenticated;
+notify pgrst, 'reload schema';


### PR DESCRIPTION
새 캠페인 플랜의 쿠폰 기능 두 가지를 반영했습니다.

## 1. 쿠폰별 중복 할인 가능/불가능
- 쿠폰에 **유형(group)** 과 **동일유형 중복 허용(stackSame)** 필드 추가 (`extras` jsonb — 스키마 변경 없음).
- **같은 유형끼리는 기본 중복 불가** → 조건 충족 쿠폰 중 **가장 큰 할인 1개만** 적용.
- **다른 유형은 항상 중첩**.
- **동일 쿠폰이 금액대별로 여러 개 발행**되어 모두 적용되는 케이스는 해당 유형에 **‘동일유형 중복 허용’** 을 켜면 모두 중첩(첨부 이미지처럼 동일+다른 유형 전부 적용).
- 유형 미지정(독립) 쿠폰은 **기존처럼 모두 중첩** → 하위호환.

## 2. 쿠폰별 부담율 (공헌이익 정확도)
- 쿠폰별 **자사 부담율(%)** 추가. **매출은 고객 결제가(전체 할인 반영)** 그대로 두고, **공헌이익만** 자사 부담분(`할인 × 부담율`)으로 계산(`our_net_price`).
- 네이버 등 채널이 부담한 쿠폰은 **공헌이익에서 덜 깎임** → 손익 정확도↑. (네이버 100% 지원=0%, **5:5 분담=50%**, 전액 자사=100%)
- **부담율 100%(기본)면 기존 숫자와 완전히 동일** — 회귀 가드 테스트 포함.

## 계산 단일 출처 유지
- `lib/plan.ts` — `selectSurvivors`(중복 규칙) · `stackedCoupons`(부담율 가중 `ourTotal`) · `computeOptionTotals`(`our_net_price`로 공헌이익만 보정).
- 플랜 저장 API(`route.ts`) `ExtraIn` 매핑 + `PlanEditor` 쿠폰 UI(유형·동일유형 중복 허용·자사 부담율).
- 확정 SQL(`0079`) — `apply_extras_coupons_v2`가 **고객 할인 / 자사 부담 할인**을 분리 반환하고 `confirm_plan`이 매출/공헌에 각각 반영. lib과 반올림·min 게이팅·그룹 선택 순서까지 동일.

## 검증
- `vitest run` 18 파일 / 97 테스트 통과(중복 규칙·부담율·회귀 가드 추가).
- `tsc --noEmit` 통과, 변경 파일 신규 lint 오류 없음, `next build` 성공.
- 마이그레이션 `0079`는 `extras` 필드만 확장하므로 미적용 환경에서도 기존 동작(전액 자사 부담·독립 중첩)과 동일.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kt8NuE7rRQ6iDnm52fQ1d

---
_Generated by [Claude Code](https://claude.ai/code/session_014kt8NuE7rRQ6iDnm52fQ1d)_