### PR TITLE
Add price-communication-manual.html — internal Price Communication playbook

### DIFF
--- a/price-communication-manual.html
+++ b/price-communication-manual.html
@@ -1,0 +1,251 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="가격 변경 유형별 커뮤니케이션 원칙과 CS 대응 기준을 정리한 실무 매뉴얼">
+  <title>가격 변경 커뮤니케이션 매뉴얼</title>
+  <link rel="preconnect" href="https://cdn.jsdelivr.net">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css">
+  <style>
+    :root {
+      --ink: #18332d; --muted: #66766f; --paper: #fbfcf8; --card: #fff;
+      --line: #dde5df; --green: #0b6b50; --mint: #daf1e7; --lime: #dff36b;
+      --orange: #e06f3d; --orange-soft: #fff0e8; --yellow: #fff5c8;
+      --shadow: 0 16px 45px rgba(22, 57, 47, .08); --radius: 22px;
+    }
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body { margin: 0; font-family: Pretendard, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: var(--ink); background: var(--paper); line-height: 1.7; word-break: keep-all; }
+    a { color: inherit; }
+    .progress { position: fixed; inset: 0 auto auto 0; z-index: 20; width: 0; height: 4px; background: var(--orange); }
+    .layout { display: grid; grid-template-columns: 260px minmax(0, 920px); gap: 56px; max-width: 1280px; margin: auto; padding: 40px 32px 100px; }
+    aside { position: sticky; top: 36px; align-self: start; height: calc(100vh - 72px); display: flex; flex-direction: column; }
+    .brand { display: flex; align-items: center; gap: 11px; margin-bottom: 42px; font-size: 13px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+    .brand-mark { display: grid; place-items: center; width: 36px; height: 36px; border-radius: 12px; color: white; background: var(--green); box-shadow: 0 8px 20px rgba(11,107,80,.18); }
+    nav { display: grid; gap: 5px; }
+    nav a { padding: 9px 12px; border-radius: 10px; color: var(--muted); text-decoration: none; font-size: 13px; font-weight: 650; transition: .2s; }
+    nav a:hover, nav a.active { color: var(--green); background: var(--mint); }
+    nav a span { display: inline-block; width: 25px; color: #97a39e; font-variant-numeric: tabular-nums; }
+    .aside-note { margin-top: auto; padding: 15px; border: 1px solid var(--line); border-radius: 14px; color: var(--muted); font-size: 11px; line-height: 1.6; }
+    main { min-width: 0; }
+    .hero { position: relative; overflow: hidden; padding: 64px 62px; min-height: 440px; display: flex; flex-direction: column; justify-content: flex-end; border-radius: 32px; color: white; background: var(--green); box-shadow: var(--shadow); }
+    .hero::before, .hero::after { content: ""; position: absolute; border-radius: 50%; }
+    .hero::before { width: 360px; height: 360px; right: -90px; top: -170px; background: var(--lime); opacity: .95; }
+    .hero::after { width: 190px; height: 190px; right: 90px; top: -100px; border: 45px solid rgba(255,255,255,.13); }
+    .eyebrow { position: relative; z-index: 1; margin: 0 0 22px; font-size: 12px; font-weight: 800; letter-spacing: .16em; text-transform: uppercase; color: var(--lime); }
+    h1 { position: relative; z-index: 1; max-width: 670px; margin: 0; font-size: clamp(42px, 6vw, 70px); letter-spacing: -.055em; line-height: 1.06; }
+    .meta { position: relative; z-index: 1; margin: 24px 0 0; color: rgba(255,255,255,.72); font-size: 13px; }
+    .legal { display: flex; gap: 12px; align-items: flex-start; margin: 18px 0 0; padding: 16px 18px; border: 1px solid #eddfad; border-radius: 14px; background: var(--yellow); color: #6b5a1f; font-size: 13px; }
+    section { scroll-margin-top: 30px; margin-top: 84px; }
+    .section-kicker { margin-bottom: 7px; color: var(--orange); font-size: 11px; font-weight: 850; letter-spacing: .15em; text-transform: uppercase; }
+    h2 { margin: 0 0 26px; font-size: clamp(27px, 4vw, 40px); letter-spacing: -.045em; line-height: 1.25; }
+    h3 { margin: 0 0 13px; font-size: 17px; letter-spacing: -.02em; }
+    p { margin: 0 0 13px; }
+    ul, ol { margin: 0; padding-left: 1.25em; }
+    li + li { margin-top: 8px; }
+    strong { font-weight: 800; }
+    .principle { padding: 30px; border: 1px solid #bcdccc; border-radius: var(--radius); background: linear-gradient(135deg, #edfaf4, #fff); font-size: 17px; }
+    .principle ul { display: grid; gap: 16px; }
+    .table-wrap { overflow-x: auto; border: 1px solid var(--line); border-radius: var(--radius); background: var(--card); box-shadow: var(--shadow); }
+    table { width: 100%; min-width: 720px; border-collapse: collapse; font-size: 14px; }
+    th { padding: 15px 18px; text-align: left; color: var(--muted); background: #f1f5f2; font-size: 11px; letter-spacing: .08em; text-transform: uppercase; }
+    td { padding: 17px 18px; vertical-align: top; border-top: 1px solid var(--line); }
+    td:first-child { width: 31%; color: var(--green); }
+    .badge { display: inline-grid; place-items: center; min-width: 25px; height: 25px; margin-right: 7px; border-radius: 8px; color: white; background: var(--green); font-size: 11px; font-weight: 900; }
+    .decision { margin-top: 20px; padding: 22px 24px; border-radius: 17px; background: var(--ink); color: white; }
+    .decision small { display: block; margin-bottom: 5px; color: var(--lime); font-weight: 800; letter-spacing: .08em; }
+    .guardrails { display: grid; grid-template-columns: repeat(3, 1fr); gap: 13px; margin-top: 28px; }
+    .mini-card { padding: 20px; border: 1px solid var(--line); border-radius: 16px; background: white; font-size: 13px; }
+    .mini-card b { display: block; margin-bottom: 8px; color: var(--orange); }
+    .steps { display: grid; gap: 14px; counter-reset: step; }
+    .step { position: relative; padding: 25px 26px 25px 78px; border: 1px solid var(--line); border-radius: 18px; background: white; box-shadow: 0 7px 22px rgba(22,57,47,.04); }
+    .step::before { counter-increment: step; content: counter(step); position: absolute; left: 24px; top: 24px; display: grid; place-items: center; width: 36px; height: 36px; border-radius: 12px; color: white; background: var(--green); font-weight: 900; }
+    blockquote { margin: 13px 0 0; color: #40564e; font-size: 15px; }
+    .compensation { margin-top: 12px; color: var(--muted); font-size: 14px; }
+    .do-not { margin-top: 18px; padding: 18px 20px; border-left: 4px solid var(--orange); border-radius: 0 14px 14px 0; background: var(--orange-soft); color: #75432e; font-size: 13px; }
+    .channel-list { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; padding: 0; list-style: none; counter-reset: channel; }
+    .channel-list li { position: relative; margin: 0; padding: 23px 22px 23px 60px; border: 1px solid var(--line); border-radius: 17px; background: white; }
+    .channel-list li::before { counter-increment: channel; content: "0" counter(channel); position: absolute; left: 20px; color: var(--orange); font-size: 12px; font-weight: 900; }
+    .checklist { display: grid; gap: 10px; padding: 0; list-style: none; }
+    .checklist li { position: relative; margin: 0; padding: 17px 18px 17px 52px; border: 1px solid var(--line); border-radius: 14px; background: white; }
+    .checklist li::before { content: ""; position: absolute; left: 18px; top: 18px; width: 18px; height: 18px; border: 2px solid #a9bab2; border-radius: 6px; }
+    .confirm { padding: 32px; border-radius: 24px; color: white; background: var(--ink); }
+    .confirm h2 { color: white; }
+    .confirm ol { display: grid; gap: 13px; padding-left: 1.4em; color: rgba(255,255,255,.82); }
+    footer { margin-top: 72px; padding-top: 22px; border-top: 1px solid var(--line); color: #8a9892; font-size: 11px; }
+    @media (max-width: 900px) {
+      .layout { display: block; padding: 18px 18px 70px; }
+      aside { position: static; height: auto; }
+      .brand { margin: 5px 0 18px; }
+      nav { display: flex; overflow-x: auto; margin: 0 -18px 22px; padding: 0 18px 10px; scrollbar-width: none; }
+      nav a { flex: 0 0 auto; background: white; border: 1px solid var(--line); }
+      .aside-note { display: none; }
+      .hero { min-height: 390px; padding: 40px 30px; border-radius: 24px; }
+      section { margin-top: 65px; }
+      .guardrails, .channel-list { grid-template-columns: 1fr; }
+    }
+    @media (max-width: 540px) {
+      body { word-break: normal; }
+      h1 { font-size: 41px; }
+      .hero { min-height: 420px; }
+      .step { padding: 22px 20px 22px 66px; }
+      .step::before { left: 17px; }
+      .principle, .confirm { padding: 23px; }
+    }
+    @media print {
+      @page { margin: 18mm; }
+      body { background: white; color: #111; font-size: 11pt; }
+      .progress, aside { display: none; }
+      .layout { display: block; max-width: none; padding: 0; }
+      .hero { min-height: 0; padding: 32px; color: white !important; background: var(--green) !important; print-color-adjust: exact; }
+      .hero::before, .hero::after { display: none; }
+      section { margin-top: 38px; break-inside: avoid; }
+      .table-wrap, .principle, .step, .mini-card, .confirm { box-shadow: none; break-inside: avoid; }
+      footer { margin-top: 38px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="progress" aria-hidden="true"></div>
+  <div class="layout">
+    <aside>
+      <div class="brand"><span class="brand-mark">P</span>Price Playbook</div>
+      <nav aria-label="문서 목차">
+        <a href="#principle"><span>00</span>대원칙</a>
+        <a href="#matrix"><span>01</span>유형별 기준</a>
+        <a href="#cs"><span>02</span>고객 방어 로직</a>
+        <a href="#terms"><span>03</span>약관 검토</a>
+        <a href="#channel"><span>04</span>채널 운영</a>
+        <a href="#checklist"><span>05</span>체크리스트</a>
+        <a href="#confirm"><span>06</span>확정 필요 사항</a>
+      </nav>
+      <div class="aside-note">INTERNAL DRAFT<br>팀리더 그룹 검토용<br><br>7/21 팀리더회의 · 7/24 가격 커뮤니케이션 토론</div>
+    </aside>
+
+    <main>
+      <header class="hero">
+        <p class="eyebrow">Internal playbook · Draft</p>
+        <h1>가격 변경<br>커뮤니케이션<br>매뉴얼</h1>
+        <p class="meta">작성 Howoo · 팀리더 그룹 검토 요청</p>
+      </header>
+      <div class="legal"><span aria-hidden="true">⚠️</span><span>법률 관련 항목은 참고 의견이며 법률 자문이 아닙니다. 시행 전 필요 시 전문가 검토가 필요합니다.</span></div>
+
+      <section id="principle">
+        <p class="section-kicker">Principle 00</p>
+        <h2>공지로 해명하지 않고,<br>구조로 방어한다</h2>
+        <div class="principle">
+          <ul>
+            <li>쿠팡·무신사 등 대형 플랫폼은 가격 변동을 ‘공지’하지 않는다. <strong>애초에 가격을 약속한 적이 없기 때문</strong>이다.</li>
+            <li>공지·약관·안내문으로 해명을 반복하면 “가격을 약속하는 브랜드”라는 프레임을 스스로 만든다. 그 안에서는 모든 가격 변동이 ‘약속 위반’이 된다.</li>
+            <li>기준은 할인 심도가 아니라 <strong>“고객과의 약속, 즉 예측 가능성을 훼손하는가”</strong>이다. 클레임은 ‘싸게 판 것’이 아니라 ‘몰래 바뀐 것’과 ‘약속이 깨진 것’에서 발생한다.</li>
+          </ul>
+        </div>
+      </section>
+
+      <section id="matrix">
+        <p class="section-kicker">Decision Matrix 01</p>
+        <h2>가격 변동 유형별<br>커뮤니케이션 기준</h2>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>유형</th><th>기준</th><th>커뮤니케이션</th></tr></thead>
+            <tbody>
+              <tr><td><span class="badge">A</span><strong>소폭 인상</strong><br>(원가·환율 반영)</td><td>상시가 대비 <strong>~5% 이내</strong></td><td><strong>무공지.</strong> 문의 시 CS 스크립트로 대응</td></tr>
+              <tr><td><span class="badge">B</span><strong>중폭 인상</strong></td><td>5~10%</td><td>무공지 원칙. 단, FAQ 사전 업데이트 + CS 매크로 준비</td></tr>
+              <tr><td><span class="badge">C</span><strong>리뉴얼 동반 인상</strong></td><td>폭 무관</td><td>‘가격 인상 안내’가 아닌 <strong>‘제품 개선 안내’로 소구</strong> (7/21 결정)</td></tr>
+              <tr><td><span class="badge">D</span><strong>약속 상품 가격 변경</strong><br>(정기구독·멤버십·회차 혜택)</td><td>폭 무관</td><td><strong>사전 공지 필수</strong> (7/21 결정). 기존 구독자는 가격 유지 원칙(케어라인 선례)</td></tr>
+              <tr><td><span class="badge">E</span><strong>단기 프로모션 할인</strong><br>(기간 명시 행사)</td><td>심도 무관<br>(60%도 가능)</td><td>행사 자체가 공지. <strong>종료 후 원복에 대한 별도 해명 안 함</strong></td></tr>
+              <tr><td><span class="badge">F</span><strong>플랫폼 자동 가격 변동</strong><br>(쿠팡 매칭 등)</td><td>폭 무관</td><td><strong>무공지·무해명.</strong> “판매 채널별 가격은 각 채널 정책에 따라 달라질 수 있다” 한 줄 원칙만 유지</td></tr>
+              <tr><td><span class="badge">G</span><strong>상시가 인하</strong></td><td>10% 초과</td><td>신중 결정. 기존 구매자 역풍이 가장 큰 유형. 인하 사유를 브랜드 스토리로 소화할 수 있을 때만</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="decision"><small>핵심 제안</small>기간이 명시된 행사는 <strong>심도 제한 없음</strong>, 상시가의 무공지 변동은 <strong>±5% 이내</strong>로 이원화한다. 심도가 아니라 ‘상시가 체계가 흔들리는가’가 기준이다.</div>
+        <div class="guardrails">
+          <div class="mini-card"><b>01 · 특가 하한선</b>SKU별 최저 허용가를 내부 문서로 관리해 브랜드 가치의 방어선으로 삼는다.</div>
+          <div class="mini-card"><b>02 · 허위 정상가 금지</b>‘정상가 부풀리기 후 상시 할인’ 구조는 표시광고 리스크와 신뢰 훼손을 만든다.</div>
+          <div class="mini-card"><b>03 · 보장 표현 금지</b>‘최저가 보장’, ‘가격 보장’ 문구는 전 채널에서 사용하지 않는다.</div>
+        </div>
+      </section>
+
+      <section id="cs">
+        <p class="section-kicker">CS Protocol 02</p>
+        <h2>고객 방어 로직<br>3단 대응</h2>
+        <div class="steps">
+          <article class="step"><h3>공감 <small>— 해명 아님</small></h3><blockquote>“구매하신 뒤에 가격이 달라진 걸 보시면 속상하실 수 있어요. 말씀 주셔서 감사합니다.”</blockquote></article>
+          <article class="step"><h3>원칙 설명 <small>— 전 채널 동일</small></h3><blockquote>“저희 제품의 상시 가격은 원료와 품질 기준에 맞춰 책정되어 있고, 행사 가격은 기간을 정해 운영하는 한정 혜택이에요. 행사 종료 후에는 상시 가격으로 돌아가며, 판매 채널별 가격은 각 채널의 정책·행사에 따라 다를 수 있습니다.”</blockquote></article>
+          <article class="step"><h3>보상 원칙 <small>— 명확히, 예외 없이</small></h3><div class="compensation"><ul><li>가격 차액 보상은 하지 않는 것이 원칙이다. 보상 선례 1건은 상시 보상 제도가 된다.</li><li>단, <strong>구매 후 24시간 이내 동일 채널에서 대형 행사가 시작된 경우</strong>에 한해 CS 재량 쿠폰 지급 가능. ‘차액 보상’이 아니라 ‘다음 구매 혜택’으로 표현한다.</li><li>반복 클레임 고객에게도 톤을 바꾸지 않고 같은 원칙을 같은 문장으로 안내한다.</li></ul></div></article>
+        </div>
+        <div class="do-not"><strong>금지 표현</strong> · “죄송하지만 가격은 저희도 어쩔 수 없어요” / “특별히 이번만 보상해드릴게요” / “쿠팡이 마음대로 바꾼 거예요”</div>
+      </section>
+
+      <section id="terms">
+        <p class="section-kicker">Terms Review 03</p>
+        <h2>약관 신설보다<br>FAQ와 CS 스크립트</h2>
+        <div class="decision"><small>결론</small>약관 ‘신설·강조’는 실익이 작고 리스크가 있다. 표준 수준 조항 확인만 하고, 방어는 <strong>FAQ + CS 스크립트</strong>로 한다.</div>
+        <div class="table-wrap" style="margin-top:20px">
+          <table>
+            <thead><tr><th>관점</th><th>검토 내용</th></tr></thead>
+            <tbody>
+              <tr><td><strong>법적 효력</strong></td><td>판매자는 원래 가격 결정·변경의 자유가 있다. 관련 조항 유무가 분쟁의 결정적 방어가 되지는 않는다(참고 자료 수준). <strong>자사몰 약관의 기존 유사 조항 확인 필요.</strong></td></tr>
+              <tr><td><strong>프레임 리스크</strong></td><td>가격 변동 조항을 새로 만들어 강조하면 “가격을 자주 바꾸는 브랜드”라는 신호가 된다.</td></tr>
+              <tr><td><strong>실효적 위치</strong></td><td>고객이 실제로 읽는 곳은 약관이 아닌 <strong>FAQ와 CS 답변</strong>이다. FAQ 1문항과 2단 원칙 문단이 더 실효적이다.</td></tr>
+              <tr><td><strong>진짜 법적 유의점</strong></td><td>① 허위 정상가 표시 금지 ② ‘최저가/가격 보장’ 표현 금지 ③ 정기구독 가격 변경 시 사전 고지 의무 이행</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="channel">
+        <p class="section-kicker">Channel Rule 04</p>
+        <h2>가격이 아니라<br>상품으로 채널을 나눈다</h2>
+        <ol class="channel-list">
+          <li>주요 프로모션 확정 전, 전 채널 가격·쿠폰 상태를 확인한다. 쿠팡 쿠폰·계약 행사를 기획 체크리스트에 포함한다.</li>
+          <li>자사몰 네이버 가격비교 비노출을 유지해 쿠팡 트래킹을 차단한다.</li>
+          <li>채널 간 SKU·구성을 분리한다. 대용량·번들은 자사몰 전용 등 <strong>상품으로 채널을 나눈다.</strong></li>
+          <li>쿠팡 매칭으로 인한 일시 변동은 대응하거나 해명하지 않는다(F유형).</li>
+        </ol>
+      </section>
+
+      <section id="checklist">
+        <p class="section-kicker">Action List 05</p>
+        <h2>운영 체크리스트</h2>
+        <ul class="checklist">
+          <li>가격 변경 발생 시 유형(A~G) 분류 → 매트릭스대로 실행</li>
+          <li>D유형 사전 공지 리드타임 확보 — 최소 발송 1회 + 리드타임 기준 협의 필요(7일?)</li>
+          <li>FAQ 1문항 게재 + CS 매크로 등록(2단 원칙 문단)</li>
+          <li>자사몰 약관 내 가격 변동 조항 유무 확인 — 신설이 아닌 확인만</li>
+          <li>SKU별 최저 허용가 내부 문서 유지·갱신</li>
+          <li>프로모션 기획 시 전 채널 가격·쿠폰 사전 확인을 체크리스트 항목화</li>
+        </ul>
+      </section>
+
+      <section id="confirm" class="confirm">
+        <p class="section-kicker">Need Decision 06</p>
+        <h2>확정 필요 사항</h2>
+        <ol>
+          <li>A유형 무공지 상한: 5%가 적정한가? (7/21 회의 ‘1~5% 검토’)</li>
+          <li>CS 재량 쿠폰의 허용 조건(24시간? 48시간?)과 금액 상한</li>
+          <li>D유형 사전 공지 리드타임 기준</li>
+          <li>시행 시점과 CS팀 교육 일정</li>
+        </ol>
+      </section>
+
+      <footer>PRICE COMMUNICATION MANUAL · INTERNAL DRAFT · Based on 7/21 &amp; 7/24 discussions</footer>
+    </main>
+  </div>
+  <script>
+    const progress = document.querySelector('.progress');
+    const links = [...document.querySelectorAll('nav a')];
+    const sections = links.map(link => document.querySelector(link.hash));
+    function updatePage() {
+      const max = document.documentElement.scrollHeight - innerHeight;
+      progress.style.width = `${max ? scrollY / max * 100 : 0}%`;
+      const current = [...sections].reverse().find(section => section.getBoundingClientRect().top <= 180) || sections[0];
+      links.forEach(link => link.classList.toggle('active', link.hash === `#${current.id}`));
+    }
+    addEventListener('scroll', updatePage, { passive: true });
+    updatePage();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Add a self-contained internal playbook to document price-change communication principles, CS scripts, and operational checklists for consistent handling of pricing events.
- Provide a single-page, printable reference for team leads to review decisions from recent discussions (7/21, 7/24) and to standardize responses across channels.

### Description
- Add new file `price-communication-manual.html` containing a complete responsive HTML document with styles, navigation, and print rules for an internal Price Communication Manual. 
- Implement decision matrix, CS protocol, FAQ/terms guidance, channel rules, checklist, and a “need decision” section as content modules in Korean. 
- Include a lightweight front-end script (`updatePage()`) to drive a scroll progress bar and active-section highlighting in the left navigation. 
- Provide comprehensive CSS for layout, responsive breakpoints, accessible anchors, and print-friendly output.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a9465a51083229a833aef6d1fa4db)