### PR TITLE
동심원 차트: 카테고리 색 구분 + 카드 넘침(범례 이탈) 수정

### DIFF
--- a/promo-analytics/app/(dash)/DashCharts.tsx
+++ b/promo-analytics/app/(dash)/DashCharts.tsx
@@ -15,6 +15,11 @@ import { wonShort } from "@/lib/format";
 
 const BRAND = "#2f8f72"; // Dr.Felis mint-green (brand-500)
 
+// 카테고리형(서로 다른 항목) 차트용 팔레트 — Neo Organic 액센트 색상들.
+// 같은 초록 명암이 아니라 '서로 구분되는 hue'라야 항목이 읽힌다.
+// accent green · navy · gold · burgundy · clay · teal
+const CAT = ["#2f8f72", "#507a91", "#b8893f", "#c86652", "#6f8f87", "#247f63"];
+
 // 목적별 비중 바 (가중 기여매출/공헌) — value 점유율
 export function PurposeShareBars({
   data,
@@ -131,7 +136,7 @@ export function AchievementTrend({
           contentStyle={{ borderRadius: 14, border: "none", boxShadow: "0 8px 24px -8px rgba(0,0,0,.2)", fontSize: 12 }}
         />
         <Line type="monotone" dataKey="revenue" stroke={BRAND} strokeWidth={2.5} dot={{ r: 3 }} connectNulls animationDuration={1100} animationEasing="ease-out" />
-        <Line type="monotone" dataKey="contribution" stroke="#34504d" strokeWidth={2} dot={{ r: 2 }} connectNulls animationDuration={1100} animationEasing="ease-out" />
+        <Line type="monotone" dataKey="contribution" stroke="#507a91" strokeWidth={2} dot={{ r: 2 }} connectNulls animationDuration={1100} animationEasing="ease-out" />
       </LineChart>
     </ResponsiveContainer>
   );
@@ -198,30 +203,32 @@ export function Concentric({
   if (items.length === 0)
     return <div className="text-sm text-ink-4">데이터가 없습니다.</div>;
   const max = items[0].value;
-  const shades = ["#cfeadf", "#a6d7c2", "#58ac8e", BRAND];
-  const baseShade = (i: number) => shades[Math.min(i, shades.length - 1)];
+  // 항목별로 '서로 다른 색상'을 부여 — 명암이 아니라 hue로 구분(카테고리형).
+  // 약간의 투명도로 겹치는 원이 아래 항목까지 비쳐 크기(증분)도 함께 읽히게 한다.
+  const catColor = (i: number) => CAT[i % CAT.length];
 
+  // 카드가 좁아(예: 3열 그리드의 1/3) 원+범례를 나란히 두면 폭을 초과한다.
+  // 항상 세로 스택(원 위 · 범례 아래 전체폭)으로 두고, 원은 컨테이너 폭에 맞춰 줄인다.
   return (
-    <div className="flex flex-col items-center gap-3 sm:flex-row sm:items-end sm:gap-5">
-      <div className="relative h-[220px] w-[220px] shrink-0">
+    <div className="flex w-full flex-col items-center gap-3 overflow-hidden">
+      <div className="relative mx-auto h-[190px] w-[190px] max-w-full shrink-0">
         {items.map((d, i) => {
-          const dia = 110 + 110 * Math.sqrt(d.value / max);
-          const shade = baseShade(items.length - 1 - i); // 바깥=연하게, 안=진하게
+          const dia = 95 + 95 * Math.sqrt(d.value / max);
           return (
             <div
               key={d.label}
               className="absolute bottom-0 left-1/2 -translate-x-1/2 rounded-full"
-              style={{ width: dia, height: dia, background: shade, zIndex: i }}
+              style={{ width: dia, height: dia, background: catColor(i), opacity: 0.82, zIndex: i }}
             />
           );
         })}
       </div>
-      <ul className="flex w-full flex-col gap-1.5 text-xs sm:max-w-[180px]">
+      <ul className="flex w-full flex-col gap-1.5 text-xs">
         {items.map((d, i) => (
           <li key={d.label} className="flex items-center gap-2">
             <span
               className="h-2.5 w-2.5 shrink-0 rounded-full"
-              style={{ background: baseShade(items.length - 1 - i) }}
+              style={{ background: catColor(i) }}
             />
             <span className="min-w-0 flex-1 truncate text-ink-2">{d.label}</span>
             <span className="shrink-0 font-semibold tabular-nums text-ink">


### PR DESCRIPTION
대시보드 ‘혜택 유형별 초과 달성’ 동심원 차트의 두 가지 문제를 수정했습니다.

## 문제
1. **색 구분 안 됨** — 카테고리(4+4/할인)를 같은 초록 명암 램프(`#cfeadf`→`#a6d7c2`→…)로 칠해, 항목이 2개일 때 둘 다 옅은 초록이라 구분 불가.
2. **범례가 카드 밖으로 넘침** — 이 카드는 3열 그리드의 1/3 폭(좁음)인데, 차트가 뷰포트 기준 `sm:flex-row`로 원(220px)+옆 범례를 나란히 배치해 카드 폭을 초과 → 범례 텍스트가 카드 밖으로 삐져나감.

## 수정
- **카테고리 팔레트 도입**: 명암 램프 대신 서로 다른 hue(green/navy/gold/burgundy/clay/teal, Neo Organic 액센트)로 항목을 구분. 4+4=green / 할인=navy 처럼 확실히 구별.
- **레이아웃 항상 세로 스택**: 원(위) → 범례(아래 전체폭)로 배치해 좁은 카드에서도 넘치지 않음. 원 크기 190px로 축소, `overflow-hidden` 안전장치, 범례 라벨은 카드 안에서 말줄임.
- 덤: 달성률 추세 라인도 매출(green)/공헌(navy)로 색 구분 강화.

## 검증
- 컴포넌트 마크업을 그대로 재현한 좁은 카드(340·280px) 렌더로 **넘침 0 · 색 구분 확인**.
- `tsc --noEmit` 통과, `next build` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kt8NuE7rRQ6iDnm52fQ1d

---
_Generated by [Claude Code](https://claude.ai/code/session_014kt8NuE7rRQ6iDnm52fQ1d)_