### PR TITLE
design-system: 딥그린 로그인 히어로 컴포넌트 + VOC 이식 프롬프트

### DIFF
--- a/design-system/README.md
+++ b/design-system/README.md
@@ -91,6 +91,35 @@ design-system/
 - `.scroll-progress` — 상단 스크롤 진행바
 - `.top-tab-bar` + `.tab-btn`(`.active`) — 상단 탭바
 
+### 로그인 / 인증 페이지 (딥그린 키컬러)
+로그인·인증 화면은 본문(크림/민트)과 달리 **딥그린 히어로**를 키컬러로 씁니다.
+
+- `.login-hero` — 딥그린 풀스크린 컨테이너(최상위 `div`에 부여). 흰 텍스트,
+  강조어는 `<mark>` 또는 `.k`로 민트(`#8FD7B8`).
+- `.login-card` — 딥그린 위에 올리는 유리질 흰 카드(max 400px).
+- `.login-brand` · `.login-title` · `.login-sub` — 카드 상단 브랜드/제목/부제.
+- `.login-field`(label+input) — 입력 필드, 포커스 시 액센트 링.
+- `.login-btn` — CTA(액센트 그라데이션). `.login-alt`(보조 링크) · `.login-msg`(에러).
+
+```html
+<div class="login-hero">
+  <form class="login-card">
+    <span class="login-brand">닥터펠리스</span>
+    <h1 class="login-title">VOC 대시보드</h1>
+    <p class="login-sub">팀 계정으로 로그인하세요.</p>
+    <div class="login-field"><label>이메일</label><input type="email"></div>
+    <div class="login-field"><label>비밀번호</label><input type="password"></div>
+    <button class="login-btn" type="submit">로그인</button>
+    <p class="login-msg"></p>
+  </form>
+</div>
+```
+
+> ⚠️ 딥그린 배경은 `.login-hero`에 **직접** 지정돼 있습니다. 로그인 컨테이너를
+> `<section>`으로 만들면 `section:nth-child(){background:transparent}`에 덮여
+> 흰 글자가 안 보일 수 있으니, **`div`에 `.login-hero`를 주거나** 배경을
+> `!important`로 고정하세요. (지난 히어로 가독성 사고와 동일 원인)
+
 전체 클래스는 `felis-neo-organic.css`를 검색하면 다 나옵니다.
 
 ---

--- a/design-system/VOC-APPLY-PROMPT.md
+++ b/design-system/VOC-APPLY-PROMPT.md
@@ -1,0 +1,40 @@
+# VOC 대시보드 — Neo Organic 디자인 시스템 이식 프롬프트
+
+아래 내용을 **VOC 대시보드 작업 세션**에 그대로 붙여넣으세요.
+(원본 파일 `felis-neo-organic.css`와 `README.md`를 그 세션에 **첨부/업로드**한 뒤 사용)
+
+---
+
+첨부한 `felis-neo-organic.css`와 `README.md`가 우리 "Neo Organic" 디자인 시스템 원본이야.
+이 파일들을 프로젝트에 저장하고, README의 컴포넌트 치트시트대로 VOC 대시보드에 이식해줘.
+
+## 규칙
+1. 기존의 자체 색·폰트·그림자 토큰은 무시·삭제하고, 이 디자인 시스템의 토큰(:root 변수)과
+   문서화된 컴포넌트 클래스(.card / .bento+.b-* / .kpi-card / .tbl / .insight / .warn-box /
+   .chip / .acc-* / .gate-card 등)로 다시 조립해.
+2. 색을 바꿔야 하면 CSS 하단 `DR.FELIS NEO ORGANIC DASHBOARD` :root 의 `--accent` 등
+   토큰만 수정해. 개별 요소에 하드코딩 금지.
+3. 콘텐츠·데이터·로직은 절대 바꾸지 말고 **디자인만** 교체해.
+4. React/Next 프로젝트라면 CSS를 그대로 링크하기보다, 하단 :root 토큰을
+   globals.css(또는 Tailwind theme)로 옮기고 컴포넌트가 그 토큰을 쓰도록 바꿔.
+5. 폰트: Pretendard 링크를 반드시 포함(없으면 자간·굵기가 무너짐).
+
+## 로그인(인증) 페이지 — 딥그린 히어로 키컬러
+로그인 페이지는 본문(크림/민트)과 달리 **딥그린 히어로**를 키컬러로 써. 디자인 시스템에
+이미 `.login-*` 클래스로 문서화돼 있으니 그대로 사용해:
+
+- 최상위 풀스크린 컨테이너(**div**)에 `.login-hero` → 딥그린 그라데이션 배경
+  (`linear-gradient(145deg,#153633,#1C4842,#24564D)` + 민트/블루 글로우, 흰 텍스트)
+- 그 위에 유리질 흰 카드 `.login-card`
+- `.login-brand`(액센트) · `.login-title` · `.login-sub`(강조어는 `<mark>`=민트 #8FD7B8)
+- 입력은 `.login-field`(label+input), CTA는 `.login-btn`(액센트 그라데이션),
+  보조 링크 `.login-alt`, 에러 `.login-msg`
+
+⚠️ **가독성 필수 확인**: `.login-hero`의 딥그린 배경이 다른 규칙(`section:nth-child(){
+background:transparent}` 등)에 덮이면 흰 글자가 안 보인다. 로그인 컨테이너는 `<section>`이
+아니라 `<div>`로 만들거나 배경을 `!important`로 고정하고, **렌더 스크린샷으로 배경이 실제로
+딥그린인지, 흰 글자 대비가 충분한지 반드시 확인**해줘.
+
+## 마무리
+- 데스크톱·모바일 둘 다 렌더해서 가독성(대비)까지 확인하고 스크린샷 보여줘.
+- 대상 파일/컴포넌트 경로가 모호하면 추측하지 말고 먼저 물어봐.

--- a/design-system/felis-neo-organic.css
+++ b/design-system/felis-neo-organic.css
@@ -1081,3 +1081,64 @@ input[type="range"]::-webkit-slider-thumb{
   .insight::after,.w-brief::after{display:none}
   .card,section{transform:none!important}
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   로그인 / 인증 히어로 — 딥그린 키컬러 (Neo Organic 커버 톤)
+   · 최상위 풀스크린 컨테이너(div)에 .login-hero 를 준다.
+   · 딥그린 배경 위에 유리질 흰 카드(.login-card)를 올리고,
+     강조어는 민트(#8FD7B8), CTA·포커스는 본문 액센트(--accent)로 잇는다.
+   · 흰 텍스트가 밝은 배경에 얹히는 사고를 막기 위해 배경은
+     .login-hero 에 직접 지정(높은 우선순위 유지).
+   ═══════════════════════════════════════════════════════════════ */
+.login-hero{
+  position:relative;overflow:hidden;min-height:100vh;min-height:100svh;
+  display:flex;align-items:center;justify-content:center;padding:40px 20px;
+  color:#fff;
+  background:
+    radial-gradient(circle at 78% 26%,rgba(133,211,179,.26),transparent 30%),
+    radial-gradient(circle at 16% 78%,rgba(110,157,180,.16),transparent 26%),
+    linear-gradient(145deg,#153633 0%,#1C4842 56%,#24564D 100%)
+}
+.login-hero::before{content:"";position:absolute;pointer-events:none;width:420px;height:320px;
+  right:-90px;bottom:-120px;border-radius:64% 36% 38% 62%/50% 62% 38% 50%;
+  background:rgba(233,247,240,.08);border:1px solid rgba(255,255,255,.08)}
+.login-hero::after{content:"";position:absolute;pointer-events:none;width:190px;height:150px;
+  left:8%;top:16%;border-radius:43% 57% 66% 34%/54% 44% 56% 46%;background:rgba(255,255,255,.035)}
+.login-hero mark,.login-hero .k{background:none;color:#8FD7B8;font-weight:850}
+
+/* 로그인 카드 — 딥그린 위 유리질 흰 패널 */
+.login-card{
+  position:relative;z-index:1;width:min(400px,100%);
+  background:rgba(255,255,255,.96);border:1px solid rgba(255,255,255,.5);
+  border-radius:var(--radius);padding:32px 28px;
+  box-shadow:0 24px 60px rgba(20,48,46,.35);backdrop-filter:blur(6px);
+  color:var(--txt-900)
+}
+.login-brand{display:block;font-size:12px;font-weight:850;letter-spacing:2px;text-transform:uppercase;
+  color:var(--accent);margin-bottom:14px}
+.login-title{font-size:clamp(22px,3vw,28px);font-weight:850;letter-spacing:-.02em;color:var(--txt-900);margin:0 0 6px}
+.login-sub{font-size:13.5px;color:var(--txt-500);line-height:1.6;margin:0 0 22px}
+
+/* 입력 필드 */
+.login-field{margin-bottom:14px;text-align:left}
+.login-field label{display:block;font-size:11px;font-weight:800;letter-spacing:.04em;
+  color:var(--txt-400);margin-bottom:6px}
+.login-field input{width:100%;padding:12px 14px;border:1px solid var(--border-md);border-radius:13px;
+  background:#fff;color:var(--txt-900);font-family:var(--ff);font-size:14px;outline:none;
+  transition:border .2s,box-shadow .2s}
+.login-field input:focus{border-color:var(--accent);box-shadow:var(--focus-ring)}
+
+/* CTA 버튼 — 본문 액센트 그라데이션 */
+.login-btn{width:100%;min-height:48px;margin-top:6px;border:none;border-radius:14px;cursor:pointer;
+  font-family:var(--ff);font-size:15px;font-weight:800;color:#fff;
+  background:linear-gradient(135deg,var(--accent),#287A63);
+  box-shadow:0 12px 26px rgba(47,143,114,.28);transition:transform .2s,box-shadow .2s}
+.login-btn:hover{transform:translateY(-1px);box-shadow:0 16px 32px rgba(47,143,114,.34)}
+.login-btn:active{transform:translateY(0);box-shadow:0 6px 14px rgba(47,143,114,.24)}
+.login-btn:disabled{opacity:.6;cursor:not-allowed;transform:none;box-shadow:none}
+
+.login-alt{display:block;margin-top:16px;font-size:12.5px;color:var(--txt-500);text-align:center}
+.login-alt a{color:var(--accent);font-weight:700;text-decoration:none}
+.login-alt a:hover{text-decoration:underline}
+.login-msg{margin-top:12px;font-size:12.5px;font-weight:700;color:var(--burgundy);
+  text-align:center;min-height:16px}


### PR DESCRIPTION
## 무엇을

Neo Organic 디자인 시스템에 **로그인/인증 페이지용 딥그린 히어로 컴포넌트**를 추가하고, VOC 대시보드에 이식할 프롬프트를 문서로 정리했습니다.

## 변경 내용

- **`felis-neo-organic.css`** — `.login-*` 컴포넌트 추가
  - `.login-hero` — 딥그린 그라데이션(`#153633→#1C4842→#24564D`) + 유기체 블롭, 흰 텍스트, 민트(`#8FD7B8`) 강조
  - `.login-card`(유리질 흰 카드) · `.login-brand` · `.login-title` · `.login-sub`
  - `.login-field`(입력) · `.login-btn`(액센트 CTA) · `.login-alt` · `.login-msg`
- **`README.md`** — 로그인 컴포넌트 사용 스니펫 + 가독성 주의(배경을 `.login-hero`에 직접 지정해 `section:nth-child` 투명 덮어쓰기 사고 방지)
- **`VOC-APPLY-PROMPT.md`** — VOC 대시보드 이식용 붙여넣기 프롬프트(딥그린 로그인 지시 포함)

## 왜 딥그린을 직접 지정하나

이전 히어로에서 흰 글자가 안 보였던 원인이 디자인 시스템의 `section:nth-child(odd){background:transparent}`(특이도 0,1,1)가 히어로 배경을 덮은 것이었습니다. `.login-hero`는 `div`에 부여하도록 문서화하고 배경을 그 클래스에 직접 실어 같은 사고를 예방합니다.

## 검증

Playwright로 로그인 페이지를 렌더해 딥그린 배경 + 유리질 카드 + 민트 강조 + 액센트 CTA가 정상 표시되고 흰 텍스트 대비가 충분함을 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ERGYgjyFuFdcbVL1UQekE

---
_Generated by [Claude Code](https://claude.ai/code/session_018ERGYgjyFuFdcbVL1UQekE)_